### PR TITLE
Audit 2026-05-30 : validation, CI/Taskfile, tests, MSRV & nettoyage archi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,8 @@ jobs:
       - run: task lint
       - run: task test
       - run: task build
+
+      # Run after the build so the toolchain and rust-cache are already warm.
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - run: task audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,12 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get install -y libhdf5-dev libfontconfig-dev
 
+      - name: Install Task
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo fmt --check
-      - run: cargo clippy --workspace
-      - run: cargo clippy --workspace --all-features
-      - run: cargo test --workspace
-      - run: cargo test --workspace --all-features
-      - run: cargo build --release --all-features
+      # Checks are defined in the Taskfile so CI and local runs stay in sync.
+      - run: task lint
+      - run: task test
+      - run: task build

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      # Gated by the `main` ruleset (not classic branch protection): merges only once
+      # the required `checks` CI job — including cargo-audit — passes.
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
 resolver = "3"
 members = ["cli","core"]
+
+[workspace.package]
+# Floor set by the let-chains used in the code (stabilized in Rust 1.88);
+# edition 2024 alone would only require 1.85.
+rust-version = "1.88"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -42,6 +42,11 @@ tasks:
       - cargo clippy --workspace --all-targets -- -D warnings
       - cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  audit:
+    desc: Scan dependencies for security advisories (requires cargo-audit)
+    cmds:
+      - cargo audit
+
   coverage:
     desc: Measure test coverage of the core crate (requires cargo-llvm-cov)
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -39,8 +39,18 @@ tasks:
     desc: Check formatting and run Clippy on the workspace
     cmds:
       - cargo fmt --check
-      - cargo clippy --workspace
-      - cargo clippy --workspace --all-features
+      - cargo clippy --workspace --all-targets -- -D warnings
+      - cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  coverage:
+    desc: Measure test coverage of the core crate (requires cargo-llvm-cov)
+    cmds:
+      - cargo llvm-cov -p nrn --all-features --summary-only
+
+  coverage-html:
+    desc: Generate an HTML coverage report for core and open it
+    cmds:
+      - cargo llvm-cov -p nrn --all-features --html --open
 
   install:
     desc: Install the nrn binary to ~/.cargo/bin (uses locked deps)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nrn-cli"
 version = "0.2.0"
 edition = "2024"
+rust-version.workspace = true
 
 [[bin]]
 name = "nrn"

--- a/cli/src/commands/train.rs
+++ b/cli/src/commands/train.rs
@@ -1,5 +1,5 @@
 use crate::actions::*;
-use crate::display::{Summary, completed, trace};
+use crate::display::{Summary, completed, trace, warning};
 use crate::progression::Progression;
 use clap::*;
 use console::style;
@@ -247,6 +247,16 @@ impl TrainArgs {
             None => initialize_model_with(&dataset, self.layers.clone(), self.auto_layers),
         };
 
+        // Optimizer state is not persisted: a stateful optimizer resets its moments and
+        // step counter when resuming from a saved model, so its adaptive steps warm up
+        // again over the first epochs. See `make_optimizer`.
+        if self.model.is_some() && matches!(self.optimizer, OptimizerType::Adam) {
+            warning(
+                "Resuming with Adam: optimizer state is not restored, \
+                 its moments restart from zero for the first epochs",
+            );
+        }
+
         // 👨‍🎓 TRAINING LOOP
         let mut checkpoints: Option<Checkpoints> =
             Checkpoints::by_interval(self.checkpoint_interval, self.epochs);
@@ -406,6 +416,11 @@ impl TrainArgs {
         }
     }
 
