### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fmeriaux/nrn/security/code-scanning/2](https://github.com/fmeriaux/nrn/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root so it applies to all jobs (currently just `checks`). The minimal least-privilege setting here is:

- `contents: read`

This preserves current CI functionality (checkout + build/test/lint) while preventing unnecessary token write scopes. No imports, methods, or dependencies are needed—just YAML configuration in the existing workflow file near the top-level keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
