### PR TITLE
refactor(activations): replace derivative() with vjp() and fix CE gradient

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Notes
+
+<!-- Anything non-obvious a reviewer should know? Leave blank if none. -->

--- a/core/src/nn/activations/mod.rs
+++ b/core/src/nn/activations/mod.rs
@@ -34,23 +34,19 @@ pub trait Activation: Send + Sync {
     /// This non-linear transformation enables the network to model complex patterns.
     fn apply(&self, input: ArrayView2<f32>) -> Array2<f32>;
 
-    /// Computes the element-wise derivative of the activation function for backpropagation.
+    /// Computes the vector-Jacobian product (VJP) for backpropagation.
+    ///
+    /// Given the upstream gradient ∂L/∂a (with respect to post-activation values),
+    /// returns ∂L/∂z (with respect to pre-activation values), correctly handling
+    /// both diagonal (ReLU, Sigmoid) and full (Softmax) Jacobians.
     ///
     /// # Arguments
-    ///
-    /// * `activations` - A 2D array of post-activation values from the forward pass.
+    /// * `upstream` - Incoming gradient ∂L/∂a, shape `(neurons, samples)`.
+    /// * `activations` - Post-activation values from the forward pass, same shape.
     ///
     /// # Returns
-    ///
-    /// A 2D array of the same shape containing `dσ/dz` at each position, used to scale
-    /// the incoming gradient via element-wise multiplication in the chain rule.
-    ///
-    /// # Note
-    ///
-    /// This interface assumes a diagonal Jacobian (element-wise activations like ReLU and
-    /// Sigmoid). Activations with a full Jacobian (e.g. Softmax) cannot implement this
-    /// correctly; their output-layer gradient is handled separately by the loss function.
-    fn derivative(&self, activations: ArrayView2<f32>) -> Array2<f32>;
+    /// ∂L/∂z — gradient with respect to the pre-activation input.
+    fn vjp(&self, upstream: ArrayView2<f32>, activations: ArrayView2<f32>) -> Array2<f32>;
 
     /// Provides an initialization method linked to this activation.
     ///

--- a/core/src/nn/activations/relu.rs
+++ b/core/src/nn/activations/relu.rs
@@ -23,12 +23,9 @@ impl Activation for ReLU {
         input.mapv(|x| x.max(0.0))
     }
 
-    /// Computes the derivative of the ReLU function for backpropagation.
-    ///
-    /// The derivative is 1 for positive input values and 0 otherwise.
-    /// This property allows gradients to flow only through activated neurons.
-    fn derivative(&self, activations: ArrayView2<f32>) -> Array2<f32> {
-        activations.mapv(|x| if x > 0.0 { 1.0 } else { 0.0 })
+    /// Computes ∂L/∂z = upstream ⊙ 1[a > 0].
+    fn vjp(&self, upstream: ArrayView2<f32>, activations: ArrayView2<f32>) -> Array2<f32> {
+        upstream.to_owned() * activations.mapv(|x| if x > 0.0 { 1.0 } else { 0.0 })
     }
 
     /// Provides the recommended initialization for layers using ReLU.
@@ -70,16 +67,26 @@ mod tests {
     }
 
     #[test]
-    fn derivative_is_one_for_positive_activations() {
+    fn vjp_passes_upstream_for_positive_activations() {
+        let upstream = array![[1.0, 2.0], [3.0, 4.0]];
         let activations = array![[0.5, 1.0], [2.0, 0.1]];
-        let d = RELU.derivative(activations.view());
-        assert_eq!(d, array![[1.0, 1.0], [1.0, 1.0]]);
+        assert_eq!(RELU.vjp(upstream.view(), activations.view()), upstream);
     }
 
     #[test]
-    fn derivative_is_zero_for_nonpositive_activations() {
+    fn vjp_blocks_upstream_for_nonpositive_activations() {
+        let upstream = array![[1.0, 2.0], [3.0, 4.0]];
         let activations = array![[0.0, -1.0], [-2.0, 0.0]];
-        let d = RELU.derivative(activations.view());
-        assert_eq!(d, array![[0.0, 0.0], [0.0, 0.0]]);
+        assert_eq!(
+            RELU.vjp(upstream.view(), activations.view()),
+            array![[0.0, 0.0], [0.0, 0.0]]
+        );
+    }
+
+    #[test]
+    fn vjp_mixed_activations() {
+        let upstream = array![[2.0, 3.0]];
+        let activations = array![[1.0, -1.0]];
+        assert_eq!(RELU.vjp(upstream.view(), activations.view()), array![[2.0, 0.0]]);
     }
 }

--- a/core/src/nn/activations/relu.rs
+++ b/core/src/nn/activations/relu.rs
@@ -87,6 +87,9 @@ mod tests {
     fn vjp_mixed_activations() {
         let upstream = array![[2.0, 3.0]];
         let activations = array![[1.0, -1.0]];
-        assert_eq!(RELU.vjp(upstream.view(), activations.view()), array![[2.0, 0.0]]);
+        assert_eq!(
+            RELU.vjp(upstream.view(), activations.view()),
+            array![[2.0, 0.0]]
+        );
     }
 }

--- a/core/src/nn/activations/sigmoid.rs
+++ b/core/src/nn/activations/sigmoid.rs
@@ -23,11 +23,9 @@ impl Activation for Sigmoid {
         input.mapv(|x| 1.0 / (1.0 + (-x).exp()))
     }
 
-    /// Computes the derivative of the sigmoid function for backpropagation.
-    ///
-    /// This is used to propagate gradients during training.
-    fn derivative(&self, activations: ArrayView2<f32>) -> Array2<f32> {
-        activations.mapv(|s| s * (1.0 - s))
+    /// Computes ∂L/∂z = upstream ⊙ a(1 − a).
+    fn vjp(&self, upstream: ArrayView2<f32>, activations: ArrayView2<f32>) -> Array2<f32> {
+        upstream.to_owned() * activations.mapv(|s| s * (1.0 - s))
     }
 
     /// Provides the recommended initialization for layers using sigmoid.
@@ -78,10 +76,16 @@ mod tests {
     }
 
     #[test]
-    fn derivative_at_half_is_quarter() {
-        // sigma'(x) = sigma(x) * (1 - sigma(x)), at sigma(x)=0.5 -> 0.5 * 0.5 = 0.25
-        let activations = array![[0.5]];
-        let d = SIGMOID.derivative(activations.view());
-        assert!((d[[0, 0]] - 0.25).abs() < 1e-6);
+    fn vjp_at_half_scales_by_quarter() {
+        // a=0.5 → a(1-a)=0.25, upstream=1.0 → vjp=0.25
+        let result = SIGMOID.vjp(array![[1.0]].view(), array![[0.5]].view());
+        assert!((result[[0, 0]] - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn vjp_scales_upstream_by_local_derivative() {
+        // upstream=2.0, a=0.5 → vjp = 2.0 * 0.25 = 0.5
+        let result = SIGMOID.vjp(array![[2.0]].view(), array![[0.5]].view());
+        assert!((result[[0, 0]] - 0.5).abs() < 1e-6);
     }
 }

--- a/core/src/nn/activations/softmax.rs
+++ b/core/src/nn/activations/softmax.rs
@@ -8,7 +8,7 @@
 
 use crate::activations::{Activation, ActivationProvider};
 use crate::initializations::{Initialization, XAVIER_UNIFORM};
-use ndarray::{Array2, ArrayView2};
+use ndarray::{Array2, ArrayView2, Axis};
 use once_cell::sync::Lazy;
 use std::sync::Arc;
 
@@ -48,14 +48,12 @@ impl Activation for Softmax {
         result
     }
 
-    /// Not implemented: the softmax Jacobian is not diagonal and cannot be expressed as an
-    /// element-wise operation. The output-layer gradient (softmax + cross-entropy) is computed
-    /// directly by `LossFunction::gradient` in the backward pass, bypassing this method.
-    fn derivative(&self, _activations: ArrayView2<f32>) -> Array2<f32> {
-        unimplemented!(
-            "Softmax has a full (non-diagonal) Jacobian and does not support element-wise \
-             backprop. Use it only as an output activation; its gradient is handled by the loss function."
-        )
+    /// Computes ∂L/∂z = a ⊙ (upstream − ⟨a, upstream⟩) per sample.
+    fn vjp(&self, upstream: ArrayView2<f32>, activations: ArrayView2<f32>) -> Array2<f32> {
+        let dot = (&activations * &upstream)
+            .sum_axis(Axis(0))
+            .insert_axis(Axis(0));
+        activations.to_owned() * (upstream.to_owned() - dot)
     }
 
     /// Provides the recommended initialization for layers using softmax.
@@ -120,9 +118,25 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Softmax has a full (non-diagonal) Jacobian")]
-    fn derivative_is_not_implemented() {
-        let activations = array![[0.7, 0.2], [0.2, 0.5], [0.1, 0.3]];
-        SOFTMAX.derivative(activations.view());
+    fn vjp_output_sums_to_zero_per_column() {
+        // Property: softmax VJP always produces zero-sum columns
+        let activations = array![[0.7, 0.3], [0.2, 0.3], [0.1, 0.4]];
+        let upstream = array![[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]];
+        let result = SOFTMAX.vjp(upstream.view(), activations.view());
+        for col in result.columns() {
+            let sum: f32 = col.iter().sum();
+            assert!(sum.abs() < 1e-5, "column sum {sum} != 0");
+        }
+    }
+
+    #[test]
+    fn vjp_known_values() {
+        // a=[0.7, 0.2, 0.1], u=[1, 0, 0]: dot=0.7, vjp=a*(u-dot)=[0.21, -0.14, -0.07]
+        let activations = array![[0.7], [0.2], [0.1]];
+        let upstream = array![[1.0], [0.0], [0.0]];
+        let result = SOFTMAX.vjp(upstream.view(), activations.view());
+        assert!((result[[0, 0]] - 0.21).abs() < 1e-6);
+        assert!((result[[1, 0]] - (-0.14)).abs() < 1e-6);
+        assert!((result[[2, 0]] - (-0.07)).abs() < 1e-6);
     }
 }

--- a/core/src/nn/loss_functions/cross_entropy_loss.rs
+++ b/core/src/nn/loss_functions/cross_entropy_loss.rs
@@ -46,18 +46,29 @@ impl LossFunction for CrossEntropyLoss {
         }
     }
 
-    /// Computes the gradient of the loss with respect to the predictions.
+    /// Computes ∂L/∂a — the gradient of the loss with respect to the predicted probabilities.
+    ///
+    /// Expects `predictions` to be clipped to a safe interior of (0, 1) by the caller;
+    /// no clipping is applied here so that the caller can pass identical values to the
+    /// activation's `vjp`, ensuring exact compositional cancellation.
     ///
     /// # Arguments
     /// * `predictions` - Same as in `compute`.
     /// * `targets` - Same as in `compute`.
     ///
     /// # Returns
-    /// Gradient array (`Array2<f32>`) of the same shape as predictions, corresponding to
-    /// the derivative of the loss with respect to each predicted probability.
+    /// Gradient array (`Array2<f32>`) of the same shape as predictions.
+    /// Binary CE: `(p - y) / (p * (1 - p))`. Multi-class CE: `-y / p`.
     fn gradient(&self, predictions: ArrayView2<f32>, targets: ArrayView2<f32>) -> Array2<f32> {
-        let clipped_predictions = Self::clip_probabilities(&predictions);
-        clipped_predictions - targets
+        if predictions.nrows() == 1 {
+            // Binary CE: ∂L/∂p = (p - y) / (p * (1 - p))
+            let p = predictions.to_owned();
+            let denom = &p * p.mapv(|x| 1.0 - x);
+            (p - targets) / denom
+        } else {
+            // Multi-class CE: ∂L/∂p_i = -y_i / p_i
+            -targets.to_owned() / predictions.to_owned()
+        }
     }
 }
 

--- a/core/src/nn/training.rs
+++ b/core/src/nn/training.rs
@@ -193,7 +193,17 @@ impl NeuralNetwork {
     ) -> Vec<Gradients> {
         let m = targets.ncols() as f32;
 
-        let mut dz = loss_function.gradient(last_activation(activations).view(), targets);
+        let last_act = last_activation(activations);
+        // Clip to (0, 1) interior so gradient() and vjp() see the same values;
+        // their product then cancels exactly to p − y even near saturation.
+        let safe_act = last_act.mapv(|p| p.clamp(1e-15_f32, 1.0 - 1e-15_f32));
+        let loss_grad = loss_function.gradient(safe_act.view(), targets);
+        let mut dz = self
+            .layers
+            .last()
+            .unwrap()
+            .activation
+            .vjp(loss_grad.view(), safe_act.view());
 
         let mut gradients = Vec::with_capacity(activations.len() - 1);
 
@@ -205,15 +215,11 @@ impl NeuralNetwork {
             gradients.insert(0, Gradients { dw, db });
 
             if i > 1 {
-                // The output layer's dz comes from loss_function.gradient() above, which
-                // already encodes the combined activation+loss gradient (e.g. p-y for
-                // softmax+CE). Activation::derivative is only called for hidden layers,
-                // which are always element-wise (ReLU, Sigmoid).
                 let next_layer = &self.layers[i - 1];
-                dz = next_layer.weights.t().dot(&dz)
-                    * self.layers[i - 2]
-                        .activation
-                        .derivative(previous_activations);
+                let da = next_layer.weights.t().dot(&dz);
+                dz = self.layers[i - 2]
+                    .activation
+                    .vjp(da.view(), previous_activations);
             }
         }
 
@@ -362,9 +368,9 @@ mod tests {
     #[test]
     fn backprop_gradients_match_numerical_approximation_softmax_output() {
         // Single-layer network (inputs → softmax), no hidden layers.
-        // Tests the specific path backward() takes for a softmax output layer: it uses
-        // loss_function.gradient() (= p - y) as dz, then computes dw = dz @ x.T / m
-        // and db = sum(dz) / m. The hidden-layer chain rule is covered by the sigmoid test.
+        // Verifies that loss.gradient() (→ -y/p) composed with softmax.vjp() yields the
+        // correct dz (= p - y) and that the resulting weight/bias gradients match finite
+        // differences. The hidden-layer chain rule is covered by the sigmoid test.
         // A single output layer keeps gradients large (O(0.1)) and well within f32 precision.
         let specs = NeuronLayerSpec::network_for(vec![], &*SIGMOID, 3);
         let mut model = NeuralNetwork::initialization(2, &specs);


### PR DESCRIPTION
## Summary

Replace `Activation::derivative()` with a proper vector-Jacobian product `vjp(upstream, activations)`, and fix `CrossEntropyLoss::gradient()` to return the true ∂L/∂a instead of the combined ∂L/∂z.

Previously, `backward()` relied on `loss.gradient()` returning `p − y` (the fused activation+loss delta), which was silently correct only for sigmoid+CE and softmax+CE. Any other output activation would have produced wrong gradients without error.

`vjp()` handles both diagonal Jacobians (ReLU, Sigmoid) and full Jacobians (Softmax) correctly. The `p − y` simplification now emerges from the composition rather than being hard-coded. Output activations are clipped to a safe interior before the composition so the product cancels exactly even near sigmoid saturation.

Also adds the GitHub PR template.

## Notes

`derivative()` has been removed from the `Activation` trait entirely — it was an implementation detail that leaked into the public API. Callers must use `vjp()`.