### PR TITLE
chore: add conventional commits convention and group dependabot ndarray updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      ndarray:
+        patterns:
+          - "ndarray*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,23 @@ cargo test -p nrn <test_name>   # core crate only
 
 **System dependency**: HDF5 C library is required (`brew install hdf5` on macOS, `sudo apt-get install libhdf5-dev` on Ubuntu).
 
+## Commit conventions
+
+This project follows [Conventional Commits](https://conventionalcommits.org). Every commit message must be prefixed with a type:
+
+| Type | When to use |
+|------|-------------|
+| `feat:` | new feature or capability |
+| `fix:` | bug fix |
+| `refactor:` | code change that is neither a feature nor a fix |
+| `test:` | adding or updating tests |
+| `docs:` | documentation only |
+| `ci:` | CI/CD configuration |
+| `build:` | build system or dependencies (e.g. Cargo.toml) |
+| `chore:` | everything else (tooling, config files, housekeeping) |
+
+A scope can be added in parentheses: `feat(training): add cosine scheduler`.
+
 ## Workspace structure
 
 Two crates:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Neural Network CLI
 
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+
 This project is a personal educational initiative aimed at learning Rust and understanding the fundamentals of neural networks. The main goal is to explore how neural networks work by implementing them from scratch in Rust, while also gaining hands-on experience with the language and its ecosystem.
 
 As this is an educational project, if you notice any mistakes or have suggestions for clarification, please feel free to open an issue or otherwise provide constructive feedback. Your input is welcome and will help strengthen my understanding!


### PR DESCRIPTION
## Summary

- Document [Conventional Commits](https://conventionalcommits.org) in `CLAUDE.md` with a type reference table
- Add Conventional Commits badge to `README.md`
- Group `ndarray` and `ndarray-rand` in Dependabot to prevent broken PRs from version mismatches (fixes #7)

## Test plan

- [x] `task checks` passes locally (lint + build + 58 tests)