### PR TITLE
feat(training): seed runs for reproducible training

### DIFF
--- a/cli/src/actions.rs
+++ b/cli/src/actions.rs
@@ -82,6 +82,7 @@ pub(crate) fn initialize_model_with(
     dataset: &Dataset,
     layers: Option<Vec<usize>>,
     auto_layers: bool,
+    seed: u64,
 ) -> NeuralNetwork {
     let layer_specs = if auto_layers {
         NeuronLayerSpec::infer_from(
@@ -93,7 +94,7 @@ pub(crate) fn initialize_model_with(
     } else {
         NeuronLayerSpec::network_for(layers.unwrap_or_default(), &*RELU, dataset.n_classes())
     };
-    let model = NeuralNetwork::initialization(dataset.n_features(), &layer_specs);
+    let model = NeuralNetwork::initialization(dataset.n_features(), &layer_specs, seed);
     initialized(&model);
     model
 }

--- a/cli/src/commands/train/args.rs
+++ b/cli/src/commands/train/args.rs
@@ -97,6 +97,11 @@ pub struct TrainArgs {
     /// Mini-batch size (omit for full-batch)
     #[arg(long)]
     batch_size: Option<usize>,
+
+    /// Seed for weight initialization and mini-batch shuffling (omit for a random,
+    /// reported seed). Recorded so the run is reproducible and resumable.
+    #[arg(long)]
+    pub seed: Option<u64>,
 }
 
 impl From<OptimizerType> for OptimizerConfig {
@@ -176,6 +181,7 @@ impl TryFrom<&TrainArgs> for HyperParameters {
             args.early_stopping()?,
             args.val_ratio,
             args.test_ratio,
+            args.seed.unwrap_or_else(ndarray_rand::rand::random),
         )
     }
 }

--- a/cli/src/commands/train/mod.rs
+++ b/cli/src/commands/train/mod.rs
@@ -83,7 +83,12 @@ impl StartArgs {
 
         let model = match &self.model {
             Some(path) => load_model(path)?,
-            None => initialize_model_with(&dataset, self.layers.clone(), self.auto_layers),
+            None => initialize_model_with(
+                &dataset,
+                self.layers.clone(),
+                self.auto_layers,
+                hyperparameters.seed(),
+            ),
         };
 
         let run_dir = dataset_path.with_file_name(format!("training-model-{dataset_name}"));

--- a/cli/src/commands/train/monitor.rs
+++ b/cli/src/commands/train/monitor.rs
@@ -120,6 +120,7 @@ type Row = (&'static str, fn(&HyperParameters) -> String);
 /// Recap rows in display order. [`print_recap`] iterates over these to align
 /// the leader dots and to diff each field against `previous`.
 const ROWS: &[Row] = &[
+    ("Seed", |h| h.seed().to_string()),
     ("Epochs", |h| h.epochs().to_string()),
     ("Loss", |h| loss_value(h.loss())),
     ("Optimizer", optimizer_value),

--- a/cli/tests/train_plot.rs
+++ b/cli/tests/train_plot.rs
@@ -59,6 +59,8 @@ fn train_creates_run_dir_and_plot_generates_png_and_gif() {
         &[
             "train",
             "start",
+            "--seed",
+            "42",
             ds_name,
             "--epochs",
             "20",
@@ -121,6 +123,8 @@ fn load_history_rejects_too_few_checkpoints() {
         &[
             "train",
             "start",
+            "--seed",
+            "42",
             ds_name,
             "--epochs",
             "2",
@@ -169,6 +173,8 @@ fn early_stopping_writes_final_checkpoint() {
         .args([
             "train",
             "start",
+            "--seed",
+            "42",
             ds_name,
             "--epochs",
             "30",
@@ -231,6 +237,8 @@ fn no_duplicate_checkpoint_when_early_stop_fires_on_interval_boundary() {
         .args([
             "train",
             "start",
+            "--seed",
+            "42",
             ds_name,
             "--epochs",
             "20",
@@ -302,6 +310,8 @@ fn start_prints_recap_without_overrides() {
         .args([
             "train",
             "start",
+            "--seed",
+            "42",
             ds_name,
             "--epochs",
             "2",
@@ -352,6 +362,8 @@ fn resume_with_lr_override_shows_marker_on_optimizer_line() {
         &[
             "train",
             "start",
+            "--seed",
+            "42",
             ds_name,
             "--epochs",
             "2",
@@ -413,6 +425,8 @@ fn resume_restores_adam_optimizer_state() {
         &[
             "train",
             "start",
+            "--seed",
+            "42",
             ds_name,
             "--epochs",
             "2",
@@ -460,6 +474,8 @@ fn resume_rejects_val_ratio_override() {
         &[
             "train",
             "start",
+            "--seed",
+            "42",
             ds_name,
             "--epochs",
             "2",
@@ -508,6 +524,8 @@ fn divergence_with_early_stopping_recovers_best_model() {
         .args([
             "train",
             "start",
+            "--seed",
+            "42",
             ds_name,
             "--epochs",
             "50",

--- a/core/src/io/checkpoint.rs
+++ b/core/src/io/checkpoint.rs
@@ -304,7 +304,7 @@ mod tests {
 
     fn sample_model() -> NeuralNetwork {
         let specs = NeuronLayerSpec::network_for(vec![3], &*RELU, 2);
-        NeuralNetwork::initialization(2, &specs)
+        NeuralNetwork::initialization(2, &specs, 0)
     }
 
     fn make_eval(loss: f32, with_validation: bool) -> EvaluationSet {

--- a/core/src/io/hyperparams.rs
+++ b/core/src/io/hyperparams.rs
@@ -200,6 +200,7 @@ pub struct HyperParametersRecord {
     pub val_ratio: f32,
     pub test_ratio: f32,
     pub loss: LossRecord,
+    pub seed: u64,
 }
 
 impl From<&HyperParameters> for HyperParametersRecord {
@@ -216,6 +217,7 @@ impl From<&HyperParameters> for HyperParametersRecord {
             val_ratio: hyperparameters.val_ratio(),
             test_ratio: hyperparameters.test_ratio(),
             loss: hyperparameters.loss().into(),
+            seed: hyperparameters.seed(),
         }
     }
 }
@@ -249,6 +251,7 @@ impl TryFrom<HyperParametersRecord> for HyperParameters {
             early_stopping,
             record.val_ratio,
             record.test_ratio,
+            record.seed,
         )
     }
 }
@@ -272,6 +275,7 @@ impl HyperParametersRecord {
             val_ratio: 0.1,
             test_ratio: 0.1,
             loss: LossRecord::CrossEntropy,
+            seed: 42,
         }
     }
 }

--- a/core/src/io/model.rs
+++ b/core/src/io/model.rs
@@ -100,7 +100,7 @@ mod tests {
     #[test]
     fn save_load_roundtrip_predictions_are_identical() {
         let specs = NeuronLayerSpec::network_for(vec![4], &*RELU, 2);
-        let model = NeuralNetwork::initialization(3, &specs);
+        let model = NeuralNetwork::initialization(3, &specs, 0);
 
         let inputs = Array2::from_shape_fn((3, 5), |(i, j)| (i * 5 + j) as f32 * 0.1);
         let predictions_before = model.predict(inputs.view());

--- a/core/src/nn/initializations/he.rs
+++ b/core/src/nn/initializations/he.rs
@@ -1,6 +1,7 @@
 use crate::initializations::Initialization;
 use crate::initializations::uniform_distribution;
 use ndarray::{Array1, Array2};
+use ndarray_rand::rand::RngCore;
 use ndarray_rand::rand_distr::Uniform;
 use once_cell::sync::Lazy;
 use std::sync::Arc;
@@ -17,14 +18,16 @@ impl Initialization for HeUniform {
     ///
     /// # Arguments
     /// * `shape` - Tuple (fan_out, fan_in) for the weight matrix.
+    /// * `rng` - The random number generator the weights are drawn from.
     ///
     /// # Returns
     /// Tuple of (weights, biases) as ndarray arrays.
-    fn apply(&self, shape: (usize, usize)) -> (Array2<f32>, Array1<f32>) {
+    fn apply(&self, shape: (usize, usize), rng: &mut dyn RngCore) -> (Array2<f32>, Array1<f32>) {
         let limit = (6.0 / shape.1 as f32).sqrt();
         uniform_distribution(
             shape,
             &Uniform::new(-limit, limit).expect("valid He limits require fan_in > 0"),
+            rng,
         )
     }
 }

--- a/core/src/nn/initializations/mod.rs
+++ b/core/src/nn/initializations/mod.rs
@@ -20,6 +20,7 @@ pub use xavier::XAVIER_UNIFORM;
 
 use ndarray::{Array1, Array2};
 use ndarray_rand::RandomExt;
+use ndarray_rand::rand::RngCore;
 use ndarray_rand::rand_distr::Uniform;
 
 pub trait Initialization: Send + Sync {
@@ -28,6 +29,8 @@ pub trait Initialization: Send + Sync {
     /// # Arguments
     ///
     /// * `shape` - A tuple `(rows, cols)` specifying the desired shape of the weight matrix.
+    /// * `rng` - The random number generator the weights are drawn from. Passing a
+    ///   seeded generator makes the initialization reproducible.
     ///
     /// # Returns
     ///
@@ -37,14 +40,15 @@ pub trait Initialization: Send + Sync {
     ///
     /// This allows layers to start training from a well-defined state,
     /// tailored to the activation function or network architecture.
-    fn apply(&self, shape: (usize, usize)) -> (Array2<f32>, Array1<f32>);
+    fn apply(&self, shape: (usize, usize), rng: &mut dyn RngCore) -> (Array2<f32>, Array1<f32>);
 }
 
 fn uniform_distribution(
     shape: (usize, usize),
     distribution: &Uniform<f32>,
+    rng: &mut dyn RngCore,
 ) -> (Array2<f32>, Array1<f32>) {
-    let weights = Array2::random(shape, distribution);
+    let weights = Array2::random_using(shape, distribution, rng);
     let biases = Array1::zeros(shape.0);
     (weights, biases)
 }

--- a/core/src/nn/initializations/xavier.rs
+++ b/core/src/nn/initializations/xavier.rs
@@ -1,5 +1,6 @@
 use crate::initializations::{Initialization, uniform_distribution};
 use ndarray::{Array1, Array2};
+use ndarray_rand::rand::RngCore;
 use ndarray_rand::rand_distr::Uniform;
 use once_cell::sync::Lazy;
 use std::sync::Arc;
@@ -16,14 +17,16 @@ impl Initialization for XavierUniform {
     ///
     /// # Arguments
     /// * `shape` - Tuple (fan_out, fan_in) for the weight matrix.
+    /// * `rng` - The random number generator the weights are drawn from.
     ///
     /// # Returns
     /// Tuple of (weights, biases) as ndarray arrays.
-    fn apply(&self, shape: (usize, usize)) -> (Array2<f32>, Array1<f32>) {
+    fn apply(&self, shape: (usize, usize), rng: &mut dyn RngCore) -> (Array2<f32>, Array1<f32>) {
         let limit = (6.0 / (shape.1 + shape.0) as f32).sqrt();
         uniform_distribution(
             shape,
             &Uniform::new(-limit, limit).expect("valid Xavier limits require fan_in + fan_out > 0"),
+            rng,
         )
     }
 }

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -6,6 +6,9 @@
 
 use crate::activations::{Activation, SIGMOID, SOFTMAX};
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Axis};
+use ndarray_rand::rand::RngCore;
+use ndarray_rand::rand::SeedableRng;
+use ndarray_rand::rand::rngs::StdRng;
 use std::iter::once;
 use std::sync::Arc;
 
@@ -47,13 +50,15 @@ pub fn last_activation(activations: &[Array2<f32>]) -> Array2<f32> {
 }
 
 impl NeuronLayer {
-    /// Initializes a new `NeuronLayer` with random weights and biases.
+    /// Initializes a new `NeuronLayer` with random weights and biases drawn from `rng`.
     /// # Panics
     /// - When `neurons` or `inputs` are less than or equal to zero.
     /// # Arguments
     /// - `inputs`: The number of inputs to this layer (i.e., the number of neurons in the previous layer).
     /// - `spec`: The specifications for this layer, including the number of neurons and the activation method.
-    pub fn initialization(inputs: usize, spec: &NeuronLayerSpec) -> Self {
+    /// - `rng`: The random number generator the weights are drawn from. Passing a seeded
+    ///   generator makes the initialization reproducible.
+    pub fn initialization(inputs: usize, spec: &NeuronLayerSpec, rng: &mut dyn RngCore) -> Self {
         assert!(
             spec.neurons > 0 && inputs > 0,
             "Neurons and inputs must be greater than zero."
@@ -62,7 +67,7 @@ impl NeuronLayer {
         let (weights, biases) = spec
             .activation
             .initialization()
-            .apply((spec.neurons, inputs));
+            .apply((spec.neurons, inputs), rng);
 
         NeuronLayer {
             weights,
@@ -117,22 +122,35 @@ impl NeuronLayer {
 }
 
 impl NeuralNetwork {
-    /// Creates a new `NeuronNetwork` with the specified input size and layer specifications.
+    /// Creates a new `NeuralNetwork` with the specified input size and layer specifications.
+    ///
+    /// The weights are drawn from a generator seeded with `seed`, so initialization is
+    /// always reproducible: the same `seed` and architecture yield the same starting
+    /// weights. There is intentionally no unseeded constructor — an implicit random
+    /// initialization is exactly the source of non-reproducible (flaky) training runs.
     /// # Arguments
     /// - `inputs`: The number of inputs to the first layer of the network.
     /// - `layer_specs`: A slice of `NeuronLayerSpec` representing the specifications for each layer in the network.
-    pub fn initialization(inputs: usize, layer_specs: &[NeuronLayerSpec]) -> Self {
+    /// - `seed`: The seed for the weight-initialization generator.
+    pub fn initialization(inputs: usize, layer_specs: &[NeuronLayerSpec], seed: u64) -> Self {
         assert!(inputs > 0, "Input size must be greater than zero.");
         assert!(
             !layer_specs.is_empty(),
             "At least one layer must be specified."
         );
 
+        // A single generator threaded through every layer, so the layers draw
+        // decorrelated weights from one reproducible stream.
+        let mut rng = StdRng::seed_from_u64(seed);
         let mut layers = Vec::with_capacity(layer_specs.len());
         let mut layer_input = inputs;
 
         for layer_spec in layer_specs {
-            layers.push(NeuronLayer::initialization(layer_input, layer_spec));
+            layers.push(NeuronLayer::initialization(
+                layer_input,
+                layer_spec,
+                &mut rng,
+            ));
             layer_input = layer_spec.neurons;
         }
 
@@ -375,7 +393,7 @@ mod tests {
     fn network_reports_specs_input_size_and_summary() {
         // 3 inputs -> 4 relu -> 3 softmax
         let specs = NeuronLayerSpec::network_for(vec![4], &*RELU, 3);
-        let model = NeuralNetwork::initialization(3, &specs);
+        let model = NeuralNetwork::initialization(3, &specs, 0);
 
         assert_eq!(model.input_size(), 3);
 
@@ -392,7 +410,7 @@ mod tests {
         // Network: 3 inputs -> 4 hidden (relu) -> 3 output (softmax), 5 samples
         // Note: n_classes=2 produces 1 sigmoid neuron (binary); use 3 for multi-class
         let specs = NeuronLayerSpec::network_for(vec![4], &*RELU, 3);
-        let model = NeuralNetwork::initialization(3, &specs);
+        let model = NeuralNetwork::initialization(3, &specs, 0);
         let inputs = Array2::zeros((3, 5)); // (features, samples)
         let output = model.predict(inputs.view());
         assert_eq!(output.shape(), &[3, 5]); // (classes, samples)
@@ -426,7 +444,7 @@ mod tests {
     #[test]
     fn sigmoid_output_always_in_zero_one() {
         let specs = NeuronLayerSpec::network_for(vec![], &*SIGMOID, 2);
-        let model = NeuralNetwork::initialization(4, &specs);
+        let model = NeuralNetwork::initialization(4, &specs, 0);
         // f32 saturates to exactly 0.0 or 1.0 for large inputs, so use closed interval
         let inputs = array![
             [100.0, -100.0],
@@ -447,7 +465,7 @@ mod tests {
     #[test]
     fn predict_returns_last_forward_activation() {
         let specs = NeuronLayerSpec::network_for(vec![4], &*RELU, 2);
-        let model = NeuralNetwork::initialization(3, &specs);
+        let model = NeuralNetwork::initialization(3, &specs, 0);
         let inputs = Array2::zeros((3, 5));
 
         let activations = model.forward(inputs.view());
@@ -489,19 +507,19 @@ mod tests {
     fn n_classes_derives_from_output_layer_size() {
         // 1 sigmoid output -> binary (2 classes)
         let binary =
-            NeuralNetwork::initialization(3, &NeuronLayerSpec::network_for(vec![4], &*RELU, 2));
+            NeuralNetwork::initialization(3, &NeuronLayerSpec::network_for(vec![4], &*RELU, 2), 0);
         assert_eq!(binary.n_classes(), 2);
 
         // k softmax outputs -> k classes
         let multi =
-            NeuralNetwork::initialization(3, &NeuronLayerSpec::network_for(vec![4], &*RELU, 5));
+            NeuralNetwork::initialization(3, &NeuronLayerSpec::network_for(vec![4], &*RELU, 5), 0);
         assert_eq!(multi.n_classes(), 5);
     }
 
     #[test]
     fn predict_single_matches_predict_on_one_sample() {
         let specs = NeuronLayerSpec::network_for(vec![4], &*RELU, 2);
-        let model = NeuralNetwork::initialization(3, &specs);
+        let model = NeuralNetwork::initialization(3, &specs, 0);
 
         let sample = array![1.0, 2.0, 3.0];
         let single = model.predict_single(sample.view());

--- a/core/src/nn/training/backprop.rs
+++ b/core/src/nn/training/backprop.rs
@@ -5,8 +5,35 @@ use crate::model::{NeuralNetwork, last_activation};
 use crate::optimizers::Optimizer;
 use crate::schedulers::Scheduler;
 use ndarray::{Array2, ArrayView2, Axis};
-use ndarray_rand::rand;
+use ndarray_rand::rand::SeedableRng;
+use ndarray_rand::rand::rngs::StdRng;
 use std::sync::Arc;
+
+/// 2⁶⁴⁄φ rounded to an odd integer — the golden-ratio (splitmix64) multiplier. Mixed
+/// with the epoch number, it scatters consecutive epochs across the whole seed space,
+/// so each epoch's mini-batch shuffle differs from its neighbours'.
+const GOLDEN_RATIO: u64 = 0x9E37_79B9_7F4A_7C15;
+
+/// Mini-batch SGD configuration for a single epoch. Bundling the batch `size` with the
+/// `rng` that shuffles it makes the two inseparable: passing `None` to
+/// [`NeuralNetwork::train`] is full-batch (no size, no shuffle), while `Some` always
+/// carries both. This rules out the illegal "size without a generator" (or vice versa)
+/// states a pair of separate parameters would allow. Built via [`MiniBatch::new`].
+pub struct MiniBatch {
+    size: usize,
+    rng: StdRng,
+}
+
+impl MiniBatch {
+    /// Builds the mini-batch config for one epoch: batches of `size`, shuffled by a
+    /// generator seeded from a mix of the run's `seed` and the `epoch`. Deriving it
+    /// from `(seed, epoch)` keeps the shuffle a pure function of the two — reproducible
+    /// and resume-safe, with no RNG state to persist across a checkpoint.
+    pub fn new(size: usize, seed: u64, epoch: usize) -> Self {
+        let rng = StdRng::seed_from_u64(seed ^ (epoch as u64).wrapping_mul(GOLDEN_RATIO));
+        Self { size, rng }
+    }
+}
 
 impl NeuralNetwork {
     /// Trains the network for one epoch using the provided dataset.
@@ -18,8 +45,8 @@ impl NeuralNetwork {
     /// - `optimizer`: The optimizer to use for updating the weights and biases.
     /// - `scheduler`: The learning rate scheduler, stepped once per epoch.
     /// - `clipping`: The gradient clipping strategy to apply during training.
-    /// - `batch_size`: If `Some(n)`, performs mini-batch SGD with batches of size `n`, shuffling
-    ///   the dataset each epoch. If `None`, performs full-batch gradient descent.
+    /// - `mini_batch`: `Some(MiniBatch)` performs mini-batch SGD, shuffling the dataset
+    ///   each epoch; `None` performs full-batch gradient descent.
     pub fn train(
         &mut self,
         dataset: &ModelDataset,
@@ -27,7 +54,7 @@ impl NeuralNetwork {
         optimizer: &mut dyn Optimizer,
         scheduler: &mut dyn Scheduler,
         clipping: &GradientClipping,
-        batch_size: Option<usize>,
+        mini_batch: Option<MiniBatch>,
     ) {
         let n_samples = dataset.inputs.ncols();
         assert_eq!(
@@ -40,7 +67,7 @@ impl NeuralNetwork {
         let lr = scheduler.step();
         optimizer.set_learning_rate(lr);
 
-        match batch_size {
+        match mini_batch {
             None => {
                 let activations = self.forward(dataset.inputs.view());
                 self.update_parameters(
@@ -51,8 +78,8 @@ impl NeuralNetwork {
                     clipping,
                 );
             }
-            Some(size) => {
-                for batch in dataset.batches(size, &mut rand::rng()) {
+            Some(MiniBatch { size, mut rng }) => {
+                for batch in dataset.batches(size, &mut rng) {
                     let activations = self.forward(batch.inputs.view());
                     self.update_parameters(
                         &activations,
@@ -163,7 +190,7 @@ mod tests {
         // Network: 2 inputs -> 2 hidden (sigmoid) -> 1 output (sigmoid, binary)
         // Using sigmoid everywhere to avoid relu's non-differentiable point at 0
         let specs = NeuronLayerSpec::network_for(vec![2], &*SIGMOID, 2);
-        let mut model = NeuralNetwork::initialization(2, &specs);
+        let mut model = NeuralNetwork::initialization(2, &specs, 0);
 
         // Fixed weights for reproducibility
         model.layers[0].weights = array![[0.1, -0.2], [0.3, 0.1]];
@@ -238,7 +265,7 @@ mod tests {
         // differences. The hidden-layer chain rule is covered by the sigmoid test.
         // A single output layer keeps gradients large (O(0.1)) and well within f32 precision.
         let specs = NeuronLayerSpec::network_for(vec![], &*SIGMOID, 3);
-        let mut model = NeuralNetwork::initialization(2, &specs);
+        let mut model = NeuralNetwork::initialization(2, &specs, 0);
 
         model.layers[0].weights = array![[0.5, -0.3], [0.2, 0.8], [-0.4, 0.1]];
         model.layers[0].biases = Array1::from_vec(vec![0.1, -0.2, 0.1]);

--- a/core/src/nn/training/callbacks.rs
+++ b/core/src/nn/training/callbacks.rs
@@ -170,7 +170,7 @@ mod tests {
 
     fn sample_model() -> NeuralNetwork {
         let specs = NeuronLayerSpec::network_for(vec![3], &*RELU, 2);
-        NeuralNetwork::initialization(2, &specs)
+        NeuralNetwork::initialization(2, &specs, 0)
     }
 
     fn sample_split() -> ModelSplit {

--- a/core/src/nn/training/early_stopping.rs
+++ b/core/src/nn/training/early_stopping.rs
@@ -125,7 +125,7 @@ mod tests {
         // After stop, best_model must reflect the state at loss=0.5, not the final state.
         let specs = NeuronLayerSpec::network_for(vec![2], &*SIGMOID, 2);
 
-        let model_initial = NeuralNetwork::initialization(2, &specs);
+        let model_initial = NeuralNetwork::initialization(2, &specs, 0);
         let mut es = EarlyStopping::new(EarlyStoppingConfig::new(2, true).unwrap(), &model_initial);
 
         let mut model_at_best = model_initial.clone();
@@ -150,7 +150,7 @@ mod tests {
     fn early_stopping_skips_snapshot_when_restore_disabled() {
         // With restore_best_model = false, an improvement must NOT clone the model.
         let specs = NeuronLayerSpec::network_for(vec![2], &*SIGMOID, 2);
-        let model = NeuralNetwork::initialization(2, &specs);
+        let model = NeuralNetwork::initialization(2, &specs, 0);
         let mut es = EarlyStopping::new(EarlyStoppingConfig::new(2, false).unwrap(), &model);
 
         assert!(!es.observe(1.0, &model)); // improvement, but no snapshot is taken
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn new_seeds_best_model_when_restore_enabled() {
         let specs = NeuronLayerSpec::network_for(vec![2], &*SIGMOID, 2);
-        let model = NeuralNetwork::initialization(2, &specs);
+        let model = NeuralNetwork::initialization(2, &specs, 0);
         let es = EarlyStopping::new(EarlyStoppingConfig::new(2, true).unwrap(), &model);
 
         assert!(es.best_model.is_some());
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn new_does_not_seed_best_model_when_restore_disabled() {
         let specs = NeuronLayerSpec::network_for(vec![2], &*SIGMOID, 2);
-        let model = NeuralNetwork::initialization(2, &specs);
+        let model = NeuralNetwork::initialization(2, &specs, 0);
         let es = EarlyStopping::new(EarlyStoppingConfig::new(2, false).unwrap(), &model);
 
         assert!(es.best_model.is_none());

--- a/core/src/nn/training/hyperparams.rs
+++ b/core/src/nn/training/hyperparams.rs
@@ -127,6 +127,10 @@ pub struct HyperParameters {
     /// [`build`](HyperParameters::build) applies it (with `val_ratio`) to split
     /// the dataset.
     test_ratio: f32,
+    /// Seed for the run's randomness — the mini-batch shuffle here, and (by
+    /// convention) the model's weight initialization at the call site. Part of the
+    /// run's identity so a run is always reproducible and the seed is recorded.
+    seed: u64,
 }
 
 /// The single error type for constructing a [`HyperParameters`] spec, whether
@@ -243,6 +247,7 @@ impl HyperParameters {
         early_stopping: Option<EarlyStoppingConfig>,
         val_ratio: f32,
         test_ratio: f32,
+        seed: u64,
     ) -> Result<Self, HyperParametersError> {
         if epochs < 1 {
             return Err(HyperParametersError::ZeroEpochs);
@@ -279,6 +284,7 @@ impl HyperParameters {
             early_stopping,
             val_ratio,
             test_ratio,
+            seed,
         })
     }
 
@@ -307,6 +313,7 @@ impl HyperParameters {
         early_stopping: Option<EarlyStoppingConfig>,
         val_ratio: f32,
         test_ratio: f32,
+        seed: u64,
     ) -> Result<Self, HyperParametersError> {
         HyperParameters::new(
             epochs,
@@ -320,6 +327,7 @@ impl HyperParameters {
             early_stopping,
             val_ratio,
             test_ratio,
+            seed,
         )
     }
 
@@ -367,6 +375,10 @@ impl HyperParameters {
         self.test_ratio
     }
 
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Instantiates the runtime [`Trainer`] from this specification, binding it
     /// to the `model` and `callbacks`. This is the one place declarative configs
     /// become concrete objects: the optimizer/scheduler/loss are instantiated, and
@@ -403,6 +415,7 @@ impl HyperParameters {
             checkpoint_interval: self.checkpoint_interval,
             early_stopping: self.early_stopping,
             epoch_start: 0,
+            seed: self.seed,
         }
     }
 }
@@ -433,6 +446,7 @@ mod tests {
             None,
             val_ratio,
             test_ratio,
+            0,
         )
     }
 

--- a/core/src/nn/training/mod.rs
+++ b/core/src/nn/training/mod.rs
@@ -8,6 +8,7 @@ pub mod trainer;
 
 pub use crate::gradients::{GradientClipping, GradientClippingError, Gradients};
 pub use crate::learning_rate::LearningRate;
+pub use backprop::MiniBatch;
 pub use callbacks::{CallbackError, CallbackResult, Callbacks, TrainerCallback};
 pub use early_stopping::{EarlyStopping, EarlyStoppingConfig, EarlyStoppingConfigError};
 pub use evaluator::Evaluator;

--- a/core/src/nn/training/trainer.rs
+++ b/core/src/nn/training/trainer.rs
@@ -1,3 +1,4 @@
+use super::backprop::MiniBatch;
 use super::callbacks::{CallbackError, CallbackResult, Callbacks, TrainerCallback};
 use super::early_stopping::{EarlyStopping, EarlyStoppingConfig};
 use super::evaluator::Evaluator;
@@ -75,6 +76,7 @@ pub struct Trainer {
     pub(super) checkpoint_interval: usize,
     pub(super) early_stopping: Option<EarlyStoppingConfig>,
     pub(super) epoch_start: usize,
+    pub(super) seed: u64,
 }
 
 impl Trainer {
@@ -139,7 +141,8 @@ impl Trainer {
                 self.optimizer.as_mut(),
                 self.scheduler.as_mut(),
                 &self.clipping,
-                self.batch_size,
+                self.batch_size
+                    .map(|size| MiniBatch::new(size, self.seed, epoch)),
             );
 
             final_epoch = epoch;
@@ -288,6 +291,7 @@ mod tests {
             early_stopping,
             val_ratio,
             0.1,
+            0,
         )
         .unwrap()
     }
@@ -691,6 +695,7 @@ mod tests {
             None,
             0.1,
             0.1,
+            0,
         )
         .unwrap();
 
@@ -735,6 +740,7 @@ mod tests {
             None,
             0.1,
             0.1,
+            0,
         )
         .unwrap();
 
@@ -774,6 +780,7 @@ mod tests {
             None,
             0.1,
             0.1,
+            0,
         )
         .unwrap();
 

--- a/core/tests/convergence.rs
+++ b/core/tests/convergence.rs
@@ -35,10 +35,11 @@ fn xor_converges_to_low_loss() {
         None,
         0.0,
         0.5,
+        42,
     )
     .unwrap()
     .build(
-        NeuralNetwork::initialization(2, &specs),
+        NeuralNetwork::initialization(2, &specs, 42),
         xor_dataset(),
         Callbacks::new(vec![]),
     )
@@ -77,10 +78,11 @@ fn xor_converges_with_mini_batch() {
         None,
         0.0,
         0.5,
+        42,
     )
     .unwrap()
     .build(
-        NeuralNetwork::initialization(2, &specs),
+        NeuralNetwork::initialization(2, &specs, 42),
         xor_dataset(),
         Callbacks::new(vec![]),
     )
@@ -128,10 +130,11 @@ fn three_class_converges_to_low_loss() {
         None,
         0.0,
         0.5,
+        42,
     )
     .unwrap()
     .build(
-        NeuralNetwork::initialization(2, &specs),
+        NeuralNetwork::initialization(2, &specs, 42),
         three_class_dataset(),
         Callbacks::new(vec![]),
     )

--- a/core/tests/io_roundtrip.rs
+++ b/core/tests/io_roundtrip.rs
@@ -41,6 +41,7 @@ fn sample_hyperparams() -> HyperParametersRecord {
         val_ratio: 0.1,
         test_ratio: 0.1,
         loss: LossRecord::CrossEntropy,
+        seed: 0,
     }
 }
 
@@ -77,7 +78,7 @@ fn full_pipeline_roundtrips_through_safetensors() {
     // --- Model + training run (incremental writer → directory load) --
     let model_dataset = dataset.to_model_dataset();
     let specs = NeuronLayerSpec::network_for(vec![4], &*RELU, 2);
-    let mut model = NeuralNetwork::initialization(2, &specs);
+    let mut model = NeuralNetwork::initialization(2, &specs, 0);
 
     let loss_fn: Arc<dyn LossFunction> = CROSS_ENTROPY_LOSS.clone();
     let mut optimizer = Adam::with_defaults(0.05.try_into().unwrap());


### PR DESCRIPTION
## Summary

Training was non-deterministic: weight init (`Array2::random` → thread_rng) and the mini-batch shuffle (`rand::rng()`) were unseeded, so the same dataset could diverge on one run and converge on another — the source of the intermittent failures in `train_plot` and `convergence` tests.

This makes a run reproducible from a single seed:

- `NeuralNetwork::initialization(inputs, specs, seed)` is now the **only** constructor — the unseeded path is removed so the footgun can't return.
- Mini-batch SGD takes `Option<MiniBatch>`; `MiniBatch::new(size, seed, epoch)` derives the epoch's shuffle generator, so `Some` always carries both a size and its generator (`None` = full-batch).
- `seed: u64` is a first-class field of `HyperParameters` / `HyperParametersRecord`, recorded in the run metadata.
- CLI: `--seed` on `train start` (random, reported, if omitted), shown in the monitor recap.

## Notes

- The per-epoch shuffle generator depends only on `(seed, epoch)`, never on accumulated RNG state — so a resumed run reproduces the original batch order without persisting any RNG state.
- `HyperParametersRecord` gained `seed` without a serde default: pre-existing `meta.json` files won't deserialize (acceptable, no backward-compat guarantee).