+    /// Builds the optimizer for this run.
+    ///
+    /// Note: optimizer state (e.g. Adam's moment estimates and step counter) is not
+    /// persisted across runs. When resuming from a saved model with `--model`, a stateful
+    /// optimizer starts fresh; the user is warned in [`Self::run`].
     fn make_optimizer(&self) -> Arc<Mutex<dyn Optimizer>> {
         match self.optimizer {
             OptimizerType::Sgd => Arc::new(Mutex::new(StochasticGradientDescent::new(self.lr()))),

--- a/cli/src/commands/train.rs
+++ b/cli/src/commands/train.rs
@@ -15,7 +15,7 @@ use schedulers::CosineAnnealing;
 use std::error::Error;
 use std::fmt::Display;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 #[derive(ValueEnum, Debug, Copy, Clone)]
 enum OptimizerType {
@@ -214,14 +214,14 @@ impl TrainArgs {
             style("Cross-Entropy").bold().blue()
         ));
 
-        let optimizer: Arc<Mutex<dyn Optimizer>> = self.make_optimizer();
+        let mut optimizer = self.make_optimizer();
         trace(&format!(
             "Using {} optimizer with learning rate {}",
             style(self.optimizer).bold().blue(),
             style(self.lr).yellow()
         ));
 
-        let scheduler: Arc<Mutex<dyn Scheduler>> = self.make_scheduler();
+        let mut scheduler = self.make_scheduler();
         if !matches!(self.scheduler, SchedulerType::Constant) {
             trace(&format!(
                 "Learning rate scheduled by {}",
@@ -280,8 +280,8 @@ impl TrainArgs {
             model.train(
                 &split.train,
                 &loss_function,
-                &optimizer,
-                &scheduler,
+                optimizer.as_mut(),
+                scheduler.as_mut(),
                 &clipping,
                 self.batch_size,
             );
@@ -394,25 +394,23 @@ impl TrainArgs {
         }
     }
 
-    fn make_scheduler(&self) -> Arc<Mutex<dyn Scheduler>> {
+    fn make_scheduler(&self) -> Box<dyn Scheduler> {
         match self.scheduler {
-            SchedulerType::Constant => Arc::new(Mutex::new(ConstantScheduler::new(self.lr()))),
+            SchedulerType::Constant => Box::new(ConstantScheduler::new(self.lr())),
             SchedulerType::Cosine => {
                 let cosine = CosineAnnealing::new(self.lr_min(), self.lr(), self.step_size());
 
                 if self.warm_restarts {
-                    Arc::new(Mutex::new(
-                        cosine.with_restarts(true, self.cycle_multiplier()),
-                    ))
+                    Box::new(cosine.with_restarts(true, self.cycle_multiplier()))
                 } else {
-                    Arc::new(Mutex::new(cosine))
+                    Box::new(cosine)
                 }
             }
-            SchedulerType::Step => Arc::new(Mutex::new(StepDecay::new(
+            SchedulerType::Step => Box::new(StepDecay::new(
                 self.lr(),
                 self.step_size(),
                 self.decay_factor,
-            ))),
+            )),
         }
     }
 
@@ -421,10 +419,10 @@ impl TrainArgs {
     /// Note: optimizer state (e.g. Adam's moment estimates and step counter) is not
     /// persisted across runs. When resuming from a saved model with `--model`, a stateful
     /// optimizer starts fresh; the user is warned in [`Self::run`].
-    fn make_optimizer(&self) -> Arc<Mutex<dyn Optimizer>> {
+    fn make_optimizer(&self) -> Box<dyn Optimizer> {
         match self.optimizer {
-            OptimizerType::Sgd => Arc::new(Mutex::new(StochasticGradientDescent::new(self.lr()))),
-            OptimizerType::Adam => Arc::new(Mutex::new(Adam::with_defaults(self.lr()))),
+            OptimizerType::Sgd => Box::new(StochasticGradientDescent::new(self.lr())),
+            OptimizerType::Adam => Box::new(Adam::with_defaults(self.lr())),
         }
     }
 }

--- a/cli/src/commands/train.rs
+++ b/cli/src/commands/train.rs
@@ -233,6 +233,7 @@ impl TrainArgs {
         trace(&format!("Using {}", clipping.summary()));
 
         let dataset = load_dataset(&self.dataset)?;
+        dataset.validate()?;
         let split = dataset
             .to_model_dataset()
             .split(self.val_ratio, self.test_ratio);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nrn"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [features]
 io = ["hdf5-metno", "serde_json", "serde", "ndarray/serde", "image", "png", "gif"]

--- a/core/src/analysis/boundary.rs
+++ b/core/src/analysis/boundary.rs
@@ -156,30 +156,6 @@ fn make_grid_and_inputs(
     (grid_points, inputs)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    #[should_panic(expected = "Grid too large")]
-    #[cfg(target_pointer_width = "64")]
-    fn overflow_panics_with_clear_message() {
-        // 2^65 > usize::MAX on 64-bit — without checked_pow this silently wraps to 0
-        let n = (usize::BITS + 1) as usize;
-        let mins = vec![0.0f32; n];
-        let maxs = vec![1.0f32; n];
-        make_grid_and_inputs(&mins, &maxs, 2);
-    }
-
-    #[test]
-    fn small_2d_grid_has_correct_shape() {
-        // resolution=3, n_dims=2 → 3^2=9 points, each with 2 coords
-        let (grid, inputs) = make_grid_and_inputs(&[0.0, 0.0], &[1.0, 1.0], 3);
-        assert_eq!(grid.shape(), &[9, 2]);
-        assert_eq!(inputs.shape(), &[2, 9]);
-    }
-}
-
 /// Recursively generates all grid points using backtracking algorithm.
 ///
 /// This function implements a systematic approach to generate all possible combinations
@@ -229,5 +205,29 @@ fn generate_points_recursive(
         generate_points_recursive(mins, steps, resolution, n_dims, current_point, result);
         // Backtrack: remove coordinate to try next value in current dimension
         current_point.pop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "Grid too large")]
+    #[cfg(target_pointer_width = "64")]
+    fn overflow_panics_with_clear_message() {
+        // 2^65 > usize::MAX on 64-bit — without checked_pow this silently wraps to 0
+        let n = (usize::BITS + 1) as usize;
+        let mins = vec![0.0f32; n];
+        let maxs = vec![1.0f32; n];
+        make_grid_and_inputs(&mins, &maxs, 2);
+    }
+
+    #[test]
+    fn small_2d_grid_has_correct_shape() {
+        // resolution=3, n_dims=2 → 3^2=9 points, each with 2 coords
+        let (grid, inputs) = make_grid_and_inputs(&[0.0, 0.0], &[1.0, 1.0], 3);
+        assert_eq!(grid.shape(), &[9, 2]);
+        assert_eq!(inputs.shape(), &[2, 9]);
     }
 }

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -143,7 +143,11 @@ impl Dataset {
             }
             one_hot
         } else {
-            // If labels are binary, we can use them directly
+            // Binary labels are used directly; they must be exactly 0.0 or 1.0.
+            assert!(
+                self.labels.iter().all(|&l| l == 0.0 || l == 1.0),
+                "Binary labels must be 0.0 or 1.0. Found a label outside this range."
+            );
             self.labels.to_owned().insert_axis(Axis(0))
         };
 
@@ -300,6 +304,23 @@ impl ModelDataset {
     }
 }
 
+impl ModelSplit {
+    /// Returns the number of training samples in the dataset.
+    pub fn train_size(&self) -> usize {
+        self.train.inputs.ncols()
+    }
+
+    /// Returns the number of validation samples in the dataset.
+    pub fn validation_size(&self) -> usize {
+        self.validation.as_ref().map_or(0, |val| val.inputs.ncols())
+    }
+
+    /// Returns the number of testing samples in the dataset.
+    pub fn test_size(&self) -> usize {
+        self.test.inputs.ncols()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -330,6 +351,16 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Binary labels must be 0.0 or 1.0")]
+    fn out_of_range_binary_label_panics_with_clear_message() {
+        // labels = [1, 2]: n_classes=2 (binary branch), but 2 is not a valid binary target
+        let features = Array2::zeros((2, 2));
+        let labels = array![1.0f32, 2.0];
+        let dataset = Dataset { features, labels };
+        dataset.to_model_dataset();
+    }
+
+    #[test]
     fn split_ratios_produce_correct_sizes() {
         // 100 samples, 20% test, 10% val → 70 train / 10 val / 20 test
         let inputs = Array2::zeros((2, 100));
@@ -339,22 +370,5 @@ mod tests {
         assert_eq!(split.train_size(), 70);
         assert_eq!(split.validation_size(), 10);
         assert_eq!(split.test_size(), 20);
-    }
-}
-
-impl ModelSplit {
-    /// Returns the number of training samples in the dataset.
-    pub fn train_size(&self) -> usize {
-        self.train.inputs.ncols()
-    }
-
-    /// Returns the number of validation samples in the dataset.
-    pub fn validation_size(&self) -> usize {
-        self.validation.as_ref().map_or(0, |val| val.inputs.ncols())
-    }
-
-    /// Returns the number of testing samples in the dataset.
-    pub fn test_size(&self) -> usize {
-        self.test.inputs.ncols()
     }
 }

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -31,10 +31,60 @@ pub struct ModelSplit {
     pub test: ModelDataset,
 }
 
+/// Errors returned when a [`Dataset`] is not suitable for training a classifier.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DatasetError {
+    /// The dataset has no features.
+    NoFeatures,
+    /// The dataset has no samples.
+    NoSamples,
+    /// Fewer than two distinct classes are present (carries the count found).
+    TooFewClasses(usize),
+}
+
+impl std::fmt::Display for DatasetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DatasetError::NoFeatures => write!(f, "dataset has no features"),
+            DatasetError::NoSamples => write!(f, "dataset has no samples"),
+            DatasetError::TooFewClasses(n) => {
+                write!(f, "a classifier needs at least 2 classes, but found {n}")
+            }
+        }
+    }
+}
+
+impl Error for DatasetError {}
+
 impl Dataset {
     /// Checks if the dataset is empty (i.e., has no features or labels).
     pub fn is_empty(&self) -> bool {
         self.features.is_empty() || self.labels.is_empty()
+    }
+
+    /// Validates that the dataset can be used to train a classifier.
+    ///
+    /// This is the single boundary where dataset-level invariants are checked, so the
+    /// downstream layer-spec constructors ([`crate::model::NeuronLayerSpec::output_for`],
+    /// [`crate::model::NeuronLayerSpec::infer_from`]) can assume valid input and stay
+    /// infallible. Call it once, right after loading a dataset, before building a model.
+    ///
+    /// # Errors
+    /// - [`DatasetError::NoFeatures`] when the dataset has zero features.
+    /// - [`DatasetError::NoSamples`] when the dataset has zero samples.
+    /// - [`DatasetError::TooFewClasses`] when fewer than two classes are present.
+    pub fn validate(&self) -> Result<(), DatasetError> {
+        if self.n_features() == 0 {
+            return Err(DatasetError::NoFeatures);
+        }
+        if self.n_samples() == 0 {
+            return Err(DatasetError::NoSamples);
+        }
+        let n_classes = self.n_classes();
+        if n_classes < 2 {
+            return Err(DatasetError::TooFewClasses(n_classes));
+        }
+        Ok(())
     }
 
     /// Returns the number of samples in the dataset.
@@ -324,7 +374,7 @@ impl ModelSplit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ndarray::{Array2, array};
+    use ndarray::{Array1, Array2, array};
 
     #[test]
     #[should_panic(expected = "Labels must be 0-indexed")]
@@ -358,6 +408,38 @@ mod tests {
         let labels = array![1.0f32, 2.0];
         let dataset = Dataset { features, labels };
         dataset.to_model_dataset();
+    }
+
+    #[test]
+    fn validate_accepts_a_well_formed_dataset() {
+        let features = Array2::zeros((4, 2));
+        let labels = array![0.0f32, 1.0, 0.0, 1.0];
+        let dataset = Dataset { features, labels };
+        assert_eq!(dataset.validate(), Ok(()));
+    }
+
+    #[test]
+    fn validate_rejects_single_class_dataset() {
+        let features = Array2::zeros((3, 2));
+        let labels = array![1.0f32, 1.0, 1.0];
+        let dataset = Dataset { features, labels };
+        assert_eq!(dataset.validate(), Err(DatasetError::TooFewClasses(1)));
+    }
+
+    #[test]
+    fn validate_rejects_dataset_without_features() {
+        let features = Array2::zeros((3, 0));
+        let labels = array![0.0f32, 1.0, 0.0];
+        let dataset = Dataset { features, labels };
+        assert_eq!(dataset.validate(), Err(DatasetError::NoFeatures));
+    }
+
+    #[test]
+    fn validate_rejects_empty_dataset() {
+        let features = Array2::zeros((0, 2));
+        let labels = Array1::zeros(0);
+        let dataset = Dataset { features, labels };
+        assert_eq!(dataset.validate(), Err(DatasetError::NoSamples));
     }
 
     #[test]

--- a/core/src/data/preprocessors/scalers/min_max.rs
+++ b/core/src/data/preprocessors/scalers/min_max.rs
@@ -154,7 +154,7 @@ mod tests {
         let mut scaled = data.clone();
         scaler.apply_inplace(scaled.view_mut());
         for &v in scaled.iter() {
-            assert!(v >= 0.0 && v <= 1.0 + 1e-5, "Value {} out of [0, 1]", v);
+            assert!((0.0..=1.0 + 1e-5).contains(&v), "Value {} out of [0, 1]", v);
         }
     }
 

--- a/core/src/data/synth/mod.rs
+++ b/core/src/data/synth/mod.rs
@@ -4,73 +4,6 @@ mod uniform;
 pub use ring::RingDataset;
 pub use uniform::UniformDataset;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn uniform(n_samples: usize, n_clusters: usize) -> Dataset {
-        UniformDataset {
-            n_samples,
-            n_features: 2,
-            n_clusters,
-            feature_min: 0.0,
-            feature_max: 10.0,
-        }
-        .generate(42)
-    }
-
-    fn ring(n_samples: usize, n_clusters: usize) -> Dataset {
-        RingDataset {
-            n_samples,
-            n_features: 2,
-            n_clusters,
-            feature_min: 0.0,
-            feature_max: 10.0,
-        }
-        .generate(42)
-    }
-
-    #[test]
-    fn uniform_labels_are_zero_indexed() {
-        let mut labels = uniform(90, 3).unique_labels();
-        labels.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        assert_eq!(labels, vec![0.0, 1.0, 2.0]);
-    }
-
-    #[test]
-    fn ring_labels_are_zero_indexed() {
-        let mut labels = ring(90, 3).unique_labels();
-        labels.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        assert_eq!(labels, vec![0.0, 1.0, 2.0]);
-    }
-
-    #[test]
-    fn sample_count_exact_when_divisible() {
-        assert_eq!(uniform(100, 5).n_samples(), 100);
-        assert_eq!(ring(100, 5).n_samples(), 100);
-    }
-
-    #[test]
-    fn sample_count_truncated_when_not_divisible() {
-        assert_eq!(uniform(100, 3).n_samples(), 99);
-        assert_eq!(ring(100, 3).n_samples(), 99);
-    }
-
-    #[test]
-    fn uniform_features_within_bounds() {
-        for &val in uniform(200, 2).features.iter() {
-            assert!(val >= 0.0 && val <= 10.0, "feature {} hors de [0, 10]", val);
-        }
-    }
-
-    #[test]
-    fn ring_features_within_bounds() {
-        for &val in ring(90, 3).features.iter() {
-            assert!(val >= 0.0 && val <= 10.0, "feature {} hors de [0, 10]", val);
-        }
-    }
-}
-
 use crate::data::dataset::Dataset;
 use ndarray::{Array1, Array2, Axis};
 use ndarray_rand::RandomExt;
@@ -184,4 +117,79 @@ pub fn random_points(
     }
 
     points
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uniform(n_samples: usize, n_clusters: usize) -> Dataset {
+        UniformDataset {
+            n_samples,
+            n_features: 2,
+            n_clusters,
+            feature_min: 0.0,
+            feature_max: 10.0,
+        }
+        .generate(42)
+    }
+
+    fn ring(n_samples: usize, n_clusters: usize) -> Dataset {
+        RingDataset {
+            n_samples,
+            n_features: 2,
+            n_clusters,
+            feature_min: 0.0,
+            feature_max: 10.0,
+        }
+        .generate(42)
+    }
+
+    #[test]
+    fn uniform_labels_are_zero_indexed() {
+        let mut labels = uniform(90, 3).unique_labels();
+        labels.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(labels, vec![0.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn ring_labels_are_zero_indexed() {
+        let mut labels = ring(90, 3).unique_labels();
+        labels.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(labels, vec![0.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn sample_count_exact_when_divisible() {
+        assert_eq!(uniform(100, 5).n_samples(), 100);
+        assert_eq!(ring(100, 5).n_samples(), 100);
+    }
+
+    #[test]
+    fn sample_count_truncated_when_not_divisible() {
+        assert_eq!(uniform(100, 3).n_samples(), 99);
+        assert_eq!(ring(100, 3).n_samples(), 99);
+    }
+
+    #[test]
+    fn uniform_features_within_bounds() {
+        for &val in uniform(200, 2).features.iter() {
+            assert!(
+                (0.0..=10.0).contains(&val),
+                "feature {} hors de [0, 10]",
+                val
+            );
+        }
+    }
+
+    #[test]
+    fn ring_features_within_bounds() {
+        for &val in ring(90, 3).features.iter() {
+            assert!(
+                (0.0..=10.0).contains(&val),
+                "feature {} hors de [0, 10]",
+                val
+            );
+        }
+    }
 }

--- a/core/src/io/model.rs
+++ b/core/src/io/model.rs
@@ -8,33 +8,6 @@ use std::io::ErrorKind::InvalidData;
 use std::io::{Error, Result};
 use std::path::{Path, PathBuf};
 
-#[cfg(test)]
-mod tests {
-    use crate::activations::RELU;
-    use crate::model::{NeuralNetwork, NeuronLayerSpec};
-    use ndarray::Array2;
-
-    #[test]
-    fn save_load_roundtrip_predictions_are_identical() {
-        let specs = NeuronLayerSpec::network_for(vec![4], &*RELU, 2);
-        let model = NeuralNetwork::initialization(3, &specs);
-
-        let inputs = Array2::from_shape_fn((3, 5), |(i, j)| (i * 5 + j) as f32 * 0.1);
-        let predictions_before = model.predict(inputs.view());
-
-        let path =
-            std::path::PathBuf::from(format!("target/nrn_test_model_{}", std::process::id()));
-        model.save(&path).unwrap();
-
-        let loaded = NeuralNetwork::load(&path).unwrap();
-        let predictions_after = loaded.predict(inputs.view());
-
-        let _ = std::fs::remove_file(path.with_extension("h5"));
-
-        assert_eq!(predictions_before, predictions_after);
-    }
-}
-
 impl NeuralNetwork {
     /// Saves the neural network to an HDF5 group.
     /// # Arguments
@@ -130,5 +103,32 @@ impl NeuralNetwork {
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
         let file = h5::load_file(path)?;
         NeuralNetwork::load_from_group(&file)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::activations::RELU;
+    use crate::model::{NeuralNetwork, NeuronLayerSpec};
+    use ndarray::Array2;
+
+    #[test]
+    fn save_load_roundtrip_predictions_are_identical() {
+        let specs = NeuronLayerSpec::network_for(vec![4], &*RELU, 2);
+        let model = NeuralNetwork::initialization(3, &specs);
+
+        let inputs = Array2::from_shape_fn((3, 5), |(i, j)| (i * 5 + j) as f32 * 0.1);
+        let predictions_before = model.predict(inputs.view());
+
+        let path =
+            std::path::PathBuf::from(format!("target/nrn_test_model_{}", std::process::id()));
+        model.save(&path).unwrap();
+
+        let loaded = NeuralNetwork::load(&path).unwrap();
+        let predictions_after = loaded.predict(inputs.view());
+
+        let _ = std::fs::remove_file(path.with_extension("h5"));
+
+        assert_eq!(predictions_before, predictions_after);
     }
 }

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -376,7 +376,11 @@ mod tests {
         ];
         let output = model.predict(inputs.view());
         for &v in output.iter() {
-            assert!(v >= 0.0 && v <= 1.0, "Sigmoid output {} not in [0, 1]", v);
+            assert!(
+                (0.0..=1.0).contains(&v),
+                "Sigmoid output {} not in [0, 1]",
+                v
+            );
         }
     }
 

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -223,7 +223,9 @@ impl NeuronLayerSpec {
     /// - For multi-class classification (n_classes > 2): n_classes neurons with softmax activation
     ///
     /// # Panics
-    /// When `n_classes` is less than or equal to 1.
+    /// When `n_classes` is less than or equal to 1. This is a precondition the caller
+    /// must guarantee; for data-derived class counts, validate the dataset up front with
+    /// [`crate::data::Dataset::validate`], which reports the error instead of panicking.
     /// # Arguments
     /// - `n_classes`: The number of classes for the output layer.
     ///
@@ -269,6 +271,10 @@ impl NeuronLayerSpec {
     /// - When `n_features` is less than or equal to zero.
     /// - When `n_classes` is less than or equal to one.
     /// - When `n_samples` is less than or equal to zero.
+    ///
+    /// These are preconditions the caller must guarantee. For data-derived values,
+    /// validate the dataset up front with [`crate::data::Dataset::validate`], which
+    /// reports these conditions as errors instead of panicking.
     pub fn infer_from<A: Activation + 'static>(
         n_features: usize,
         n_classes: usize,

--- a/core/src/nn/optimizers/adam.rs
+++ b/core/src/nn/optimizers/adam.rs
@@ -115,3 +115,76 @@ impl Optimizer for Adam {
         self.time_step += 1;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::activations::RELU;
+    use ndarray::{Array1, Array2, array};
+
+    fn layer(weights: Array2<f32>, biases: Array1<f32>) -> NeuronLayer {
+        NeuronLayer {
+            weights,
+            biases,
+            activation: RELU.clone(),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Beta1 must be in (0, 1)")]
+    fn adam_rejects_invalid_beta1() {
+        Adam::new(LearningRate::new(0.01), 1.5, 0.999, 1e-8);
+    }
+
+    #[test]
+    fn adam_first_step_moves_by_approximately_learning_rate() {
+        // On the first update, m_hat = grad and v_hat = grad^2, so the step is
+        // lr * grad / |grad| = lr * sign(grad), independent of the gradient magnitude.
+        let lr = 0.01;
+        let mut opt = Adam::with_defaults(LearningRate::new(lr));
+        let mut l = layer(array![[1.0, 1.0]], array![1.0]);
+        let grads = Gradients {
+            dw: array![[2.0, -3.0]],
+            db: array![0.5],
+        };
+        opt.update(0, &mut l, &grads);
+        assert!((l.weights[[0, 0]] - (1.0 - lr)).abs() < 1e-4); // +grad → decrease
+        assert!((l.weights[[0, 1]] - (1.0 + lr)).abs() < 1e-4); // -grad → increase
+        assert!((l.biases[0] - (1.0 - lr)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn adam_zero_gradient_leaves_params_unchanged() {
+        let mut opt = Adam::with_defaults(LearningRate::new(0.1));
+        let mut l = layer(array![[1.0, -2.0]], array![3.0]);
+        let grads = Gradients {
+            dw: Array2::zeros((1, 2)),
+            db: Array1::zeros(1),
+        };
+        opt.update(0, &mut l, &grads);
+        assert!((l.weights[[0, 0]] - 1.0).abs() < 1e-6);
+        assert!((l.weights[[0, 1]] - (-2.0)).abs() < 1e-6);
+        assert!((l.biases[0] - 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn adam_minimizes_simple_quadratic() {
+        // f(w) = 0.5 * w^2 has gradient w and minimum at 0; Adam should drive w → 0.
+        let mut opt = Adam::with_defaults(LearningRate::new(0.1));
+        let mut l = layer(array![[5.0]], array![0.0]);
+        for _ in 0..200 {
+            let w = l.weights[[0, 0]];
+            let grads = Gradients {
+                dw: array![[w]],
+                db: array![0.0],
+            };
+            opt.update(0, &mut l, &grads);
+            opt.step();
+        }
+        assert!(
+            l.weights[[0, 0]].abs() < 0.5,
+            "weight should approach 0, got {}",
+            l.weights[[0, 0]]
+        );
+    }
+}

--- a/core/src/nn/optimizers/sgd.rs
+++ b/core/src/nn/optimizers/sgd.rs
@@ -33,3 +33,46 @@ impl Optimizer for StochasticGradientDescent {
         layer.biases -= &(db * self.learning_rate.value());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::activations::RELU;
+    use ndarray::{Array1, Array2, array};
+
+    fn layer(weights: Array2<f32>, biases: Array1<f32>) -> NeuronLayer {
+        NeuronLayer {
+            weights,
+            biases,
+            activation: RELU.clone(),
+        }
+    }
+
+    #[test]
+    fn sgd_subtracts_scaled_gradient() {
+        let mut opt = StochasticGradientDescent::new(LearningRate::new(0.1));
+        let mut l = layer(array![[1.0, 2.0]], array![1.0]);
+        let grads = Gradients {
+            dw: array![[0.5, 1.0]],
+            db: array![2.0],
+        };
+        opt.update(0, &mut l, &grads);
+        // params -= learning_rate * gradient
+        assert!((l.weights[[0, 0]] - 0.95).abs() < 1e-6);
+        assert!((l.weights[[0, 1]] - 1.9).abs() < 1e-6);
+        assert!((l.biases[0] - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn sgd_zero_gradient_leaves_params_unchanged() {
+        let mut opt = StochasticGradientDescent::new(LearningRate::new(0.5));
+        let mut l = layer(array![[1.0, -2.0]], array![3.0]);
+        let grads = Gradients {
+            dw: Array2::zeros((1, 2)),
+            db: Array1::zeros(1),
+        };
+        opt.update(0, &mut l, &grads);
+        assert_eq!(l.weights, array![[1.0, -2.0]]);
+        assert_eq!(l.biases, array![3.0]);
+    }
+}

--- a/core/src/nn/schedulers/constant.rs
+++ b/core/src/nn/schedulers/constant.rs
@@ -37,3 +37,16 @@ impl Scheduler for ConstantScheduler {
         self.learning_rate
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn always_returns_the_same_rate() {
+        let mut s = ConstantScheduler::new(LearningRate::new(0.003));
+        for _ in 0..5 {
+            assert!((s.step().value() - 0.003).abs() < 1e-9);
+        }
+    }
+}

--- a/core/src/nn/schedulers/cosine_annealing.rs
+++ b/core/src/nn/schedulers/cosine_annealing.rs
@@ -95,3 +95,50 @@ impl Scheduler for CosineAnnealing {
         lr
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_at_max_and_ends_at_min() {
+        let (min, max, steps) = (0.001, 0.1, 10);
+        let mut s = CosineAnnealing::new(LearningRate::new(min), LearningRate::new(max), steps);
+        // First step (cos(0) = 1) yields the maximum.
+        assert!((s.step().value() - max).abs() < 1e-6);
+        // Exhaust the remaining steps of the cycle.
+        for _ in 1..steps {
+            s.step();
+        }
+        // Past the end of the cycle (no restarts) the minimum is returned.
+        assert!((s.step().value() - min).abs() < 1e-6);
+    }
+
+    #[test]
+    fn midpoint_is_average_of_min_and_max() {
+        let (min, max, steps) = (0.0, 1.0, 4);
+        let mut s = CosineAnnealing::new(LearningRate::new(min), LearningRate::new(max), steps);
+        s.step(); // step 0
+        s.step(); // step 1
+        // step 2 of 4: cos(π/2) = 0 → lr = (min + max) / 2.
+        assert!((s.step().value() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn warm_restart_resets_to_max_and_grows_period() {
+        let (min, max, steps) = (0.0, 1.0, 2);
+        let mut s = CosineAnnealing::new(LearningRate::new(min), LearningRate::new(max), steps)
+            .with_restarts(true, 2);
+        let first = s.step().value(); // step 0 → max
+        s.step(); // step 1 → triggers restart, period grows to 4
+        let after_restart = s.step().value(); // step 0 of new cycle → max again
+        assert!((first - max).abs() < 1e-6);
+        assert!((after_restart - max).abs() < 1e-6);
+    }
+
+    #[test]
+    #[should_panic(expected = "Maximum learning rate must be greater than minimum")]
+    fn rejects_max_not_greater_than_min() {
+        CosineAnnealing::new(LearningRate::new(0.1), LearningRate::new(0.1), 10);
+    }
+}

--- a/core/src/nn/training.rs
+++ b/core/src/nn/training.rs
@@ -5,7 +5,7 @@ use crate::nn::schedulers::Scheduler;
 use crate::optimizers::Optimizer;
 use ndarray::{Array1, Array2, ArrayView2, Axis};
 use ndarray_rand::rand;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 /// Small constant to prevent division by zero in gradient clipping.
 /// This value was chosen to be sufficiently small to avoid affecting the clipping behavior
@@ -103,8 +103,8 @@ impl NeuralNetwork {
         &mut self,
         dataset: &ModelDataset,
         loss_function: &Arc<dyn LossFunction>,
-        optimizer: &Arc<Mutex<dyn Optimizer>>,
-        scheduler: &Arc<Mutex<dyn Scheduler>>,
+        optimizer: &mut dyn Optimizer,
+        scheduler: &mut dyn Scheduler,
         clipping: &GradientClipping,
         batch_size: Option<usize>,
     ) {
@@ -116,14 +116,8 @@ impl NeuralNetwork {
         );
 
         // Scheduler steps once per epoch regardless of batch size
-        let lr = scheduler
-            .lock()
-            .expect("scheduler mutex was poisoned")
-            .step();
-        optimizer
-            .lock()
-            .expect("optimizer mutex was poisoned")
-            .set_learning_rate(lr);
+        let lr = scheduler.step();
+        optimizer.set_learning_rate(lr);
 
         match batch_size {
             None => {
@@ -163,12 +157,10 @@ impl NeuralNetwork {
         activations: &[Array2<f32>],
         targets: ArrayView2<f32>,
         loss_function: &Arc<dyn LossFunction>,
-        optimizer: &Arc<Mutex<dyn Optimizer>>,
+        optimizer: &mut dyn Optimizer,
         clipping: &GradientClipping,
     ) {
         let gradients = self.backward(activations, targets, loss_function);
-
-        let mut optimizer = optimizer.lock().expect("optimizer mutex was poisoned");
 
         for (layer_index, (layer, mut layer_gradients)) in
             self.layers.iter_mut().zip(gradients).enumerate()

--- a/core/tests/convergence.rs
+++ b/core/tests/convergence.rs
@@ -3,10 +3,10 @@ use nrn::activations::SIGMOID;
 use nrn::data::ModelDataset;
 use nrn::loss_functions::{CROSS_ENTROPY_LOSS, LossFunction};
 use nrn::model::{NeuralNetwork, NeuronLayerSpec};
-use nrn::optimizers::{Adam, Optimizer};
-use nrn::schedulers::{ConstantScheduler, Scheduler};
+use nrn::optimizers::Adam;
+use nrn::schedulers::ConstantScheduler;
 use nrn::training::{GradientClipping, LearningRate};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 #[test]
 fn xor_converges_to_low_loss() {
@@ -20,14 +20,19 @@ fn xor_converges_to_low_loss() {
     let mut model = NeuralNetwork::initialization(2, &specs);
 
     let loss_fn: Arc<dyn LossFunction> = CROSS_ENTROPY_LOSS.clone();
-    let optimizer: Arc<Mutex<dyn Optimizer>> =
-        Arc::new(Mutex::new(Adam::with_defaults(LearningRate::new(0.1))));
-    let scheduler: Arc<Mutex<dyn Scheduler>> =
-        Arc::new(Mutex::new(ConstantScheduler::new(LearningRate::new(0.1))));
+    let mut optimizer = Adam::with_defaults(LearningRate::new(0.1));
+    let mut scheduler = ConstantScheduler::new(LearningRate::new(0.1));
     let clipping = GradientClipping::None;
 
     for _ in 0..10_000 {
-        model.train(&dataset, &loss_fn, &optimizer, &scheduler, &clipping, None);
+        model.train(
+            &dataset,
+            &loss_fn,
+            &mut optimizer,
+            &mut scheduler,
+            &clipping,
+            None,
+        );
     }
 
     let predictions = model.predict(dataset.inputs.view());
@@ -50,18 +55,16 @@ fn xor_converges_with_mini_batch() {
     let mut model = NeuralNetwork::initialization(2, &specs);
 
     let loss_fn: Arc<dyn LossFunction> = CROSS_ENTROPY_LOSS.clone();
-    let optimizer: Arc<Mutex<dyn Optimizer>> =
-        Arc::new(Mutex::new(Adam::with_defaults(LearningRate::new(0.01))));
-    let scheduler: Arc<Mutex<dyn Scheduler>> =
-        Arc::new(Mutex::new(ConstantScheduler::new(LearningRate::new(0.01))));
+    let mut optimizer = Adam::with_defaults(LearningRate::new(0.01));
+    let mut scheduler = ConstantScheduler::new(LearningRate::new(0.01));
     let clipping = GradientClipping::None;
 
     for _ in 0..8_000 {
         model.train(
             &dataset,
             &loss_fn,
-            &optimizer,
-            &scheduler,
+            &mut optimizer,
+            &mut scheduler,
             &clipping,
             Some(2),
         );
@@ -91,14 +94,19 @@ fn three_class_converges_to_low_loss() {
     let mut model = NeuralNetwork::initialization(2, &specs);
 
     let loss_fn: Arc<dyn LossFunction> = CROSS_ENTROPY_LOSS.clone();
-    let optimizer: Arc<Mutex<dyn Optimizer>> =
-        Arc::new(Mutex::new(Adam::with_defaults(LearningRate::new(0.05))));
-    let scheduler: Arc<Mutex<dyn Scheduler>> =
-        Arc::new(Mutex::new(ConstantScheduler::new(LearningRate::new(0.05))));
+    let mut optimizer = Adam::with_defaults(LearningRate::new(0.05));
+    let mut scheduler = ConstantScheduler::new(LearningRate::new(0.05));
     let clipping = GradientClipping::None;
 
     for _ in 0..5_000 {
-        model.train(&dataset, &loss_fn, &optimizer, &scheduler, &clipping, None);
+        model.train(
+            &dataset,
+            &loss_fn,
+            &mut optimizer,
+            &mut scheduler,
+            &clipping,
+            None,
+        );
     }
 
     let predictions = model.predict(dataset.inputs.view());

--- a/core/tests/convergence.rs
+++ b/core/tests/convergence.rs
@@ -1,5 +1,5 @@
 use ndarray::array;
-use nrn::activations::{RELU, SIGMOID};
+use nrn::activations::SIGMOID;
 use nrn::data::ModelDataset;
 use nrn::loss_functions::{CROSS_ENTROPY_LOSS, LossFunction};
 use nrn::model::{NeuralNetwork, NeuronLayerSpec};


### PR DESCRIPTION
Addresses all findings from the 2026-05-30 technical audit.

## Findings
1. Validate binary labels are `0`/`1` in `to_model_dataset()` (was only checked for multi-class).
2. Strict clippy in CI (`--all-targets -D warnings`) + fix the lints. CI now runs the Taskfile tasks so local and CI checks can't drift.
3. Unit tests for Adam/SGD and the Constant/CosineAnnealing schedulers (previously untested).
4. `n_classes == 1` no longer panics deep in layer construction: `Dataset::validate()` checks dataset validity at the boundary; constructors keep their asserts as documented preconditions.
5. Optimizer state isn't persisted on resume — documented, with a CLI warning when resuming with Adam (rather than committing to an on-disk format for a small gain).
6. Declare MSRV `1.88` (floor set by let-chains) and add a `cargo audit` step.
7. Replace `Arc<Mutex<dyn Optimizer/Scheduler>>` with `&mut dyn`: training is single-threaded and the optimizer state is inherently sequential, so the Mutex enabled no real parallelism.

## Verification
`task lint`, `task build`, `task test` (75 unit + convergence), `task audit` (no vulnerabilities) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)