### PR TITLE
feat(data): validated Dataset constructor, spiral generator & provenance

### DIFF
--- a/cli/src/commands/encode.rs
+++ b/cli/src/commands/encode.rs
@@ -1,12 +1,12 @@
-use crate::actions::save_dataset;
+use crate::actions::{get_file_stem, save_dataset};
 use crate::console::bar;
 use crate::console::{completed, trace};
 use clap::{Args, Subcommand};
 use console::style;
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::prelude::StdRng;
-use nrn::data::Dataset;
 use nrn::data::vectorizers::{ImageEncoder, VectorEncoder};
+use nrn::data::{Dataset, DatasetOrigin};
 use nrn::io::bytes::secure_read;
 use nrn::io::classes::extract_classes;
 use nrn::io::data::save_inputs;
@@ -123,7 +123,10 @@ impl ImgDirArgs {
         }
 
         let mut rng = StdRng::seed_from_u64(self.seed);
-        let dataset = Dataset::from_vec(&mut rng, data, labels)?;
+        let origin = DatasetOrigin::Encoded {
+            source: get_file_stem(&self.input),
+        };
+        let dataset = Dataset::from_vec(&mut rng, data, labels, Some(origin))?;
 
         completed(
             style("Encoding completed")

--- a/cli/src/commands/scale.rs
+++ b/cli/src/commands/scale.rs
@@ -38,7 +38,7 @@ impl ScaleArgs {
     pub fn run(self) -> Result<(), Box<dyn std::error::Error>> {
         let mut dataset = load_dataset(&self.dataset)?;
 
-        let scaler = self.scaling.fit(dataset.features.view());
+        let scaler = self.scaling.fit(dataset.features().view());
         dataset.scale_inplace(&scaler);
 
         completed(&format!(

--- a/cli/src/commands/synth.rs
+++ b/cli/src/commands/synth.rs
@@ -3,7 +3,6 @@ use crate::console::{generated, warning};
 use clap::{Args, ValueEnum};
 use nrn::data::synth::{Distribution, SynthDataset, SynthParams, SynthParamsError};
 use std::error::Error;
-use std::fmt;
 
 #[derive(Args, Debug)]
 pub struct SynthArgs {
@@ -50,6 +49,10 @@ pub struct SynthArgs {
     /// Indicates whether to visualize the generated dataset (requires exactly two features)
     #[arg(long, default_value_t = false)]
     plot: bool,
+
+    /// Name to save the dataset under (defaults to the dataset's identifier)
+    #[arg(short, long)]
+    output: Option<String>,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug)]
@@ -57,16 +60,6 @@ enum DistributionOption {
     Uniform,
     Ring,
     Spiral,
-}
-
-impl fmt::Display for DistributionOption {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DistributionOption::Uniform => write!(f, "uniform"),
-            DistributionOption::Ring => write!(f, "ring"),
-            DistributionOption::Spiral => write!(f, "spiral"),
-        }
-    }
 }
 
 impl From<&SynthArgs> for Distribution {
@@ -117,14 +110,7 @@ impl SynthArgs {
 
         generated(&dataset);
 
-        let filename = format!(
-            "{}-c{}-f{}-n{}-seed{}",
-            self.distribution,
-            self.clusters,
-            dataset.n_features(),
-            dataset.n_samples(),
-            self.seed
-        );
+        let filename = self.output.clone().unwrap_or_else(|| dataset.id());
 
         save_dataset(dataset, "DATASET", self.plot, &filename)?;
 

--- a/cli/src/commands/synth.rs
+++ b/cli/src/commands/synth.rs
@@ -117,3 +117,81 @@ impl SynthArgs {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// Minimal parser wrapper so the flattened [`SynthArgs`] can be exercised
+    /// through clap (defaults, value enums, and the conversion impls) in one path.
+    #[derive(Parser)]
+    struct Cli {
+        #[command(flatten)]
+        args: SynthArgs,
+    }
+
+    fn parse(extra: &[&str]) -> SynthArgs {
+        let mut argv = vec!["synth", "--seed", "7", "--distribution"];
+        argv.extend_from_slice(extra);
+        Cli::parse_from(argv).args
+    }
+
+    #[test]
+    fn uniform_maps_to_uniform_distribution() {
+        let args = parse(&["uniform"]);
+        assert_eq!(Distribution::from(&args), Distribution::Uniform);
+    }
+
+    #[test]
+    fn ring_carries_overlap_flag() {
+        let args = parse(&["ring", "--overlap", "0.25"]);
+        assert_eq!(
+            Distribution::from(&args),
+            Distribution::Ring { overlap: 0.25 }
+        );
+    }
+
+    #[test]
+    fn ring_overlap_defaults_when_omitted() {
+        let args = parse(&["ring"]);
+        assert_eq!(
+            Distribution::from(&args),
+            Distribution::Ring { overlap: -0.2 }
+        );
+    }
+
+    #[test]
+    fn spiral_carries_turns_and_noise() {
+        let args = parse(&["spiral", "--turns", "2.0", "--noise", "0.1"]);
+        assert_eq!(
+            Distribution::from(&args),
+            Distribution::Spiral {
+                turns: 2.0,
+                noise: 0.1
+            }
+        );
+    }
+
+    #[test]
+    fn synth_params_built_from_sizing_flags() {
+        let args = parse(&[
+            "uniform", "-n", "200", "-f", "3", "-c", "4", "--min=-1", "--max", "5",
+        ]);
+        let params = SynthParams::try_from(&args).expect("valid params");
+        assert_eq!(params, SynthParams::new(200, 3, 4, -1.0, 5.0).unwrap());
+    }
+
+    #[test]
+    fn synth_params_surface_validation_errors() {
+        // Fewer samples than clusters is rejected by the core validator.
+        let args = parse(&["uniform", "-n", "2", "-c", "5"]);
+        assert_eq!(
+            SynthParams::try_from(&args),
+            Err(SynthParamsError::NotEnoughSamples {
+                samples: 2,
+                clusters: 5,
+            })
+        );
+    }
+}

--- a/cli/src/commands/synth.rs
+++ b/cli/src/commands/synth.rs
@@ -1,10 +1,9 @@
 use crate::actions::save_dataset;
 use crate::console::{generated, warning};
 use clap::{Args, ValueEnum};
-use nrn::data::synth::{DatasetGenerator, RingDataset, UniformDataset};
+use nrn::data::synth::{Distribution, SynthDataset, SynthParams, SynthParamsError};
 use std::error::Error;
 use std::fmt;
-use std::sync::Arc;
 
 #[derive(Args, Debug)]
 pub struct SynthArgs {
@@ -36,15 +35,28 @@ pub struct SynthArgs {
     #[arg(long, default_value_t = 10.0)]
     max: f32,
 
+    /// Ring overlap fraction between consecutive rings (negative = a gap)
+    #[arg(long, default_value_t = -0.2)]
+    overlap: f32,
+
+    /// Number of turns each spiral arm makes
+    #[arg(long, default_value_t = 1.5)]
+    turns: f32,
+
+    /// Spiral jitter, as a fraction of the arm's max radius
+    #[arg(long, default_value_t = 0.03)]
+    noise: f32,
+
     /// Indicates whether to visualize the generated dataset (requires exactly two features)
     #[arg(long, default_value_t = false)]
     plot: bool,
 }
 
-#[derive(ValueEnum, Clone, Debug)]
+#[derive(ValueEnum, Clone, Copy, Debug)]
 enum DistributionOption {
     Uniform,
     Ring,
+    Spiral,
 }
 
 impl fmt::Display for DistributionOption {
@@ -52,51 +64,45 @@ impl fmt::Display for DistributionOption {
         match self {
             DistributionOption::Uniform => write!(f, "uniform"),
             DistributionOption::Ring => write!(f, "ring"),
+            DistributionOption::Spiral => write!(f, "spiral"),
         }
     }
 }
 
-impl SynthArgs {
-    /// Validate the command line arguments
-    fn validate(&self) -> Result<(), String> {
-        if self.features < 1 {
-            return Err("The number of features must be at least 1.".to_string());
+impl From<&SynthArgs> for Distribution {
+    /// Selects the core distribution, supplying each variant's shape knobs from
+    /// the relevant flags.
+    fn from(args: &SynthArgs) -> Self {
+        match args.distribution {
+            DistributionOption::Uniform => Distribution::Uniform,
+            DistributionOption::Ring => Distribution::Ring {
+                overlap: args.overlap,
+            },
+            DistributionOption::Spiral => Distribution::Spiral {
+                turns: args.turns,
+                noise: args.noise,
+            },
         }
-        if self.clusters < 1 {
-            return Err("The number of clusters must be at least 1.".to_string());
-        }
-        if self.samples < self.clusters {
-            return Err(
-                "The number of samples must be at least equal to the number of clusters."
-                    .to_string(),
-            );
-        }
-        if self.min >= self.max {
-            return Err("The minimum value must be less than the maximum value.".to_string());
-        }
-        Ok(())
     }
+}
 
+impl TryFrom<&SynthArgs> for SynthParams {
+    type Error = SynthParamsError;
+
+    fn try_from(args: &SynthArgs) -> Result<Self, Self::Error> {
+        SynthParams::new(
+            args.samples,
+            args.features,
+            args.clusters,
+            args.min,
+            args.max,
+        )
+    }
+}
+
+impl SynthArgs {
     pub fn run(&self) -> Result<(), Box<dyn Error>> {
-        self.validate()?;
-
-        // 🗂️ GENERATE THE DATASET
-        let generator: Arc<dyn DatasetGenerator> = match self.distribution {
-            DistributionOption::Uniform => Arc::new(UniformDataset {
-                n_samples: self.samples,
-                n_features: self.features,
-                n_clusters: self.clusters,
-                feature_min: self.min,
-                feature_max: self.max,
-            }),
-            DistributionOption::Ring => Arc::new(RingDataset {
-                n_samples: self.samples,
-                n_features: self.features,
-                n_clusters: self.clusters,
-                feature_min: self.min,
-                feature_max: self.max,
-            }),
-        };
+        let generator = SynthDataset::new(SynthParams::try_from(self)?, Distribution::from(self))?;
 
         let dataset = generator.generate(self.seed);
 

--- a/cli/src/commands/train/args.rs
+++ b/cli/src/commands/train/args.rs
@@ -312,3 +312,323 @@ impl ResumeOverrides {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    // ─── TrainArgs conversions ─────────────────────────────────────────────────
+
+    /// Parser wrapper exercising the flattened [`TrainArgs`] through clap so
+    /// defaults and the conversion impls are covered in one path.
+    #[derive(Parser)]
+    struct TrainCli {
+        #[command(flatten)]
+        args: TrainArgs,
+    }
+
+    fn train_args(extra: &[&str]) -> TrainArgs {
+        let mut argv = vec!["train", "--epochs", "100"];
+        argv.extend_from_slice(extra);
+        TrainCli::parse_from(argv).args
+    }
+
+    #[test]
+    fn optimizer_defaults_to_adam() {
+        assert_eq!(
+            OptimizerConfig::from(train_args(&[]).optimizer),
+            OptimizerConfig::Adam
+        );
+    }
+
+    #[test]
+    fn optimizer_sgd_selected() {
+        assert_eq!(
+            OptimizerConfig::from(train_args(&["--optimizer", "sgd"]).optimizer),
+            OptimizerConfig::Sgd
+        );
+    }
+
+    #[test]
+    fn scheduler_defaults_to_constant() {
+        assert_eq!(
+            SchedulerConfig::from(&train_args(&[])),
+            SchedulerConfig::Constant
+        );
+    }
+
+    #[test]
+    fn cosine_steps_default_to_total_epochs() {
+        assert_eq!(
+            SchedulerConfig::from(&train_args(&["--scheduler", "cosine"])),
+            SchedulerConfig::Cosine {
+                lr_min: 0.0,
+                steps: 100,
+                warm_restarts: false,
+                cycle_multiplier: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn cosine_carries_warm_restart_knobs() {
+        let args = train_args(&[
+            "--scheduler",
+            "cosine",
+            "--lr-min",
+            "0.0001",
+            "--steps",
+            "20",
+            "--warm-restarts",
+            "--cycle-multiplier",
+            "2",
+        ]);
+        assert_eq!(
+            SchedulerConfig::from(&args),
+            SchedulerConfig::Cosine {
+                lr_min: 0.0001,
+                steps: 20,
+                warm_restarts: true,
+                cycle_multiplier: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn step_scheduler_carries_decay_factor() {
+        let args = train_args(&[
+            "--scheduler",
+            "step",
+            "--decay-factor",
+            "0.5",
+            "--steps",
+            "30",
+        ]);
+        assert_eq!(
+            SchedulerConfig::from(&args),
+            SchedulerConfig::Step {
+                decay_factor: 0.5,
+                steps: 30,
+            }
+        );
+    }
+
+    #[test]
+    fn clipping_defaults_to_norm() {
+        assert_eq!(
+            GradientClipping::try_from(&train_args(&[])).unwrap(),
+            GradientClipping::Norm { max_norm: 1.0 }
+        );
+    }
+
+    #[test]
+    fn clip_value_is_symmetric() {
+        assert_eq!(
+            GradientClipping::try_from(&train_args(&["--clip-value", "0.5"])).unwrap(),
+            GradientClipping::Value {
+                min: -0.5,
+                max: 0.5
+            }
+        );
+    }
+
+    #[test]
+    fn no_clip_disables_clipping() {
+        assert_eq!(
+            GradientClipping::try_from(&train_args(&["--no-clip"])).unwrap(),
+            GradientClipping::None
+        );
+    }
+
+    #[test]
+    fn invalid_clip_norm_surfaces_error() {
+        assert!(GradientClipping::try_from(&train_args(&["--clip-norm", "0"])).is_err());
+    }
+
+    #[test]
+    fn early_stopping_disabled_when_zero() {
+        assert_eq!(train_args(&[]).early_stopping().unwrap(), None);
+    }
+
+    #[test]
+    fn early_stopping_enabled_with_patience() {
+        let config = train_args(&["--early-stopping", "5"])
+            .early_stopping()
+            .unwrap()
+            .expect("early stopping enabled");
+        assert_eq!(config.patience(), 5);
+        assert!(config.restore_best_model());
+    }
+
+    #[test]
+    fn hyperparameters_assembled_from_args() {
+        let args = train_args(&["--lr", "0.01", "--batch-size", "32", "--seed", "42"]);
+        let hp = HyperParameters::try_from(&args).expect("valid hyperparameters");
+        assert_eq!(hp.epochs(), 100);
+        assert_eq!(hp.lr().value(), 0.01);
+        assert_eq!(hp.batch_size(), Some(32));
+        assert_eq!(hp.seed(), 42);
+        assert_eq!(hp.optimizer(), &OptimizerConfig::Adam);
+    }
+
+    #[test]
+    fn hyperparameters_surface_validation_errors() {
+        // Validation/test ratios summing past 1.0 is a cross-field invariant violation.
+        let args = train_args(&["--val-ratio", "0.8", "--test-ratio", "0.8"]);
+        assert!(HyperParameters::try_from(&args).is_err());
+    }
+
+    // ─── ResumeOverrides ───────────────────────────────────────────────────────
+
+    #[derive(Parser)]
+    struct ResumeCli {
+        #[command(flatten)]
+        overrides: ResumeOverrides,
+    }
+
+    fn overrides(extra: &[&str]) -> ResumeOverrides {
+        let mut argv = vec!["resume"];
+        argv.extend_from_slice(extra);
+        ResumeCli::parse_from(argv).overrides
+    }
+
+    fn base_record() -> HyperParametersRecord {
+        HyperParametersRecord {
+            epochs: 100,
+            checkpoint_interval: 10,
+            batch_size: Some(32),
+            lr: 0.001,
+            optimizer: nrn::io::hyperparams::OptimizerRecord::Adam,
+            scheduler: SchedulerRecord::Constant,
+            clipping: ClippingRecord::Norm { max_norm: 1.0 },
+            early_stopping: None,
+            val_ratio: 0.1,
+            test_ratio: 0.1,
+            loss: nrn::io::hyperparams::LossRecord::CrossEntropy,
+            seed: 42,
+        }
+    }
+
+    #[test]
+    fn empty_overrides_leave_record_unchanged() {
+        let mut record = base_record();
+        overrides(&[]).apply(&mut record);
+        assert_eq!(record, base_record());
+    }
+
+    #[test]
+    fn scalar_overrides_applied() {
+        let mut record = base_record();
+        overrides(&[
+            "--epochs",
+            "200",
+            "--checkpoint-interval",
+            "5",
+            "--lr",
+            "0.01",
+        ])
+        .apply(&mut record);
+        assert_eq!(record.epochs, 200);
+        assert_eq!(record.checkpoint_interval, 5);
+        assert_eq!(record.lr, 0.01);
+    }
+
+    #[test]
+    fn lr_min_override_only_affects_cosine() {
+        // Constant scheduler: lr_min has nowhere to land, record stays put.
+        let mut constant = base_record();
+        overrides(&["--lr-min", "0.0001"]).apply(&mut constant);
+        assert_eq!(constant.scheduler, SchedulerRecord::Constant);
+
+        // Cosine scheduler: lr_min is patched in place.
+        let mut cosine = base_record();
+        cosine.scheduler = SchedulerRecord::Cosine {
+            lr_min: 0.0,
+            steps: 100,
+            warm_restarts: false,
+            cycle_multiplier: 1,
+        };
+        overrides(&["--lr-min", "0.0001"]).apply(&mut cosine);
+        assert_eq!(
+            cosine.scheduler,
+            SchedulerRecord::Cosine {
+                lr_min: 0.0001,
+                steps: 100,
+                warm_restarts: false,
+                cycle_multiplier: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn clipping_overrides_applied() {
+        let mut value = base_record();
+        overrides(&["--clip-value", "0.5"]).apply(&mut value);
+        assert_eq!(
+            value.clipping,
+            ClippingRecord::Value {
+                min: -0.5,
+                max: 0.5
+            }
+        );
+
+        let mut none = base_record();
+        overrides(&["--no-clip"]).apply(&mut none);
+        assert_eq!(none.clipping, ClippingRecord::None);
+
+        let mut norm = base_record();
+        overrides(&["--clip-norm", "2.0"]).apply(&mut norm);
+        assert_eq!(norm.clipping, ClippingRecord::Norm { max_norm: 2.0 });
+    }
+
+    #[test]
+    fn early_stopping_can_be_enabled_and_disabled() {
+        let mut enabled = base_record();
+        overrides(&["--early-stopping", "5"]).apply(&mut enabled);
+        assert_eq!(
+            enabled.early_stopping,
+            Some(EarlyStoppingRecord {
+                patience: 5,
+                restore_best_model: true,
+            })
+        );
+
+        // Patience 0 clears an existing config.
+        let mut disabled = base_record();
+        disabled.early_stopping = Some(EarlyStoppingRecord {
+            patience: 5,
+            restore_best_model: true,
+        });
+        overrides(&["--early-stopping", "0"]).apply(&mut disabled);
+        assert_eq!(disabled.early_stopping, None);
+    }
+
+    #[test]
+    fn restore_best_model_override_reuses_existing_patience() {
+        let mut record = base_record();
+        record.early_stopping = Some(EarlyStoppingRecord {
+            patience: 7,
+            restore_best_model: true,
+        });
+        overrides(&["--restore-best-model", "false"]).apply(&mut record);
+        assert_eq!(
+            record.early_stopping,
+            Some(EarlyStoppingRecord {
+                patience: 7,
+                restore_best_model: false,
+            })
+        );
+    }
+
+    #[test]
+    fn batch_size_and_full_batch_overrides() {
+        let mut sized = base_record();
+        overrides(&["--batch-size", "64"]).apply(&mut sized);
+        assert_eq!(sized.batch_size, Some(64));
+
+        let mut full = base_record();
+        overrides(&["--full-batch"]).apply(&mut full);
+        assert_eq!(full.batch_size, None);
+    }
+}

--- a/cli/src/commands/train/mod.rs
+++ b/cli/src/commands/train/mod.rs
@@ -77,7 +77,6 @@ impl StartArgs {
         let dataset_name = get_file_stem(Path::new(&self.dataset));
         let dataset_path = Path::new(&self.dataset);
         let dataset = load_dataset(&self.dataset)?;
-        dataset.validate()?;
 
         let hyperparameters = HyperParameters::try_from(&self.hp)?;
 
@@ -138,7 +137,6 @@ impl ResumeArgs {
         let meta = run.meta();
 
         let dataset = load_dataset(&meta.dataset)?;
-        dataset.validate()?;
 
         let previous = HyperParameters::try_from(meta.hyperparams.clone())?;
 

--- a/cli/src/console.rs
+++ b/cli/src/console.rs
@@ -1,7 +1,7 @@
 use console::{Emoji, style};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use nrn::data::Dataset;
 use nrn::data::scalers::{Scaler, ScalerMethod};
+use nrn::data::{Dataset, DatasetOrigin};
 use nrn::io::checkpoint::CheckpointArchive;
 use nrn::model::NeuralNetwork;
 use pathdiff::diff_paths;
@@ -29,13 +29,24 @@ pub(crate) trait Summary {
 
 impl Summary for Dataset {
     fn summary(&self) -> String {
-        format!(
+        let base = format!(
             "{} | Features: {} | Classes: {} | Samples: {}",
             style("DATASET").bold().blue(),
             style(self.n_features()).yellow(),
             style(self.n_classes()).yellow(),
             style(self.n_samples()).yellow()
-        )
+        );
+        match self.origin() {
+            Some(DatasetOrigin::Synthetic { distribution, seed }) => format!(
+                "{base} | Origin: synthetic {} (seed {})",
+                style(distribution).yellow(),
+                style(seed).yellow()
+            ),
+            Some(DatasetOrigin::Encoded { source }) => {
+                format!("{base} | Origin: encoded from {}", style(source).yellow())
+            }
+            None => base,
+        }
     }
 }
 

--- a/cli/tests/train_lifecycle.rs
+++ b/cli/tests/train_lifecycle.rs
@@ -1,0 +1,288 @@
+//! End-to-end coverage of the `train` command's lifecycle and error paths:
+//! architecture validation, continuing from a saved model, the resume
+//! checkpoint-selection / trim logic, run-directory overwrite handling, and a
+//! fatal (unrecovered) divergence. The happy paths and plotting live in
+//! `train_plot.rs`.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::Path;
+
+/// Runs `nrn` with the given args from `dir`.
+fn nrn(dir: &Path, args: &[&str]) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("nrn")
+        .unwrap()
+        .current_dir(dir)
+        .args(args)
+        .assert()
+}
+
+/// Generates a small 2-class ring dataset in `dir` and returns its filename.
+fn synth_ring(dir: &Path, seed: &str, samples: &str) -> String {
+    nrn(
+        dir,
+        &[
+            "synth",
+            "--seed",
+            seed,
+            "--distribution",
+            "ring",
+            "--clusters",
+            "2",
+            "--samples",
+            samples,
+        ],
+    )
+    .success();
+    format!("ring-seed{seed}-c2-f2-n{samples}")
+}
+
+fn checkpoint_count(run_dir: &Path) -> usize {
+    fs::read_dir(run_dir)
+        .map(|rd| {
+            rd.filter_map(Result::ok)
+                .filter(|e| {
+                    e.file_name()
+                        .to_str()
+                        .map(|n| n.starts_with("checkpoint-"))
+                        .unwrap_or(false)
+                        && e.path().is_dir()
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+#[test]
+fn rejects_zero_neuron_hidden_layer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let ds = synth_ring(dir, "1", "20");
+
+    nrn(
+        dir,
+        &["train", "start", &ds, "--epochs", "2", "--layers", "4,0"],
+    )
+    .failure()
+    .stderr(contains("at least one neuron"));
+}
+
+#[test]
+fn continues_from_saved_model_without_checkpoints() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let ds = synth_ring(dir, "5", "20");
+
+    // First run saves model-<ds>.safetensors.
+    nrn(
+        dir,
+        &[
+            "train",
+            "start",
+            "--seed",
+            "42",
+            &ds,
+            "--epochs",
+            "2",
+            "--checkpoint-interval",
+            "1",
+            "--no-clip",
+        ],
+    )
+    .success();
+    assert!(dir.join(format!("model-{ds}.safetensors")).exists());
+
+    // Continue from that model with checkpoints disabled (interval 0 → no recorder).
+    nrn(
+        dir,
+        &[
+            "train",
+            "start",
+            &ds,
+            "--model",
+            &format!("model-{ds}"),
+            "--epochs",
+            "2",
+            "--checkpoint-interval",
+            "0",
+            "--no-clip",
+        ],
+    )
+    .success();
+}
+
+#[test]
+fn overwrite_required_to_replace_existing_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let ds = synth_ring(dir, "6", "20");
+
+    let start = |extra: &[&str]| {
+        let mut args = vec![
+            "train",
+            "start",
+            "--seed",
+            "42",
+            &ds,
+            "--epochs",
+            "2",
+            "--checkpoint-interval",
+            "1",
+            "--no-clip",
+        ];
+        args.extend_from_slice(extra);
+        nrn(dir, &args)
+    };
+
+    start(&[]).success();
+    // Second start onto the same run dir must be refused with a remediation hint.
+    start(&[]).failure().stderr(contains("use --overwrite"));
+    // ...and accepted once --overwrite is given.
+    start(&["--overwrite"]).success();
+}
+
+#[test]
+fn resume_from_index_trims_later_checkpoints() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let ds = synth_ring(dir, "7", "20");
+    let run_arg = format!("training-model-{ds}");
+    let run_dir = dir.join(&run_arg);
+
+    // interval=1, 4 epochs → initial + 4 = 5 checkpoints.
+    nrn(
+        dir,
+        &[
+            "train",
+            "start",
+            "--seed",
+            "42",
+            &ds,
+            "--epochs",
+            "4",
+            "--checkpoint-interval",
+            "1",
+            "--no-clip",
+        ],
+    )
+    .success();
+    assert_eq!(checkpoint_count(&run_dir), 5);
+
+    // Resuming from the first checkpoint rewinds the trajectory: the later
+    // checkpoints are trimmed before training forward again.
+    nrn(
+        dir,
+        &["train", "resume", &run_arg, "--from", "0", "--epochs", "3"],
+    )
+    .success()
+    .stderr(contains("Removed"));
+}
+
+#[test]
+fn resume_with_no_checkpoints_fails() {
+    // A run directory whose meta.json survives but whose checkpoints were all
+    // removed (corrupted / manually cleaned run) cannot be resumed.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let ds = synth_ring(dir, "9", "20");
+    let run_arg = format!("training-model-{ds}");
+    let run_dir = dir.join(&run_arg);
+
+    nrn(
+        dir,
+        &[
+            "train",
+            "start",
+            "--seed",
+            "42",
+            &ds,
+            "--epochs",
+            "2",
+            "--checkpoint-interval",
+            "1",
+            "--no-clip",
+        ],
+    )
+    .success();
+
+    // Wipe every checkpoint directory, leaving meta.json behind.
+    for entry in fs::read_dir(&run_dir).unwrap().filter_map(Result::ok) {
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|n| n.starts_with("checkpoint-"))
+        {
+            fs::remove_dir_all(entry.path()).unwrap();
+        }
+    }
+
+    nrn(dir, &["train", "resume", &run_arg, "--epochs", "3"])
+        .failure()
+        .stderr(contains("No checkpoints found"));
+}
+
+#[test]
+fn resume_from_out_of_range_index_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let ds = synth_ring(dir, "8", "20");
+    let run_arg = format!("training-model-{ds}");
+
+    nrn(
+        dir,
+        &[
+            "train",
+            "start",
+            "--seed",
+            "42",
+            &ds,
+            "--epochs",
+            "2",
+            "--checkpoint-interval",
+            "1",
+            "--no-clip",
+        ],
+    )
+    .success();
+
+    nrn(
+        dir,
+        &[
+            "train", "resume", &run_arg, "--from", "999", "--epochs", "3",
+        ],
+    )
+    .failure()
+    .stderr(contains("out of range"));
+}
+
+#[test]
+fn fatal_divergence_without_early_stopping_errors() {
+    // lr=5.0 + no-clip diverges within a few epochs. Without early stopping there
+    // is no best model to recover, so the run must fail with the divergence error.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let ds = synth_ring(dir, "42", "40");
+
+    nrn(
+        dir,
+        &[
+            "train",
+            "start",
+            "--seed",
+            "42",
+            &ds,
+            "--epochs",
+            "50",
+            "--checkpoint-interval",
+            "1000",
+            "--no-clip",
+            "--lr",
+            "5.0",
+            "--layers",
+            "4,4",
+        ],
+    )
+    .failure()
+    .stderr(contains("Model diverged at epoch"));
+}

--- a/cli/tests/train_plot.rs
+++ b/cli/tests/train_plot.rs
@@ -50,8 +50,8 @@ fn train_creates_run_dir_and_plot_generates_png_and_gif() {
     )
     .success();
 
-    // Dataset filename produced by synth: ring-c2-f2-n20-seed42
-    let ds_name = "ring-c2-f2-n20-seed42";
+    // Dataset filename produced by synth: ring-seed42-c2-f2-n20
+    let ds_name = "ring-seed42-c2-f2-n20";
 
     // Train with checkpoints every 5 epochs (20 epochs total → ≥ 5 checkpoints).
     nrn(
@@ -116,7 +116,7 @@ fn load_history_rejects_too_few_checkpoints() {
     )
     .success();
 
-    let ds_name = "ring-c2-f2-n20-seed7";
+    let ds_name = "ring-seed7-c2-f2-n20";
 
     nrn(
         dir,
@@ -162,7 +162,7 @@ fn early_stopping_writes_final_checkpoint() {
     )
     .success();
 
-    let ds_name = "ring-c2-f2-n40-seed99";
+    let ds_name = "ring-seed99-c2-f2-n40";
 
     // interval=1000 >> epochs=30: only initial + final-epoch checkpoint would be
     // written without early stopping. With patience=1 this fires quickly and
@@ -229,7 +229,7 @@ fn no_duplicate_checkpoint_when_early_stop_fires_on_interval_boundary() {
     )
     .success();
 
-    let ds_name = "ring-c2-f2-n100-seed42";
+    let ds_name = "ring-seed42-c2-f2-n100";
 
     let out = Command::cargo_bin("nrn")
         .unwrap()
@@ -302,7 +302,7 @@ fn start_prints_recap_without_overrides() {
     )
     .success();
 
-    let ds_name = "ring-c2-f2-n20-seed1";
+    let ds_name = "ring-seed1-c2-f2-n20";
 
     let out = Command::cargo_bin("nrn")
         .unwrap()
@@ -355,7 +355,7 @@ fn resume_with_lr_override_shows_marker_on_optimizer_line() {
     )
     .success();
 
-    let ds_name = "ring-c2-f2-n20-seed2";
+    let ds_name = "ring-seed2-c2-f2-n20";
 
     nrn(
         dir,
@@ -418,7 +418,7 @@ fn resume_restores_adam_optimizer_state() {
     )
     .success();
 
-    let ds_name = "ring-c2-f2-n20-seed2";
+    let ds_name = "ring-seed2-c2-f2-n20";
 
     nrn(
         dir,
@@ -467,7 +467,7 @@ fn resume_rejects_val_ratio_override() {
     )
     .success();
 
-    let ds_name = "ring-c2-f2-n20-seed3";
+    let ds_name = "ring-seed3-c2-f2-n20";
 
     nrn(
         dir,
@@ -517,7 +517,7 @@ fn divergence_with_early_stopping_recovers_best_model() {
     )
     .success();
 
-    let ds_name = "ring-c2-f2-n40-seed42";
+    let ds_name = "ring-seed42-c2-f2-n40";
     let out = Command::cargo_bin("nrn")
         .unwrap()
         .current_dir(dir)

--- a/cli/tests/train_plot.rs
+++ b/cli/tests/train_plot.rs
@@ -1,3 +1,10 @@
+//! End-to-end coverage of the `train`/`plot` happy paths: a full run produces a
+//! run directory and checkpoints, `plot` renders the training curves (PNG) and
+//! the decision-boundary animation (GIF), and the recap reflects resume
+//! overrides. Also exercises the checkpoint-count guards, early-stopping
+//! checkpoint flushing, and optimizer-state restoration on resume. The
+//! lifecycle and error paths live in `train_lifecycle.rs`.
+
 use assert_cmd::Command;
 use predicates::str::contains;
 use std::fs;

--- a/core/src/charts/dataset.rs
+++ b/core/src/charts/dataset.rs
@@ -42,10 +42,10 @@ fn draw_data_with(
         "Scatter plot can only be generated for datasets with exactly two features"
     );
 
-    let (mins, maxs) = dataset
-        .feature_range()
-        .and_then(|(mins, maxs)| add_padding(&mins, &maxs, cfg.padding_factor).into())
-        .ok_or("Dataset is empty, cannot determine feature range")?;
+    let (mins, maxs) = {
+        let (mins, maxs) = dataset.feature_range();
+        add_padding(&mins, &maxs, cfg.padding_factor)
+    };
 
     draw_with(cfg, |root| {
         draw_chart(

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -292,12 +292,7 @@ impl Dataset {
         indices.shuffle(rng);
 
         self.features = self.features.select(Axis(0), &indices);
-        self.labels = Array1::from(
-            indices
-                .iter()
-                .map(|&i| self.labels[i])
-                .collect::<Vec<f32>>(),
-        );
+        self.labels = self.labels.select(Axis(0), &indices);
         self
     }
 

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -196,17 +196,14 @@ impl Dataset {
     }
 
     /// Computes the minimum and maximum values for each feature in the dataset.
+    ///
+    /// A [`Dataset`] always has at least one sample (enforced by [`Dataset::new`]),
+    /// so the range is always defined.
     /// # Returns
-    /// An `Option` containing a tuple of two vectors:
+    /// A tuple of two vectors:
     /// - The first vector contains the minimum values for each feature.
     /// - The second vector contains the maximum values for each feature.
-    ///   If the dataset has no samples, returns `None`.
-    ///
-    pub fn feature_range(&self) -> Option<(Vec<f32>, Vec<f32>)> {
-        if self.features.nrows() == 0 {
-            return None;
-        }
-
+    pub fn feature_range(&self) -> (Vec<f32>, Vec<f32>) {
         let n_features = self.n_features();
 
         let mut mins = vec![f32::INFINITY; n_features];
@@ -219,7 +216,7 @@ impl Dataset {
             }
         }
 
-        Some((mins, maxs))
+        (mins, maxs)
     }
 
     /// Applies the specified scaling method to the training and test datasets.
@@ -554,6 +551,23 @@ mod tests {
     }
 
     #[test]
+    fn from_vec_propagates_dataset_validation_error() {
+        // The images form a valid rectangular matrix, but `from_vec` does not
+        // check that there are as many labels as images — it delegates to
+        // `Dataset::new`, which rejects the count mismatch.
+        let mut rng = StdRng::seed_from_u64(0);
+        let images = vec![array![0.0f32, 1.0], array![2.0, 3.0]];
+        let labels = vec![0usize]; // one label for two images
+        let err = Dataset::from_vec(&mut rng, images, labels, None)
+            .err()
+            .unwrap();
+        assert!(
+            err.to_string().contains("disagree on sample count"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
     fn unique_labels_deduplicates_values() {
         let dataset =
             Dataset::new(Array2::zeros((4, 1)), array![0.0f32, 1.0, 1.0, 2.0], None).unwrap();
@@ -584,7 +598,7 @@ mod tests {
             None,
         )
         .unwrap();
-        let (mins, maxs) = dataset.feature_range().unwrap();
+        let (mins, maxs) = dataset.feature_range();
         assert_eq!(mins, vec![-2.0, 5.0]);
         assert_eq!(maxs, vec![3.0, 10.0]);
     }

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -143,6 +143,24 @@ impl Dataset {
         self.origin.as_ref()
     }
 
+    /// A deterministic identifier for this dataset, pairing its origin with its
+    /// shape (classes, features, samples). Two datasets reproduced from the same
+    /// origin share it; datasets with no recorded origin fall back to a neutral
+    /// prefix.
+    pub fn id(&self) -> String {
+        let origin = self
+            .origin
+            .as_ref()
+            .map(DatasetOrigin::label)
+            .unwrap_or_else(|| "dataset".to_string());
+        format!(
+            "{origin}-c{}-f{}-n{}",
+            self.n_classes(),
+            self.n_features(),
+            self.n_samples()
+        )
+    }
+
     /// Returns the features, with one row per sample and one column per feature.
     pub fn features(&self) -> &Array2<f32> {
         &self.features
@@ -472,6 +490,26 @@ mod tests {
         let features = Array2::zeros((4, 2));
         let labels = array![0.0f32, 1.0, 0.0, 1.0];
         assert!(Dataset::new(features, labels, None).is_ok());
+    }
+
+    #[test]
+    fn id_pairs_origin_label_with_shape() {
+        let features = Array2::zeros((4, 2));
+        let labels = array![0.0f32, 1.0, 0.0, 1.0];
+        let origin = DatasetOrigin::Synthetic {
+            distribution: "spiral".to_string(),
+            seed: 42,
+        };
+        let dataset = Dataset::new(features, labels, Some(origin)).unwrap();
+        assert_eq!(dataset.id(), "spiral-seed42-c2-f2-n4");
+    }
+
+    #[test]
+    fn id_falls_back_to_a_neutral_prefix_without_origin() {
+        let features = Array2::zeros((4, 2));
+        let labels = array![0.0f32, 1.0, 0.0, 1.0];
+        let dataset = Dataset::new(features, labels, None).unwrap();
+        assert_eq!(dataset.id(), "dataset-c2-f2-n4");
     }
 
     #[test]

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -1,3 +1,4 @@
+use crate::data::origin::DatasetOrigin;
 use crate::data::scalers::Scaler;
 use ndarray::{Array1, Array2, Axis, s};
 use ndarray_rand::rand::Rng;
@@ -5,13 +6,22 @@ use ndarray_rand::rand::prelude::SliceRandom;
 use std::collections::HashSet;
 use std::error::Error;
 
-/// A dataset containing features and labels for clustering tasks.
+/// A dataset containing features and labels for classification tasks.
+///
+/// Construction goes exclusively through [`Dataset::new`], the single boundary
+/// where structural and label invariants are enforced. The fields are private so
+/// an invalid `Dataset` cannot be represented: every value of this type is
+/// guaranteed non-empty, shape-consistent, and labelled with contiguous
+/// 0-indexed class ids over at least two classes.
 #[derive(Clone)]
 pub struct Dataset {
     /// A 2D array where each row is a sample and each column is a feature
-    pub features: Array2<f32>,
+    features: Array2<f32>,
     /// A 1D array where each element is the label for the corresponding sample
-    pub labels: Array1<f32>,
+    labels: Array1<f32>,
+    /// Where the dataset came from, when known. Optional provenance that travels
+    /// with the data but plays no part in its validity.
+    origin: Option<DatasetOrigin>,
 }
 
 pub struct ModelDataset {
@@ -31,15 +41,19 @@ pub struct ModelSplit {
     pub test: ModelDataset,
 }
 
-/// Errors returned when a [`Dataset`] is not suitable for training a classifier.
+/// Errors returned when features and labels cannot form a valid [`Dataset`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum DatasetError {
     /// The dataset has no features.
     NoFeatures,
     /// The dataset has no samples.
     NoSamples,
+    /// Features and labels disagree on the sample count.
+    ShapeMismatch { features: usize, labels: usize },
     /// Fewer than two distinct classes are present (carries the count found).
     TooFewClasses(usize),
+    /// Labels are not contiguous 0-indexed class ids in `[0, n_classes)`.
+    InvalidLabels,
 }
 
 impl std::fmt::Display for DatasetError {
@@ -47,9 +61,17 @@ impl std::fmt::Display for DatasetError {
         match self {
             DatasetError::NoFeatures => write!(f, "dataset has no features"),
             DatasetError::NoSamples => write!(f, "dataset has no samples"),
+            DatasetError::ShapeMismatch { features, labels } => write!(
+                f,
+                "features and labels disagree on sample count: {features} rows vs {labels} labels"
+            ),
             DatasetError::TooFewClasses(n) => {
                 write!(f, "a classifier needs at least 2 classes, but found {n}")
             }
+            DatasetError::InvalidLabels => write!(
+                f,
+                "labels must be contiguous 0-indexed class ids in [0, n_classes)"
+            ),
         }
     }
 }
@@ -57,34 +79,78 @@ impl std::fmt::Display for DatasetError {
 impl Error for DatasetError {}
 
 impl Dataset {
-    /// Checks if the dataset is empty (i.e., has no features or labels).
-    pub fn is_empty(&self) -> bool {
-        self.features.is_empty() || self.labels.is_empty()
-    }
-
-    /// Validates that the dataset can be used to train a classifier.
+    /// Builds a validated dataset from raw `features` (rows = samples, columns =
+    /// features) and `labels`.
     ///
-    /// This is the single boundary where dataset-level invariants are checked, so the
-    /// downstream layer-spec constructors ([`crate::model::NeuronLayerSpec::output_for`],
-    /// [`crate::model::NeuronLayerSpec::infer_from`]) can assume valid input and stay
-    /// infallible. Call it once, right after loading a dataset, before building a model.
+    /// This is the single boundary where dataset invariants are enforced, so every
+    /// downstream consumer — the layer-spec constructors
+    /// ([`crate::model::NeuronLayerSpec::output_for`],
+    /// [`crate::model::NeuronLayerSpec::infer_from`]) and [`Self::to_model_dataset`] —
+    /// can assume valid input and stay infallible.
     ///
     /// # Errors
+    /// - [`DatasetError::ShapeMismatch`] when the feature rows and labels disagree
+    ///   on the sample count.
     /// - [`DatasetError::NoFeatures`] when the dataset has zero features.
     /// - [`DatasetError::NoSamples`] when the dataset has zero samples.
     /// - [`DatasetError::TooFewClasses`] when fewer than two classes are present.
-    pub fn validate(&self) -> Result<(), DatasetError> {
-        if self.n_features() == 0 {
+    /// - [`DatasetError::InvalidLabels`] when labels are not contiguous 0-indexed
+    ///   class ids in `[0, n_classes)` (this also rejects non-integer labels).
+    pub fn new(
+        features: Array2<f32>,
+        labels: Array1<f32>,
+        origin: Option<DatasetOrigin>,
+    ) -> Result<Self, DatasetError> {
+        if features.nrows() != labels.len() {
+            return Err(DatasetError::ShapeMismatch {
+                features: features.nrows(),
+                labels: labels.len(),
+            });
+        }
+        if features.ncols() == 0 {
             return Err(DatasetError::NoFeatures);
         }
-        if self.n_samples() == 0 {
+        if labels.is_empty() {
             return Err(DatasetError::NoSamples);
         }
-        let n_classes = self.n_classes();
+
+        let dataset = Self {
+            features,
+            labels,
+            origin,
+        };
+
+        let n_classes = dataset.n_classes();
         if n_classes < 2 {
             return Err(DatasetError::TooFewClasses(n_classes));
         }
-        Ok(())
+        // Contiguous 0-indexed ids: with exactly `n_classes` distinct values, every
+        // label lying in `[0, n_classes)` (and integral) forces the set to be
+        // {0, 1, …, n_classes-1}. This subsumes the binary {0, 1} requirement.
+        let valid_labels = dataset
+            .labels
+            .iter()
+            .all(|&l| l >= 0.0 && l.fract() == 0.0 && (l as usize) < n_classes);
+        if !valid_labels {
+            return Err(DatasetError::InvalidLabels);
+        }
+
+        Ok(dataset)
+    }
+
+    /// Returns the dataset's recorded origin, if any.
+    pub fn origin(&self) -> Option<&DatasetOrigin> {
+        self.origin.as_ref()
+    }
+
+    /// Returns the features, with one row per sample and one column per feature.
+    pub fn features(&self) -> &Array2<f32> {
+        &self.features
+    }
+
+    /// Returns the per-sample labels.
+    pub fn labels(&self) -> &Array1<f32> {
+        &self.labels
     }
 
     /// Returns the number of samples in the dataset.
@@ -179,70 +245,45 @@ impl Dataset {
 
         let n_classes = self.n_classes();
 
+        // Label validity (contiguous 0-indexed ids, binary ⊆ {0, 1}) is guaranteed
+        // by [`Self::new`], so no re-check is needed here.
         let targets: Array2<f32> = if n_classes > 2 {
-            // Labels must be 0-indexed integers in [0, n_classes)
-            assert!(
-                self.labels
-                    .iter()
-                    .all(|&l| l >= 0.0 && (l as usize) < n_classes),
-                "Labels must be 0-indexed integers in [0, n_classes). Found a label outside this range."
-            );
             let mut one_hot = Array2::zeros((n_classes, self.n_samples()));
             for (i, &label) in self.labels.iter().enumerate() {
                 one_hot[[label as usize, i]] = 1.0;
             }
             one_hot
         } else {
-            // Binary labels are used directly; they must be exactly 0.0 or 1.0.
-            assert!(
-                self.labels.iter().all(|&l| l == 0.0 || l == 1.0),
-                "Binary labels must be 0.0 or 1.0. Found a label outside this range."
-            );
+            // Binary labels (0.0 / 1.0) are used directly as a single target row.
             self.labels.to_owned().insert_axis(Axis(0))
         };
 
         ModelDataset { inputs, targets }
     }
 
-    /// Shuffles the dataset features and labels in unison using a random number generator.
-    /// See [`shuffle_inplace`](Self::shuffle_inplace) for details.
-    pub fn shuffled<R: Rng>(rng: &mut R, features: &Array2<f32>, labels: &Array1<f32>) -> Self {
-        assert_eq!(
-            features.nrows(),
-            labels.len(),
-            "Features and labels must have the same number of samples"
-        );
-
-        let mut dataset = Dataset {
-            features: features.to_owned(),
-            labels: labels.to_owned(),
-        };
-        dataset.shuffle_inplace(rng);
-        dataset
-    }
-
-    /// Shuffles the dataset features and labels in unison using a random number generator.
+    /// Shuffles the dataset features and labels in unison and returns it, so
+    /// construction and shuffling can be chained (`Dataset::new(..)?.shuffled(rng)`).
+    ///
+    /// Reordering preserves every dataset invariant, so the result needs no
+    /// re-validation.
     /// # Arguments
     /// - `rng`: A mutable reference to a random number generator.
     /// # Details
-    /// - The method generates a vector of indices corresponding to the number of samples in the dataset
-    /// - It shuffles these indices using the provided random number generator.
-    /// - It then reorders both the `features` and `labels` arrays according to
-    ///   the shuffled indices, ensuring that the correspondence between features and labels is maintained.
-    pub fn shuffle_inplace<R: Rng>(&mut self, rng: &mut R) {
+    /// - Generates a vector of indices over the samples and shuffles it.
+    /// - Reorders both `features` and `labels` by those indices, keeping the
+    ///   feature/label correspondence intact.
+    pub fn shuffled<R: Rng + ?Sized>(mut self, rng: &mut R) -> Self {
         let mut indices: Vec<usize> = (0..self.features.nrows()).collect();
         indices.shuffle(rng);
 
-        let shuffled_features = self.features.select(Axis(0), &indices);
-        let shuffled_labels = Array1::from(
+        self.features = self.features.select(Axis(0), &indices);
+        self.labels = Array1::from(
             indices
                 .iter()
                 .map(|&i| self.labels[i])
                 .collect::<Vec<f32>>(),
         );
-
-        self.features = shuffled_features.to_owned();
-        self.labels = shuffled_labels;
+        self
     }
 
     /// Creates a new dataset from a vector of images and their corresponding labels.
@@ -250,10 +291,12 @@ impl Dataset {
     /// - `rng`: A mutable reference to a random number generator for shuffling.
     /// - `images`: A vector of images represented as 1D arrays of pixel values.
     /// - `labels`: A vector of labels corresponding to each image.
+    /// - `origin`: Where the images were encoded from, when known.
     pub fn from_vec<R: Rng>(
         rng: &mut R,
         images: Vec<Array1<f32>>,
         labels: Vec<usize>,
+        origin: Option<DatasetOrigin>,
     ) -> Result<Self, Box<dyn Error>> {
         assert!(
             !images.is_empty(),
@@ -268,7 +311,7 @@ impl Dataset {
         let labels: Array1<f32> =
             Array1::from(labels.into_iter().map(|x| x as f32).collect::<Vec<_>>());
 
-        Ok(Dataset::shuffled(rng, &features, &labels))
+        Ok(Dataset::new(features, labels, origin)?.shuffled(rng))
     }
 }
 
@@ -380,20 +423,21 @@ mod tests {
     use ndarray_rand::rand::prelude::StdRng;
 
     #[test]
-    #[should_panic(expected = "Labels must be 0-indexed")]
-    fn out_of_range_label_panics_with_clear_message() {
+    fn new_rejects_out_of_range_multiclass_label() {
         // labels = [0, 1, 2, 5]: n_classes=4, but label 5 >= n_classes=4
         let features = Array2::zeros((4, 2));
         let labels = array![0.0f32, 1.0, 2.0, 5.0];
-        let dataset = Dataset { features, labels };
-        dataset.to_model_dataset();
+        assert_eq!(
+            Dataset::new(features, labels, None).err(),
+            Some(DatasetError::InvalidLabels)
+        );
     }
 
     #[test]
     fn valid_multiclass_labels_produce_correct_one_hot() {
         let features = Array2::zeros((3, 2));
         let labels = array![0.0f32, 1.0, 2.0];
-        let dataset = Dataset { features, labels };
+        let dataset = Dataset::new(features, labels, None).unwrap();
         let model_dataset = dataset.to_model_dataset();
         // targets shape: (n_classes=3, n_samples=3)
         assert_eq!(model_dataset.targets.shape(), &[3, 3]);
@@ -407,52 +451,74 @@ mod tests {
     fn binary_labels_produce_single_row_targets() {
         let features = Array2::zeros((3, 2));
         let labels = array![0.0f32, 1.0, 0.0];
-        let model_dataset = Dataset { features, labels }.to_model_dataset();
+        let model_dataset = Dataset::new(features, labels, None)
+            .unwrap()
+            .to_model_dataset();
         // Binary labels stay as a single (1, n_samples) row, not one-hot encoded.
         assert_eq!(model_dataset.targets.shape(), &[1, 3]);
         assert_eq!(model_dataset.targets.row(0).to_vec(), vec![0.0, 1.0, 0.0]);
     }
 
     #[test]
-    #[should_panic(expected = "Binary labels must be 0.0 or 1.0")]
-    fn out_of_range_binary_label_panics_with_clear_message() {
-        // labels = [1, 2]: n_classes=2 (binary branch), but 2 is not a valid binary target
+    fn new_rejects_non_contiguous_binary_labels() {
+        // labels = [1, 2]: two classes, but not the contiguous {0, 1} set.
         let features = Array2::zeros((2, 2));
         let labels = array![1.0f32, 2.0];
-        let dataset = Dataset { features, labels };
-        dataset.to_model_dataset();
+        assert_eq!(
+            Dataset::new(features, labels, None).err(),
+            Some(DatasetError::InvalidLabels)
+        );
     }
 
     #[test]
-    fn validate_accepts_a_well_formed_dataset() {
+    fn new_accepts_a_well_formed_dataset() {
         let features = Array2::zeros((4, 2));
         let labels = array![0.0f32, 1.0, 0.0, 1.0];
-        let dataset = Dataset { features, labels };
-        assert_eq!(dataset.validate(), Ok(()));
+        assert!(Dataset::new(features, labels, None).is_ok());
     }
 
     #[test]
-    fn validate_rejects_single_class_dataset() {
+    fn new_rejects_single_class_dataset() {
         let features = Array2::zeros((3, 2));
         let labels = array![1.0f32, 1.0, 1.0];
-        let dataset = Dataset { features, labels };
-        assert_eq!(dataset.validate(), Err(DatasetError::TooFewClasses(1)));
+        assert_eq!(
+            Dataset::new(features, labels, None).err(),
+            Some(DatasetError::TooFewClasses(1))
+        );
     }
 
     #[test]
-    fn validate_rejects_dataset_without_features() {
+    fn new_rejects_dataset_without_features() {
         let features = Array2::zeros((3, 0));
         let labels = array![0.0f32, 1.0, 0.0];
-        let dataset = Dataset { features, labels };
-        assert_eq!(dataset.validate(), Err(DatasetError::NoFeatures));
+        assert_eq!(
+            Dataset::new(features, labels, None).err(),
+            Some(DatasetError::NoFeatures)
+        );
     }
 
     #[test]
-    fn validate_rejects_empty_dataset() {
+    fn new_rejects_empty_dataset() {
         let features = Array2::zeros((0, 2));
         let labels = Array1::zeros(0);
-        let dataset = Dataset { features, labels };
-        assert_eq!(dataset.validate(), Err(DatasetError::NoSamples));
+        assert_eq!(
+            Dataset::new(features, labels, None).err(),
+            Some(DatasetError::NoSamples)
+        );
+    }
+
+    #[test]
+    fn new_rejects_shape_mismatch() {
+        // 3 feature rows but only 2 labels.
+        let features = Array2::zeros((3, 2));
+        let labels = array![0.0f32, 1.0];
+        assert_eq!(
+            Dataset::new(features, labels, None).err(),
+            Some(DatasetError::ShapeMismatch {
+                features: 3,
+                labels: 2
+            })
+        );
     }
 
     #[test]
@@ -484,36 +550,13 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(0);
         let images = vec![array![0.0f32, 1.0], array![2.0, 3.0, 4.0]];
         let labels = vec![0usize, 1];
-        assert!(Dataset::from_vec(&mut rng, images, labels).is_err());
-    }
-
-    #[test]
-    fn is_empty_reflects_missing_features_or_labels() {
-        let populated = Dataset {
-            features: Array2::zeros((2, 2)),
-            labels: array![0.0f32, 1.0],
-        };
-        assert!(!populated.is_empty());
-
-        let no_features = Dataset {
-            features: Array2::zeros((0, 0)),
-            labels: array![0.0f32],
-        };
-        assert!(no_features.is_empty());
-
-        let no_labels = Dataset {
-            features: Array2::zeros((2, 2)),
-            labels: Array1::zeros(0),
-        };
-        assert!(no_labels.is_empty());
+        assert!(Dataset::from_vec(&mut rng, images, labels, None).is_err());
     }
 
     #[test]
     fn unique_labels_deduplicates_values() {
-        let dataset = Dataset {
-            features: Array2::zeros((4, 1)),
-            labels: array![0.0f32, 1.0, 1.0, 2.0],
-        };
+        let dataset =
+            Dataset::new(Array2::zeros((4, 1)), array![0.0f32, 1.0, 1.0, 2.0], None).unwrap();
         let mut unique = dataset.unique_labels();
         unique.sort_by(f32::total_cmp);
         assert_eq!(unique, vec![0.0, 1.0, 2.0]);
@@ -521,10 +564,12 @@ mod tests {
 
     #[test]
     fn get_features_for_label_selects_matching_rows() {
-        let dataset = Dataset {
-            features: array![[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
-            labels: array![0.0f32, 1.0, 0.0],
-        };
+        let dataset = Dataset::new(
+            array![[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            array![0.0f32, 1.0, 0.0],
+            None,
+        )
+        .unwrap();
         let rows = dataset.get_features_for_label(0.0);
         assert_eq!(rows.shape(), &[2, 2]);
         assert_eq!(rows.row(0).to_vec(), vec![1.0, 1.0]);
@@ -533,35 +578,26 @@ mod tests {
 
     #[test]
     fn feature_range_returns_per_feature_min_max() {
-        let dataset = Dataset {
-            features: array![[1.0, 10.0], [3.0, 5.0], [-2.0, 8.0]],
-            labels: array![0.0f32, 1.0, 0.0],
-        };
+        let dataset = Dataset::new(
+            array![[1.0, 10.0], [3.0, 5.0], [-2.0, 8.0]],
+            array![0.0f32, 1.0, 0.0],
+            None,
+        )
+        .unwrap();
         let (mins, maxs) = dataset.feature_range().unwrap();
         assert_eq!(mins, vec![-2.0, 5.0]);
         assert_eq!(maxs, vec![3.0, 10.0]);
     }
 
     #[test]
-    fn feature_range_is_none_without_samples() {
-        let dataset = Dataset {
-            features: Array2::zeros((0, 2)),
-            labels: Array1::zeros(0),
-        };
-        assert!(dataset.feature_range().is_none());
-    }
-
-    #[test]
     fn scale_inplace_applies_scaler_to_features() {
-        let mut dataset = Dataset {
-            features: array![[0.0, 0.0], [10.0, 20.0]],
-            labels: array![0.0f32, 1.0],
-        };
-        let scaler = MinMaxScaler::default().fit(dataset.features.view());
+        let mut dataset =
+            Dataset::new(array![[0.0, 0.0], [10.0, 20.0]], array![0.0f32, 1.0], None).unwrap();
+        let scaler = MinMaxScaler::default().fit(dataset.features().view());
         dataset.scale_inplace(&scaler);
         assert!(
             dataset
-                .features
+                .features()
                 .iter()
                 .all(|&v| (0.0..=1.0 + 1e-5).contains(&v))
         );
@@ -573,9 +609,9 @@ mod tests {
         let images = vec![array![0.0f32, 1.0], array![2.0, 3.0], array![4.0, 5.0]];
         let labels = vec![0usize, 1, 2];
 
-        let dataset = Dataset::from_vec(&mut rng, images, labels).unwrap();
-        assert_eq!(dataset.features.shape(), &[3, 2]);
-        assert_eq!(dataset.labels.len(), 3);
+        let dataset = Dataset::from_vec(&mut rng, images, labels, None).unwrap();
+        assert_eq!(dataset.features().shape(), &[3, 2]);
+        assert_eq!(dataset.labels().len(), 3);
         let mut unique = dataset.unique_labels();
         unique.sort_by(f32::total_cmp);
         assert_eq!(unique, vec![0.0, 1.0, 2.0]);
@@ -592,8 +628,20 @@ mod tests {
             "dataset has no samples"
         );
         assert_eq!(
+            DatasetError::ShapeMismatch {
+                features: 3,
+                labels: 2
+            }
+            .to_string(),
+            "features and labels disagree on sample count: 3 rows vs 2 labels"
+        );
+        assert_eq!(
             DatasetError::TooFewClasses(1).to_string(),
             "a classifier needs at least 2 classes, but found 1"
+        );
+        assert_eq!(
+            DatasetError::InvalidLabels.to_string(),
+            "labels must be contiguous 0-indexed class ids in [0, n_classes)"
         );
     }
 }

--- a/core/src/data/mod.rs
+++ b/core/src/data/mod.rs
@@ -1,7 +1,9 @@
 mod dataset;
+mod origin;
 mod preprocessors;
 
 pub use dataset::*;
+pub use origin::*;
 pub use preprocessors::*;
 
 pub mod synth;

--- a/core/src/data/origin.rs
+++ b/core/src/data/origin.rs
@@ -1,0 +1,12 @@
+/// Where a dataset came from: which producer built it.
+///
+/// A pure value object — the I/O layer owns how it is persisted. It records only
+/// what the data cannot reveal; sizing (features, samples, classes) stays
+/// derivable from the dataset itself.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DatasetOrigin {
+    /// Produced by a synthetic generator, reproducible from `distribution` + `seed`.
+    Synthetic { distribution: String, seed: u64 },
+    /// Encoded from a directory of images at `source`.
+    Encoded { source: String },
+}

--- a/core/src/data/origin.rs
+++ b/core/src/data/origin.rs
@@ -10,3 +10,36 @@ pub enum DatasetOrigin {
     /// Encoded from a directory of images at `source`.
     Encoded { source: String },
 }
+
+impl DatasetOrigin {
+    /// A deterministic slug naming this origin: the distribution and seed for a
+    /// synthetic dataset, the source name for an encoded one.
+    pub fn label(&self) -> String {
+        match self {
+            DatasetOrigin::Synthetic { distribution, seed } => format!("{distribution}-seed{seed}"),
+            DatasetOrigin::Encoded { source } => source.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synthetic_label_carries_distribution_and_seed() {
+        let origin = DatasetOrigin::Synthetic {
+            distribution: "spiral".to_string(),
+            seed: 42,
+        };
+        assert_eq!(origin.label(), "spiral-seed42");
+    }
+
+    #[test]
+    fn encoded_label_is_the_source_name() {
+        let origin = DatasetOrigin::Encoded {
+            source: "mnist".to_string(),
+        };
+        assert_eq!(origin.label(), "mnist");
+    }
+}

--- a/core/src/data/synth/mod.rs
+++ b/core/src/data/synth/mod.rs
@@ -1,25 +1,235 @@
 mod ring;
+mod spiral;
 mod uniform;
 
-pub use ring::RingDataset;
-pub use uniform::UniformDataset;
-
+use crate::data::DatasetOrigin;
 use crate::data::dataset::Dataset;
 use ndarray::{Array1, Array2, ArrayViewMut1, Axis};
 use ndarray_rand::RandomExt;
 use ndarray_rand::rand::prelude::StdRng;
-use ndarray_rand::rand::{Rng, RngCore, SeedableRng};
+use ndarray_rand::rand::{Rng, SeedableRng};
 use ndarray_rand::rand_distr::{StandardNormal, Uniform};
+use std::error::Error;
+use std::fmt;
 
-pub trait DatasetGenerator {
-    fn generate_rng(&self, rng: &mut dyn RngCore) -> Dataset;
+/// Errors returned when synthetic-generation parameters are inconsistent.
+#[derive(Debug, PartialEq)]
+pub enum SynthParamsError {
+    /// No features were requested.
+    NoFeatures,
+    /// Fewer than two clusters: a classifier needs at least two classes.
+    TooFewClusters(usize),
+    /// Not enough samples to place at least one in each cluster.
+    NotEnoughSamples { samples: usize, clusters: usize },
+    /// The feature range is empty (`min >= max`).
+    EmptyRange { min: f32, max: f32 },
+}
 
-    /// Generate a dataset using a specific seed for the random number generator.
+impl fmt::Display for SynthParamsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SynthParamsError::NoFeatures => write!(f, "at least one feature is required"),
+            SynthParamsError::TooFewClusters(n) => {
+                write!(f, "at least 2 clusters are required, but found {n}")
+            }
+            SynthParamsError::NotEnoughSamples { samples, clusters } => write!(
+                f,
+                "need at least one sample per cluster: {samples} samples for {clusters} clusters"
+            ),
+            SynthParamsError::EmptyRange { min, max } => {
+                write!(
+                    f,
+                    "feature range is empty: min {min} must be less than max {max}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for SynthParamsError {}
+
+/// Shared, validated configuration common to every synthetic generator: how many
+/// samples and features to produce, how many clusters (classes) to split them
+/// into, and the per-feature value range the points live in.
+///
+/// Built exclusively through [`SynthParams::new`] (fields are private) so an
+/// inconsistent configuration cannot be represented. Requiring `n_clusters >= 2`
+/// guarantees the generated dataset always has enough classes to load and train.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SynthParams {
+    n_samples: usize,
+    n_features: usize,
+    n_clusters: usize,
+    feature_min: f32,
+    feature_max: f32,
+}
+
+impl SynthParams {
+    /// Builds a validated parameter set.
+    ///
+    /// # Errors
+    /// - [`SynthParamsError::NoFeatures`] when `n_features == 0`.
+    /// - [`SynthParamsError::TooFewClusters`] when `n_clusters < 2`.
+    /// - [`SynthParamsError::NotEnoughSamples`] when `n_samples < n_clusters`.
+    /// - [`SynthParamsError::EmptyRange`] when `feature_min >= feature_max`.
+    pub fn new(
+        n_samples: usize,
+        n_features: usize,
+        n_clusters: usize,
+        feature_min: f32,
+        feature_max: f32,
+    ) -> Result<Self, SynthParamsError> {
+        if n_features == 0 {
+            return Err(SynthParamsError::NoFeatures);
+        }
+        if n_clusters < 2 {
+            return Err(SynthParamsError::TooFewClusters(n_clusters));
+        }
+        if n_samples < n_clusters {
+            return Err(SynthParamsError::NotEnoughSamples {
+                samples: n_samples,
+                clusters: n_clusters,
+            });
+        }
+        if feature_min >= feature_max {
+            return Err(SynthParamsError::EmptyRange {
+                min: feature_min,
+                max: feature_max,
+            });
+        }
+
+        Ok(Self {
+            n_samples,
+            n_features,
+            n_clusters,
+            feature_min,
+            feature_max,
+        })
+    }
+
+    /// Number of samples placed in each cluster (the total is truncated to a
+    /// multiple of `n_clusters`).
+    fn samples_per_cluster(&self) -> usize {
+        self.n_samples / self.n_clusters
+    }
+}
+
+/// The point-placement strategy that distinguishes one synthetic dataset from
+/// another. Doubles as the dataset's provenance "type". Each variant carries its
+/// own shape knobs, while sizing stays in the shared [`SynthParams`]. Default
+/// values for these knobs are a caller policy and live with the caller.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Distribution {
+    /// Isotropic blobs: one randomly-placed spherical cluster per class.
+    Uniform,
+    /// Concentric rings sharing a common center, one ring per class. `overlap`
+    /// is the fraction by which consecutive rings overlap (negative = a gap).
+    Ring { overlap: f32 },
+    /// Interleaved spiral arms (2D only), one arm per class — the canonical
+    /// non-linearly-separable benchmark. `turns` is how many turns each arm makes
+    /// and `noise` the Gaussian jitter as a fraction of the arm's max radius.
+    Spiral { turns: f32, noise: f32 },
+}
+
+// `Display` is never derived in Rust (only `Debug` is), and `Debug` would yield
+// the capitalized variant name with its fields. We want the lowercase canonical
+// name used for filenames and provenance metadata, so it is written by hand.
+impl fmt::Display for Distribution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Distribution::Uniform => "uniform",
+            Distribution::Ring { .. } => "ring",
+            Distribution::Spiral { .. } => "spiral",
+        };
+        write!(f, "{name}")
+    }
+}
+
+/// Errors returned when a [`Distribution`] is incompatible with its
+/// [`SynthParams`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum SynthError {
+    /// A spiral was requested with a feature count other than two (carries the
+    /// count found); spirals are inherently two-dimensional.
+    SpiralRequiresTwoFeatures(usize),
+}
+
+impl fmt::Display for SynthError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SynthError::SpiralRequiresTwoFeatures(n) => {
+                write!(
+                    f,
+                    "spiral datasets require exactly two features, but found {n}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for SynthError {}
+
+/// A validated synthetic dataset generator: shared [`SynthParams`] plus the
+/// chosen [`Distribution`]. The distribution selects how points are placed per
+/// cluster; label assignment and shuffling are shared across all distributions.
+///
+/// Built through [`SynthDataset::new`] (fields are private) so a distribution
+/// incompatible with the parameters cannot be represented — generation therefore
+/// never fails.
+pub struct SynthDataset {
+    params: SynthParams,
+    distribution: Distribution,
+}
+
+impl SynthDataset {
+    /// Pairs validated `params` with a `distribution`, checking their cross-field
+    /// invariants.
+    ///
+    /// # Errors
+    /// - [`SynthError::SpiralRequiresTwoFeatures`] when a spiral is requested with
+    ///   a feature count other than two.
+    pub fn new(params: SynthParams, distribution: Distribution) -> Result<Self, SynthError> {
+        if matches!(distribution, Distribution::Spiral { .. }) && params.n_features != 2 {
+            return Err(SynthError::SpiralRequiresTwoFeatures(params.n_features));
+        }
+        Ok(Self {
+            params,
+            distribution,
+        })
+    }
+
+    /// Generates a dataset using a specific seed for reproducibility, stamped with
+    /// its [`DatasetOrigin::Synthetic`] provenance. The parameters were validated
+    /// at construction, so the result is always well-formed.
     /// # Arguments
     /// - `seed`: A seed for the random number generator to ensure reproducibility.
-    fn generate(&self, seed: u64) -> Dataset {
+    pub fn generate(&self, seed: u64) -> Dataset {
         let mut rng = StdRng::seed_from_u64(seed);
-        self.generate_rng(&mut rng)
+
+        let (mut features, labels) = init_features_and_labels(
+            self.params.n_features,
+            self.params.n_clusters,
+            self.params.samples_per_cluster(),
+        );
+
+        match self.distribution {
+            Distribution::Uniform => uniform::fill(&self.params, &mut features, &mut rng),
+            Distribution::Ring { overlap } => {
+                ring::fill(&self.params, overlap, &mut features, &mut rng)
+            }
+            Distribution::Spiral { turns, noise } => {
+                spiral::fill(&self.params, turns, noise, &mut features, &mut rng)
+            }
+        }
+
+        let origin = DatasetOrigin::Synthetic {
+            distribution: self.distribution.to_string(),
+            seed,
+        };
+
+        Dataset::new(features, labels, Some(origin))
+            .expect("synthetic parameters guarantee a valid dataset")
+            .shuffled(&mut rng)
     }
 }
 
@@ -132,74 +342,100 @@ mod tests {
     use super::*;
     use ndarray::array;
 
-    fn uniform(n_samples: usize, n_clusters: usize) -> Dataset {
-        UniformDataset {
-            n_samples,
-            n_features: 2,
-            n_clusters,
-            feature_min: 0.0,
-            feature_max: 10.0,
-        }
-        .generate(42)
+    const RING: Distribution = Distribution::Ring { overlap: -0.2 };
+    const SPIRAL: Distribution = Distribution::Spiral {
+        turns: 1.5,
+        noise: 0.03,
+    };
+
+    /// Test fixture: a valid two-feature parameter set over `[0, 10]`.
+    fn params(n_samples: usize, n_clusters: usize) -> SynthParams {
+        SynthParams::new(n_samples, 2, n_clusters, 0.0, 10.0).unwrap()
     }
 
-    fn ring(n_samples: usize, n_clusters: usize) -> Dataset {
-        RingDataset {
-            n_samples,
-            n_features: 2,
-            n_clusters,
-            feature_min: 0.0,
-            feature_max: 10.0,
-        }
-        .generate(42)
+    /// Generates a seeded dataset from already-validated params.
+    fn generate(distribution: Distribution, params: SynthParams) -> Dataset {
+        SynthDataset::new(params, distribution)
+            .unwrap()
+            .generate(42)
     }
 
     #[test]
-    fn uniform_labels_are_zero_indexed() {
-        let mut labels = uniform(90, 3).unique_labels();
-        labels.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        assert_eq!(labels, vec![0.0, 1.0, 2.0]);
-    }
-
-    #[test]
-    fn ring_labels_are_zero_indexed() {
-        let mut labels = ring(90, 3).unique_labels();
-        labels.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        assert_eq!(labels, vec![0.0, 1.0, 2.0]);
+    fn labels_are_zero_indexed() {
+        for distribution in [Distribution::Uniform, RING, SPIRAL] {
+            let mut labels = generate(distribution, params(90, 3)).unique_labels();
+            labels.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            assert_eq!(labels, vec![0.0, 1.0, 2.0], "{distribution}");
+        }
     }
 
     #[test]
     fn sample_count_exact_when_divisible() {
-        assert_eq!(uniform(100, 5).n_samples(), 100);
-        assert_eq!(ring(100, 5).n_samples(), 100);
+        for distribution in [Distribution::Uniform, RING, SPIRAL] {
+            assert_eq!(generate(distribution, params(100, 5)).n_samples(), 100);
+        }
     }
 
     #[test]
     fn sample_count_truncated_when_not_divisible() {
-        assert_eq!(uniform(100, 3).n_samples(), 99);
-        assert_eq!(ring(100, 3).n_samples(), 99);
-    }
-
-    #[test]
-    fn uniform_features_within_bounds() {
-        for &val in uniform(200, 2).features.iter() {
-            assert!(
-                (0.0..=10.0).contains(&val),
-                "feature {} hors de [0, 10]",
-                val
-            );
+        for distribution in [Distribution::Uniform, RING, SPIRAL] {
+            assert_eq!(generate(distribution, params(100, 3)).n_samples(), 99);
         }
     }
 
     #[test]
-    fn ring_features_within_bounds() {
-        for &val in ring(90, 3).features.iter() {
-            assert!(
-                (0.0..=10.0).contains(&val),
-                "feature {} hors de [0, 10]",
-                val
-            );
+    fn features_within_bounds() {
+        for distribution in [Distribution::Uniform, RING, SPIRAL] {
+            for &val in generate(distribution, params(200, 2)).features().iter() {
+                assert!(
+                    (0.0..=10.0).contains(&val),
+                    "{distribution}: feature {val} out of [0, 10]"
+                );
+            }
         }
+    }
+
+    #[test]
+    fn spiral_rejects_a_feature_count_other_than_two() {
+        let params = SynthParams::new(100, 3, 2, 0.0, 10.0).unwrap();
+        assert!(matches!(
+            SynthDataset::new(params, SPIRAL),
+            Err(SynthError::SpiralRequiresTwoFeatures(3))
+        ));
+    }
+
+    #[test]
+    fn new_params_validates_invariants() {
+        assert_eq!(
+            SynthParams::new(100, 0, 2, 0.0, 10.0),
+            Err(SynthParamsError::NoFeatures)
+        );
+        assert_eq!(
+            SynthParams::new(100, 2, 1, 0.0, 10.0),
+            Err(SynthParamsError::TooFewClusters(1))
+        );
+        assert_eq!(
+            SynthParams::new(2, 2, 3, 0.0, 10.0),
+            Err(SynthParamsError::NotEnoughSamples {
+                samples: 2,
+                clusters: 3
+            })
+        );
+        assert_eq!(
+            SynthParams::new(100, 2, 2, 10.0, 10.0),
+            Err(SynthParamsError::EmptyRange {
+                min: 10.0,
+                max: 10.0
+            })
+        );
+        assert!(SynthParams::new(100, 2, 2, 0.0, 10.0).is_ok());
+    }
+
+    #[test]
+    fn distribution_display_is_the_lowercase_name() {
+        assert_eq!(Distribution::Uniform.to_string(), "uniform");
+        assert_eq!(RING.to_string(), "ring");
+        assert_eq!(SPIRAL.to_string(), "spiral");
     }
 
     #[test]

--- a/core/src/data/synth/mod.rs
+++ b/core/src/data/synth/mod.rs
@@ -398,10 +398,8 @@ mod tests {
     #[test]
     fn spiral_rejects_a_feature_count_other_than_two() {
         let params = SynthParams::new(100, 3, 2, 0.0, 10.0).unwrap();
-        assert!(matches!(
-            SynthDataset::new(params, SPIRAL),
-            Err(SynthError::SpiralRequiresTwoFeatures(3))
-        ));
+        let err = SynthDataset::new(params, SPIRAL).err().unwrap();
+        assert_eq!(err, SynthError::SpiralRequiresTwoFeatures(3));
     }
 
     #[test]
@@ -429,6 +427,42 @@ mod tests {
             })
         );
         assert!(SynthParams::new(100, 2, 2, 0.0, 10.0).is_ok());
+    }
+
+    #[test]
+    fn synth_params_error_messages_are_human_readable() {
+        assert_eq!(
+            SynthParamsError::NoFeatures.to_string(),
+            "at least one feature is required"
+        );
+        assert_eq!(
+            SynthParamsError::TooFewClusters(1).to_string(),
+            "at least 2 clusters are required, but found 1"
+        );
+        assert_eq!(
+            SynthParamsError::NotEnoughSamples {
+                samples: 2,
+                clusters: 3
+            }
+            .to_string(),
+            "need at least one sample per cluster: 2 samples for 3 clusters"
+        );
+        assert_eq!(
+            SynthParamsError::EmptyRange {
+                min: 10.0,
+                max: 1.0
+            }
+            .to_string(),
+            "feature range is empty: min 10 must be less than max 1"
+        );
+    }
+
+    #[test]
+    fn synth_error_message_is_human_readable() {
+        assert_eq!(
+            SynthError::SpiralRequiresTwoFeatures(3).to_string(),
+            "spiral datasets require exactly two features, but found 3"
+        );
     }
 
     #[test]

--- a/core/src/data/synth/mod.rs
+++ b/core/src/data/synth/mod.rs
@@ -147,11 +147,18 @@ impl fmt::Display for Distribution {
 
 /// Errors returned when a [`Distribution`] is incompatible with its
 /// [`SynthParams`].
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub enum SynthError {
     /// A spiral was requested with a feature count other than two (carries the
     /// count found); spirals are inherently two-dimensional.
     SpiralRequiresTwoFeatures(usize),
+    /// A ring `overlap` of `1.0` or more was requested (carries the value); the
+    /// inner radii would turn negative.
+    RingOverlapTooLarge(f32),
+    /// The requested rings do not fit within the feature range (carries the
+    /// cluster count): too many clusters, or an overlap so low the rings grow
+    /// past the available space.
+    RingTooDenseForRange(usize),
 }
 
 impl fmt::Display for SynthError {
@@ -161,6 +168,16 @@ impl fmt::Display for SynthError {
                 write!(
                     f,
                     "spiral datasets require exactly two features, but found {n}"
+                )
+            }
+            SynthError::RingOverlapTooLarge(overlap) => {
+                write!(f, "ring overlap must be less than 1.0, but found {overlap}")
+            }
+            SynthError::RingTooDenseForRange(clusters) => {
+                write!(
+                    f,
+                    "rings for {clusters} clusters do not fit within the feature range: \
+                     reduce the number of clusters or increase the overlap"
                 )
             }
         }
@@ -182,16 +199,20 @@ pub struct SynthDataset {
 }
 
 impl SynthDataset {
-    /// Pairs validated `params` with a `distribution`, checking their cross-field
-    /// invariants.
+    /// Pairs validated `params` with a `distribution`, delegating the cross-field
+    /// check to the chosen generator's `validate` (the sibling of its `fill`).
     ///
     /// # Errors
     /// - [`SynthError::SpiralRequiresTwoFeatures`] when a spiral is requested with
     ///   a feature count other than two.
+    /// - [`SynthError::RingOverlapTooLarge`] / [`SynthError::RingTooDenseForRange`]
+    ///   when a ring's overlap or cluster count leaves no room for the rings.
     pub fn new(params: SynthParams, distribution: Distribution) -> Result<Self, SynthError> {
-        if matches!(distribution, Distribution::Spiral { .. }) && params.n_features != 2 {
-            return Err(SynthError::SpiralRequiresTwoFeatures(params.n_features));
-        }
+        match distribution {
+            Distribution::Uniform => uniform::validate(&params),
+            Distribution::Ring { overlap } => ring::validate(&params, overlap),
+            Distribution::Spiral { .. } => spiral::validate(&params),
+        }?;
         Ok(Self {
             params,
             distribution,
@@ -403,6 +424,24 @@ mod tests {
     }
 
     #[test]
+    fn ring_rejects_overlap_of_one_or_more() {
+        let err = SynthDataset::new(params(100, 2), Distribution::Ring { overlap: 1.0 })
+            .err()
+            .unwrap();
+        assert_eq!(err, SynthError::RingOverlapTooLarge(1.0));
+    }
+
+    #[test]
+    fn ring_rejects_geometry_that_overflows_the_range() {
+        // A large gap (very negative overlap) over many clusters grows the outer
+        // rings past the feature range, leaving no room for a valid center.
+        let err = SynthDataset::new(params(100, 5), Distribution::Ring { overlap: -1.0 })
+            .err()
+            .unwrap();
+        assert_eq!(err, SynthError::RingTooDenseForRange(5));
+    }
+
+    #[test]
     fn new_params_validates_invariants() {
         assert_eq!(
             SynthParams::new(100, 0, 2, 0.0, 10.0),
@@ -462,6 +501,15 @@ mod tests {
         assert_eq!(
             SynthError::SpiralRequiresTwoFeatures(3).to_string(),
             "spiral datasets require exactly two features, but found 3"
+        );
+        assert_eq!(
+            SynthError::RingOverlapTooLarge(1.5).to_string(),
+            "ring overlap must be less than 1.0, but found 1.5"
+        );
+        assert_eq!(
+            SynthError::RingTooDenseForRange(5).to_string(),
+            "rings for 5 clusters do not fit within the feature range: \
+             reduce the number of clusters or increase the overlap"
         );
     }
 

--- a/core/src/data/synth/ring.rs
+++ b/core/src/data/synth/ring.rs
@@ -1,45 +1,64 @@
-use crate::data::synth::{SynthParams, calculate_radius, feature_bounds, random_points};
-use ndarray::{Array1, Array2, s};
+use crate::data::synth::{
+    SynthError, SynthParams, calculate_radius, feature_bounds, max_radius, random_points,
+};
+use ndarray::{Array2, s};
 use ndarray_rand::rand::{Rng, RngCore};
 
+/// Increasing `(min, max)` radius range for each cluster. `overlap` controls how
+/// much consecutive rings overlap (negative values leave a gap). Shared by
+/// [`validate`] and [`fill`] so both reason about the same geometry.
+fn radii(params: &SynthParams, overlap: f32) -> Vec<(f32, f32)> {
+    let radius = calculate_radius(params.feature_min, params.feature_max, params.n_clusters);
+    (0..params.n_clusters)
+        .map(|i| {
+            let min = radius * i as f32 * (1.0 - overlap);
+            (min, min + radius)
+        })
+        .collect()
+}
+
+/// Checks that the rings fit within the feature range, so [`fill`]'s geometry
+/// invariants hold and generation cannot panic.
+///
+/// # Errors
+/// - [`SynthError::RingOverlapTooLarge`] when `overlap >= 1.0` (inner radii would
+///   turn negative).
+/// - [`SynthError::RingTooDenseForRange`] when the outermost ring leaves no room
+///   inside the feature range for a valid center.
+pub(super) fn validate(params: &SynthParams, overlap: f32) -> Result<(), SynthError> {
+    if overlap >= 1.0 {
+        return Err(SynthError::RingOverlapTooLarge(overlap));
+    }
+    // `overlap < 1.0` keeps every inner radius non-negative, so `max_radius` holds.
+    let max_radius = max_radius(&radii(params, overlap));
+    let span = params.feature_max - params.feature_min;
+    if span <= 2.0 * max_radius {
+        return Err(SynthError::RingTooDenseForRange(params.n_clusters));
+    }
+    Ok(())
+}
+
 /// Fills `features` with concentric rings sharing a common center, one ring
-/// (class) per cluster. `overlap` controls how much consecutive rings overlap
-/// (negative values leave a gap).
+/// (class) per cluster. The geometry was checked by [`validate`] at
+/// construction, so the bounds below always leave a valid center.
 pub(super) fn fill(
     params: &SynthParams,
     overlap: f32,
     features: &mut Array2<f32>,
     mut rng: &mut dyn RngCore,
 ) {
-    let radius = calculate_radius(params.feature_min, params.feature_max, params.n_clusters);
     let samples_per_cluster = params.samples_per_cluster();
-
-    // Increasing radii for each cluster; `overlap` controls how much consecutive
-    // rings overlap.
-    let radii: Vec<(f32, f32)> = (0..params.n_clusters)
-        .map(|i| {
-            let idx = i as f32;
-            let min = radius * idx * (1.0 - overlap);
-            let max = min + radius;
-            (min, max)
-        })
-        .collect();
+    let radii = radii(params, overlap);
 
     let (feature_min_bound, feature_max_bound) =
         feature_bounds(params.feature_min, params.feature_max, &radii);
 
-    let center = Array1::<f32>::from_shape_fn(params.n_features, |_| {
-        rng.random_range(feature_min_bound..feature_max_bound)
-    });
+    let center: Vec<f32> = (0..params.n_features)
+        .map(|_| rng.random_range(feature_min_bound..feature_max_bound))
+        .collect();
 
     for (cluster_idx, &(r_min, r_max)) in radii.iter().enumerate() {
-        let points = random_points(
-            &mut rng,
-            samples_per_cluster,
-            &center.to_vec(),
-            r_min,
-            r_max,
-        );
+        let points = random_points(&mut rng, samples_per_cluster, &center, r_min, r_max);
         let start = cluster_idx * samples_per_cluster;
         let end = start + samples_per_cluster;
         features.slice_mut(s![start..end, ..]).assign(&points);

--- a/core/src/data/synth/ring.rs
+++ b/core/src/data/synth/ring.rs
@@ -1,69 +1,47 @@
-use crate::data::dataset::Dataset;
-use crate::data::synth::{
-    DatasetGenerator, calculate_radius, feature_bounds, init_features_and_labels, random_points,
-};
-use ndarray::{Array1, s};
+use crate::data::synth::{SynthParams, calculate_radius, feature_bounds, random_points};
+use ndarray::{Array1, Array2, s};
 use ndarray_rand::rand::{Rng, RngCore};
 
-/// Generates a dataset with clusters arranged in concentric rings.
-pub struct RingDataset {
-    /// The number of samples to generate for each cluster.
-    pub n_samples: usize,
-    /// The number of features for each sample.
-    pub n_features: usize,
-    /// The number of clusters to generate.
-    pub n_clusters: usize,
-    /// The minimum value for each feature.
-    pub feature_min: f32,
-    /// The maximum value for each feature.
-    pub feature_max: f32,
-}
+/// Fills `features` with concentric rings sharing a common center, one ring
+/// (class) per cluster. `overlap` controls how much consecutive rings overlap
+/// (negative values leave a gap).
+pub(super) fn fill(
+    params: &SynthParams,
+    overlap: f32,
+    features: &mut Array2<f32>,
+    mut rng: &mut dyn RngCore,
+) {
+    let radius = calculate_radius(params.feature_min, params.feature_max, params.n_clusters);
+    let samples_per_cluster = params.samples_per_cluster();
 
-impl DatasetGenerator for RingDataset {
-    fn generate_rng(&self, mut rng: &mut dyn RngCore) -> Dataset {
-        assert!(
-            self.feature_min < self.feature_max,
-            "feature_min must be less than feature_max"
+    // Increasing radii for each cluster; `overlap` controls how much consecutive
+    // rings overlap.
+    let radii: Vec<(f32, f32)> = (0..params.n_clusters)
+        .map(|i| {
+            let idx = i as f32;
+            let min = radius * idx * (1.0 - overlap);
+            let max = min + radius;
+            (min, max)
+        })
+        .collect();
+
+    let (feature_min_bound, feature_max_bound) =
+        feature_bounds(params.feature_min, params.feature_max, &radii);
+
+    let center = Array1::<f32>::from_shape_fn(params.n_features, |_| {
+        rng.random_range(feature_min_bound..feature_max_bound)
+    });
+
+    for (cluster_idx, &(r_min, r_max)) in radii.iter().enumerate() {
+        let points = random_points(
+            &mut rng,
+            samples_per_cluster,
+            &center.to_vec(),
+            r_min,
+            r_max,
         );
-
-        let radius: f32 = calculate_radius(self.feature_min, self.feature_max, self.n_clusters);
-        let samples_per_cluster = self.n_samples / self.n_clusters;
-
-        // Generate increasing radii for each cluster with a configurable overlap_factor.
-        // The overlap_factor controls the percentage of overlap between clusters.
-        let overlap_factor = -0.2;
-        let radii: Vec<(f32, f32)> = (0..self.n_clusters)
-            .map(|i| {
-                let idx = i as f32;
-                let min = radius * idx * (1.0 - overlap_factor);
-                let max = min + radius;
-                (min, max)
-            })
-            .collect();
-
-        let (mut features, labels) =
-            init_features_and_labels(self.n_features, radii.len(), samples_per_cluster);
-
-        let (feature_min_bound, feature_max_bound) =
-            feature_bounds(self.feature_min, self.feature_max, &radii);
-
-        let center = Array1::<f32>::from_shape_fn(self.n_features, |_| {
-            rng.random_range(feature_min_bound..feature_max_bound)
-        });
-
-        for (cluster_idx, &(r_min, r_max)) in radii.iter().enumerate() {
-            let points = random_points(
-                &mut rng,
-                samples_per_cluster,
-                &center.to_vec(),
-                r_min,
-                r_max,
-            );
-            let start = cluster_idx * samples_per_cluster;
-            let end = start + samples_per_cluster;
-            features.slice_mut(s![start..end, ..]).assign(&points);
-        }
-
-        Dataset::shuffled(&mut rng, &features, &labels)
+        let start = cluster_idx * samples_per_cluster;
+        let end = start + samples_per_cluster;
+        features.slice_mut(s![start..end, ..]).assign(&points);
     }
 }

--- a/core/src/data/synth/spiral.rs
+++ b/core/src/data/synth/spiral.rs
@@ -1,8 +1,20 @@
-use crate::data::synth::SynthParams;
+use crate::data::synth::{SynthError, SynthParams};
 use ndarray::Array2;
 use ndarray_rand::rand::{Rng, RngCore};
 use ndarray_rand::rand_distr::StandardNormal;
 use std::f32::consts::TAU;
+
+/// Checks that the spiral is two-dimensional, the only constraint [`fill`] adds
+/// (it indexes features 0 and 1 directly).
+///
+/// # Errors
+/// - [`SynthError::SpiralRequiresTwoFeatures`] when `n_features != 2`.
+pub(super) fn validate(params: &SynthParams) -> Result<(), SynthError> {
+    if params.n_features != 2 {
+        return Err(SynthError::SpiralRequiresTwoFeatures(params.n_features));
+    }
+    Ok(())
+}
 
 /// Fills `features` with interleaved spiral arms, one arm (class) per cluster.
 ///

--- a/core/src/data/synth/spiral.rs
+++ b/core/src/data/synth/spiral.rs
@@ -1,0 +1,45 @@
+use crate::data::synth::SynthParams;
+use ndarray::Array2;
+use ndarray_rand::rand::{Rng, RngCore};
+use ndarray_rand::rand_distr::StandardNormal;
+use std::f32::consts::TAU;
+
+/// Fills `features` with interleaved spiral arms, one arm (class) per cluster.
+///
+/// Every arm is the same Archimedean spiral rotated by an even phase offset, so
+/// the classes interleave and cannot be separated by a linear boundary — the
+/// canonical benchmark for why hidden layers are needed. Spiral datasets are
+/// inherently two-dimensional. `turns` is how many turns each arm makes and
+/// `noise` is the Gaussian jitter as a fraction of the arm's max radius.
+pub(super) fn fill(
+    params: &SynthParams,
+    turns: f32,
+    noise: f32,
+    features: &mut Array2<f32>,
+    rng: &mut dyn RngCore,
+) {
+    let samples_per_cluster = params.samples_per_cluster();
+    let center = (params.feature_min + params.feature_max) / 2.0;
+    // Leave a small margin so jittered points stay inside the bounds.
+    let max_radius = (params.feature_max - params.feature_min) / 2.0 * 0.9;
+    let jitter_scale = max_radius * noise;
+
+    for arm in 0..params.n_clusters {
+        let phase = arm as f32 / params.n_clusters as f32 * TAU;
+        for i in 0..samples_per_cluster {
+            // `t` in (0, 1]: distance along the arm, from center to rim.
+            let t = (i + 1) as f32 / samples_per_cluster as f32;
+            let angle = phase + t * turns * TAU;
+            let radius = t * max_radius;
+
+            let jitter_x: f32 = rng.sample(StandardNormal);
+            let jitter_y: f32 = rng.sample(StandardNormal);
+            let x = center + radius * angle.cos() + jitter_x * jitter_scale;
+            let y = center + radius * angle.sin() + jitter_y * jitter_scale;
+
+            let row = arm * samples_per_cluster + i;
+            features[[row, 0]] = x.clamp(params.feature_min, params.feature_max);
+            features[[row, 1]] = y.clamp(params.feature_min, params.feature_max);
+        }
+    }
+}

--- a/core/src/data/synth/uniform.rs
+++ b/core/src/data/synth/uniform.rs
@@ -1,67 +1,33 @@
-use crate::data::dataset::Dataset;
-use crate::data::synth::{
-    DatasetGenerator, calculate_radius, feature_bounds, init_features_and_labels, random_points,
-};
+use crate::data::synth::{SynthParams, calculate_radius, feature_bounds, random_points};
 use ndarray::{Array2, s};
-use ndarray_rand::rand::Rng;
-use ndarray_rand::rand::RngCore;
+use ndarray_rand::rand::{Rng, RngCore};
 
-/// Generates a synthetic dataset with clusters arranged in concentric spheres.
-pub struct UniformDataset {
-    /// The total number of samples to generate.
-    pub n_samples: usize,
-    /// The number of features for each sample.
-    pub n_features: usize,
-    /// The number of clusters to generate.
-    pub n_clusters: usize,
-    /// The minimum value for each feature.
-    pub feature_min: f32,
-    /// The maximum value for each feature.
-    pub feature_max: f32,
-}
+/// Fills `features` with isotropic blobs: one spherical cluster (class) per
+/// cluster, each centered at a random point within the bounded region.
+pub(super) fn fill(params: &SynthParams, features: &mut Array2<f32>, mut rng: &mut dyn RngCore) {
+    let samples_per_cluster = params.samples_per_cluster();
+    let radius = calculate_radius(params.feature_min, params.feature_max, params.n_clusters);
+    let radii = vec![(0.0, radius); params.n_clusters];
 
-impl DatasetGenerator for UniformDataset {
-    fn generate_rng(&self, mut rng: &mut dyn RngCore) -> Dataset {
-        assert!(
-            self.n_samples > 0,
-            "Number of samples must be greater than zero."
+    let (feature_min_bound, feature_max_bound) =
+        feature_bounds(params.feature_min, params.feature_max, &radii);
+
+    let centers = Array2::<f32>::from_shape_fn((params.n_clusters, params.n_features), |_| {
+        rng.random_range(feature_min_bound..feature_max_bound)
+    });
+
+    for (cluster_idx, (center, &(radius_min, radius_max))) in
+        centers.outer_iter().zip(radii.iter()).enumerate()
+    {
+        let points = random_points(
+            &mut rng,
+            samples_per_cluster,
+            &center.to_vec(),
+            radius_min,
+            radius_max,
         );
-
-        let samples_per_cluster = self.n_samples / self.n_clusters;
-
-        let radius: f32 = calculate_radius(self.feature_min, self.feature_max, self.n_clusters);
-        let radii = &vec![(0.0, radius); self.n_clusters];
-
-        let (mut features, labels) =
-            init_features_and_labels(self.n_features, self.n_clusters, samples_per_cluster);
-
-        let (feature_min_bound, feature_max_bound) =
-            feature_bounds(self.feature_min, self.feature_max, radii);
-
-        assert!(
-            feature_max_bound > feature_min_bound,
-            "feature_max_bound must be greater than feature_min_bound"
-        );
-
-        let centers = Array2::<f32>::from_shape_fn((self.n_clusters, self.n_features), |_| {
-            rng.random_range(feature_min_bound..feature_max_bound)
-        });
-
-        for (cluster_idx, (center, &(radius_min, radius_max))) in
-            centers.outer_iter().zip(radii.iter()).enumerate()
-        {
-            let points = random_points(
-                &mut rng,
-                samples_per_cluster,
-                &center.to_vec(),
-                radius_min,
-                radius_max,
-            );
-            let start = cluster_idx * samples_per_cluster;
-            let end = start + samples_per_cluster;
-            features.slice_mut(s![start..end, ..]).assign(&points);
-        }
-
-        Dataset::shuffled(&mut rng, &features, &labels)
+        let start = cluster_idx * samples_per_cluster;
+        let end = start + samples_per_cluster;
+        features.slice_mut(s![start..end, ..]).assign(&points);
     }
 }

--- a/core/src/data/synth/uniform.rs
+++ b/core/src/data/synth/uniform.rs
@@ -1,6 +1,15 @@
-use crate::data::synth::{SynthParams, calculate_radius, feature_bounds, random_points};
+use crate::data::synth::{
+    SynthError, SynthParams, calculate_radius, feature_bounds, random_points,
+};
 use ndarray::{Array2, s};
 use ndarray_rand::rand::{Rng, RngCore};
+
+/// Uniform blobs impose no constraints beyond a valid [`SynthParams`]: the
+/// per-cluster radius is always small enough to fit the feature range. Present
+/// for symmetry with [`fill`] and the other generators' `validate`.
+pub(super) fn validate(_params: &SynthParams) -> Result<(), SynthError> {
+    Ok(())
+}
 
 /// Fills `features` with isotropic blobs: one spherical cluster (class) per
 /// cluster, each centered at a random point within the bounded region.

--- a/core/src/io/checkpoint.rs
+++ b/core/src/io/checkpoint.rs
@@ -286,20 +286,17 @@ mod tests {
         let _ = fs::remove_dir_all(dir);
     }
 
-    fn create_run<P: AsRef<Path>>(
-        path: P,
-        dataset: &str,
-        overwrite: bool,
-    ) -> Result<CheckpointRecorder> {
-        Ok(TrainingRun::create(
+    fn create_run<P: AsRef<Path>>(path: P, dataset: &str, overwrite: bool) -> CheckpointRecorder {
+        TrainingRun::create(
             path,
             &TrainingMeta {
                 dataset: dataset.to_string(),
                 hyperparams: HyperParametersRecord::sample(),
             },
             overwrite,
-        )?
-        .recorder())
+        )
+        .unwrap()
+        .recorder()
     }
 
     fn sample_model() -> NeuralNetwork {
@@ -327,7 +324,7 @@ mod tests {
     #[test]
     fn write_names_checkpoint_dir_by_epoch() {
         let dir = temp_dir("write_epoch");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
         recorder
             .write(
                 &sample_model(),
@@ -347,7 +344,7 @@ mod tests {
     #[test]
     fn roundtrip_with_validation() {
         let dir = temp_dir("roundtrip_val");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
         for i in 0..3 {
             recorder
                 .write(
@@ -376,7 +373,7 @@ mod tests {
     #[test]
     fn roundtrip_without_validation() {
         let dir = temp_dir("roundtrip_noval");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
         for i in 0..3 {
             recorder
                 .write(
@@ -405,7 +402,7 @@ mod tests {
         let model = sample_model();
         let inputs = Array2::from_shape_fn((2, 4), |(i, j)| (i + j) as f32 * 0.3);
 
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
         recorder
             .write(
                 &model,
@@ -427,7 +424,7 @@ mod tests {
     fn numeric_sort_beats_lexical() {
         let dir = temp_dir("sort");
         let model = sample_model();
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
         for i in 0..12 {
             recorder
                 .write(
@@ -480,9 +477,20 @@ mod tests {
     }
 
     #[test]
+    fn load_ignores_unrelated_directory() {
+        // A directory whose name lacks the `checkpoint-` prefix is skipped.
+        let dir = temp_dir("unrelated_dir");
+        fs::create_dir_all(dir.join("scratch")).unwrap();
+        let archive = CheckpointArchive::load(&dir).unwrap();
+        cleanup(&dir);
+
+        assert!(archive.is_empty());
+    }
+
+    #[test]
     fn model_at_out_of_range_gives_range_error() {
         let dir = temp_dir("model_at_oob");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
         recorder
             .write(
                 &sample_model(),
@@ -501,9 +509,34 @@ mod tests {
     }
 
     #[test]
+    fn optimizer_and_scheduler_at_out_of_range_error() {
+        // `optimizer_at` / `scheduler_at` reach `entry_at` through `optional_file`,
+        // a different call site than `model_at`, so its range check is covered here.
+        let dir = temp_dir("state_at_oob");
+        let recorder = create_run(&dir, "ds", false);
+        recorder
+            .write(
+                &sample_model(),
+                &sample_optimizer(),
+                &sample_scheduler(),
+                &make_eval(0.0, false),
+                0,
+            )
+            .unwrap();
+
+        let archive = CheckpointArchive::load(&dir).unwrap();
+        let opt_err = archive.optimizer_at(99).unwrap_err().to_string();
+        let sched_err = archive.scheduler_at(99).unwrap_err().to_string();
+        cleanup(&dir);
+
+        assert!(opt_err.contains("out of range"), "got: {opt_err}");
+        assert!(sched_err.contains("out of range"), "got: {sched_err}");
+    }
+
+    #[test]
     fn model_at_missing_model_file_fails() {
         let dir = temp_dir("model_at_missing");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
         recorder
             .write(
                 &sample_model(),
@@ -525,7 +558,7 @@ mod tests {
     #[test]
     fn model_at_corrupt_model_file_fails() {
         let dir = temp_dir("model_at_corrupt");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
         recorder
             .write(
                 &sample_model(),
@@ -551,7 +584,7 @@ mod tests {
     #[test]
     fn evaluation_history_corrupted_evaluations_json_fails() {
         let dir = temp_dir("corrupt_evals");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
         recorder
             .write(
                 &sample_model(),
@@ -577,7 +610,7 @@ mod tests {
     #[test]
     fn on_checkpoint_writes_a_checkpoint() {
         let dir = temp_dir("on_checkpoint");
-        let mut recorder = create_run(&dir, "ds", false).unwrap();
+        let mut recorder = create_run(&dir, "ds", false);
 
         recorder
             .on_checkpoint(
@@ -599,7 +632,7 @@ mod tests {
     #[test]
     fn write_with_adam_writes_optimizer_state() {
         let dir = temp_dir("optimizer_adam");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
 
         let mut optimizer = sample_optimizer();
         let mut trained_model = sample_model();
@@ -637,7 +670,7 @@ mod tests {
     #[test]
     fn write_with_sgd_writes_no_optimizer_file() {
         let dir = temp_dir("optimizer_sgd");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
 
         let optimizer = StochasticGradientDescent::new(0.01.try_into().unwrap());
         recorder
@@ -662,7 +695,7 @@ mod tests {
     #[test]
     fn write_with_stateful_scheduler_writes_scheduler_state() {
         let dir = temp_dir("scheduler_step");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
 
         let mut scheduler = StepDecay::from_values(0.1, 2, 0.5).unwrap();
         scheduler.step();
@@ -691,7 +724,7 @@ mod tests {
     #[test]
     fn write_with_stateless_scheduler_writes_no_scheduler_file() {
         let dir = temp_dir("scheduler_constant");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
 
         recorder
             .write(
@@ -715,7 +748,7 @@ mod tests {
     #[test]
     fn write_fails_when_evaluations_path_is_a_directory() {
         let dir = temp_dir("write_evals_dir_conflict");
-        let recorder = create_run(&dir, "ds", false).unwrap();
+        let recorder = create_run(&dir, "ds", false);
 
         // Pre-create "evaluations.json" as a directory so json::save's fs::write fails.
         fs::create_dir_all(dir.join("checkpoint-000000").join("evaluations.json")).unwrap();

--- a/core/src/io/data.rs
+++ b/core/src/io/data.rs
@@ -1,4 +1,4 @@
-use crate::data::Dataset;
+use crate::data::{Dataset, DatasetOrigin};
 use crate::io::tensors;
 use ndarray::Array1;
 use safetensors::SafeTensors;
@@ -6,6 +6,24 @@ use std::collections::HashMap;
 use std::io::ErrorKind::InvalidData;
 use std::io::{Error, Result};
 use std::path::{Path, PathBuf};
+
+fn invalid<E: std::fmt::Display>(error: E) -> Error {
+    Error::new(InvalidData, error.to_string())
+}
+
+// safetensors tensor names.
+const FEATURES: &str = "features";
+const LABELS: &str = "labels";
+
+// `__metadata__` keys carrying the dataset's origin. The wire format is an I/O
+// concern, so the keys and discriminant live here; the `DatasetOrigin` type
+// itself stays serde-free in `crate::data`.
+const ORIGIN_KIND: &str = "origin";
+const ORIGIN_DISTRIBUTION: &str = "distribution";
+const ORIGIN_SOURCE: &str = "source";
+const ORIGIN_SEED: &str = "seed";
+const KIND_SYNTHETIC: &str = "synthetic";
+const KIND_ENCODED: &str = "encoded";
 
 pub fn save_inputs<P: AsRef<Path>>(path: P, inputs: &Array1<f32>) -> Result<()> {
     let entries = vec![("inputs".to_string(), tensors::tensor(inputs))];
@@ -15,38 +33,70 @@ pub fn save_inputs<P: AsRef<Path>>(path: P, inputs: &Array1<f32>) -> Result<()> 
 
 pub fn load_inputs<P: AsRef<Path>>(path: P) -> Result<Array1<f32>> {
     let bytes = tensors::load(path)?;
-    let st =
-        SafeTensors::deserialize(&bytes).map_err(|e| Error::new(InvalidData, e.to_string()))?;
+    let st = SafeTensors::deserialize(&bytes).map_err(invalid)?;
     tensors::read_array1("inputs", &st)
 }
 
+fn origin_into_metadata(origin: &DatasetOrigin) -> HashMap<String, String> {
+    match origin {
+        DatasetOrigin::Synthetic { distribution, seed } => HashMap::from([
+            (ORIGIN_KIND.to_string(), KIND_SYNTHETIC.to_string()),
+            (ORIGIN_DISTRIBUTION.to_string(), distribution.clone()),
+            (ORIGIN_SEED.to_string(), seed.to_string()),
+        ]),
+        DatasetOrigin::Encoded { source } => HashMap::from([
+            (ORIGIN_KIND.to_string(), KIND_ENCODED.to_string()),
+            (ORIGIN_SOURCE.to_string(), source.clone()),
+        ]),
+    }
+}
+
+fn origin_from_metadata(metadata: &HashMap<String, String>) -> Option<DatasetOrigin> {
+    match metadata.get(ORIGIN_KIND)?.as_str() {
+        KIND_SYNTHETIC => Some(DatasetOrigin::Synthetic {
+            distribution: metadata.get(ORIGIN_DISTRIBUTION)?.clone(),
+            seed: metadata.get(ORIGIN_SEED)?.parse().ok()?,
+        }),
+        KIND_ENCODED => Some(DatasetOrigin::Encoded {
+            source: metadata.get(ORIGIN_SOURCE)?.clone(),
+        }),
+        _ => None,
+    }
+}
+
 impl Dataset {
-    /// Saves the dataset to a `.safetensors` file.
+    /// Saves the dataset to a `.safetensors` file, persisting its [`origin`] (when
+    /// recorded) in the `__metadata__` map.
+    ///
+    /// [`origin`]: Dataset::origin
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf> {
         let entries = vec![
-            ("features".to_string(), tensors::tensor(&self.features)),
-            ("labels".to_string(), tensors::tensor(&self.labels)),
+            (FEATURES.to_string(), tensors::tensor(self.features())),
+            (LABELS.to_string(), tensors::tensor(self.labels())),
         ];
-        tensors::save(path, entries, HashMap::new())
+        let metadata = self.origin().map(origin_into_metadata).unwrap_or_default();
+        tensors::save(path, entries, metadata)
     }
 
-    /// Loads a dataset from a `.safetensors` file.
+    /// Loads a dataset from a `.safetensors` file, restoring its origin and
+    /// validating the tensors through [`Dataset::new`], so an ill-formed file is
+    /// rejected at the I/O boundary.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Dataset> {
         let bytes = tensors::load(path)?;
-        let st =
-            SafeTensors::deserialize(&bytes).map_err(|e| Error::new(InvalidData, e.to_string()))?;
+        let st = SafeTensors::deserialize(&bytes).map_err(invalid)?;
 
-        let features = tensors::read_array2("features", &st)?;
-        let labels = tensors::read_array1("labels", &st)?;
+        let features = tensors::read_array2(FEATURES, &st)?;
+        let labels = tensors::read_array1(LABELS, &st)?;
+        let origin = origin_from_metadata(&tensors::read_metadata(&bytes)?);
 
-        Ok(Dataset { features, labels })
+        Dataset::new(features, labels, origin).map_err(invalid)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{load_inputs, save_inputs};
-    use crate::data::Dataset;
+    use crate::data::{Dataset, DatasetOrigin};
     use ndarray::{Array2, array};
     use std::path::{Path, PathBuf};
 
@@ -60,20 +110,56 @@ mod tests {
         let _ = std::fs::remove_file(path.with_extension("safetensors"));
     }
 
-    #[test]
-    fn dataset_save_load_roundtrip() {
-        let dataset = Dataset {
-            features: Array2::from_shape_fn((3, 5), |(i, j)| (i * 5 + j) as f32 * 0.25),
-            labels: array![0.0, 1.0, 0.0, 2.0, 1.0],
-        };
+    fn dataset_with(origin: Option<DatasetOrigin>) -> Dataset {
+        Dataset::new(
+            Array2::from_shape_fn((5, 3), |(i, j)| (i * 3 + j) as f32 * 0.25),
+            array![0.0, 1.0, 0.0, 2.0, 1.0],
+            origin,
+        )
+        .unwrap()
+    }
 
+    #[test]
+    fn dataset_roundtrips_data_and_no_origin() {
+        let dataset = dataset_with(None);
         let path = temp_path("dataset");
+
         dataset.save(&path).unwrap();
         let loaded = Dataset::load(&path).unwrap();
         cleanup(&path);
 
-        assert_eq!(dataset.features, loaded.features);
-        assert_eq!(dataset.labels, loaded.labels);
+        assert_eq!(dataset.features(), loaded.features());
+        assert_eq!(dataset.labels(), loaded.labels());
+        assert_eq!(loaded.origin(), None);
+    }
+
+    #[test]
+    fn dataset_roundtrips_a_synthetic_origin() {
+        let origin = DatasetOrigin::Synthetic {
+            distribution: "spiral".to_string(),
+            seed: 42,
+        };
+        let path = temp_path("dataset_synthetic");
+
+        dataset_with(Some(origin.clone())).save(&path).unwrap();
+        let loaded = Dataset::load(&path).unwrap();
+        cleanup(&path);
+
+        assert_eq!(loaded.origin(), Some(&origin));
+    }
+
+    #[test]
+    fn dataset_roundtrips_an_encoded_origin() {
+        let origin = DatasetOrigin::Encoded {
+            source: "images/digits".to_string(),
+        };
+        let path = temp_path("dataset_encoded");
+
+        dataset_with(Some(origin.clone())).save(&path).unwrap();
+        let loaded = Dataset::load(&path).unwrap();
+        cleanup(&path);
+
+        assert_eq!(loaded.origin(), Some(&origin));
     }
 
     #[test]

--- a/core/src/io/data.rs
+++ b/core/src/io/data.rs
@@ -175,6 +175,55 @@ mod tests {
     }
 
     #[test]
+    fn malformed_or_unknown_origin_metadata_degrades_to_no_origin() {
+        // A recorded origin is best-effort: an unknown discriminant or a missing /
+        // unparseable field drops the origin rather than failing the load.
+        use super::{
+            KIND_ENCODED, KIND_SYNTHETIC, ORIGIN_DISTRIBUTION, ORIGIN_KIND, ORIGIN_SEED,
+            origin_from_metadata,
+        };
+        use std::collections::HashMap;
+
+        let cases = [
+            ("no kind", HashMap::new()),
+            (
+                "unknown kind",
+                HashMap::from([(ORIGIN_KIND.to_string(), "mystery".to_string())]),
+            ),
+            (
+                "synthetic without distribution",
+                HashMap::from([
+                    (ORIGIN_KIND.to_string(), KIND_SYNTHETIC.to_string()),
+                    (ORIGIN_SEED.to_string(), "7".to_string()),
+                ]),
+            ),
+            (
+                "synthetic without seed",
+                HashMap::from([
+                    (ORIGIN_KIND.to_string(), KIND_SYNTHETIC.to_string()),
+                    (ORIGIN_DISTRIBUTION.to_string(), "spiral".to_string()),
+                ]),
+            ),
+            (
+                "synthetic with non-numeric seed",
+                HashMap::from([
+                    (ORIGIN_KIND.to_string(), KIND_SYNTHETIC.to_string()),
+                    (ORIGIN_DISTRIBUTION.to_string(), "spiral".to_string()),
+                    (ORIGIN_SEED.to_string(), "not-a-number".to_string()),
+                ]),
+            ),
+            (
+                "encoded without source",
+                HashMap::from([(ORIGIN_KIND.to_string(), KIND_ENCODED.to_string())]),
+            ),
+        ];
+
+        for (label, metadata) in cases {
+            assert_eq!(origin_from_metadata(&metadata), None, "{label}");
+        }
+    }
+
+    #[test]
     fn load_rejects_corrupt_file() {
         let path = temp_path("data_corrupt");
         std::fs::write(
@@ -186,6 +235,36 @@ mod tests {
         assert!(Dataset::load(&path).is_err());
         assert!(load_inputs(&path).is_err());
 
+        cleanup(&path);
+    }
+
+    #[test]
+    fn load_rejects_tensors_that_violate_dataset_invariants() {
+        use super::{FEATURES, LABELS};
+        use crate::io::tensors;
+        use std::collections::HashMap;
+
+        // The tensors are individually well-formed, but two feature rows against
+        // three labels is a shape mismatch that `Dataset::new` rejects — so the
+        // load must fail at the I/O boundary rather than yield a bad dataset.
+        let path = temp_path("data_invariant");
+        tensors::save(
+            &path,
+            vec![
+                (
+                    FEATURES.to_string(),
+                    tensors::tensor(&array![[0.0_f32, 1.0, 2.0], [3.0, 4.0, 5.0]]),
+                ),
+                (
+                    LABELS.to_string(),
+                    tensors::tensor(&array![0.0_f32, 1.0, 0.0]),
+                ),
+            ],
+            HashMap::new(),
+        )
+        .unwrap();
+
+        assert!(Dataset::load(&path).is_err());
         cleanup(&path);
     }
 }

--- a/core/src/io/hyperparams.rs
+++ b/core/src/io/hyperparams.rs
@@ -364,9 +364,39 @@ mod tests {
 
     #[test]
     fn record_roundtrips_through_the_domain_spec() {
-        let record = HyperParametersRecord::sample();
-        let hyperparameters = HyperParameters::try_from(record.clone()).unwrap();
-        assert_eq!(HyperParametersRecord::from(&hyperparameters), record);
+        // The conversion is lossless both ways for *every* optimizer and scheduler
+        // variant, not just the sample's — exercising both projection directions
+        // (`From<&Config>` and the `TryFrom` back) for each.
+        let with_sgd = HyperParametersRecord {
+            optimizer: OptimizerRecord::Sgd,
+            ..HyperParametersRecord::sample()
+        };
+        let with_cosine = HyperParametersRecord {
+            scheduler: SchedulerRecord::Cosine {
+                lr_min: 0.0001,
+                steps: 100,
+                warm_restarts: true,
+                cycle_multiplier: 2,
+            },
+            ..HyperParametersRecord::sample()
+        };
+        let with_step = HyperParametersRecord {
+            scheduler: SchedulerRecord::Step {
+                decay_factor: 0.5,
+                steps: 10,
+            },
+            ..HyperParametersRecord::sample()
+        };
+
+        for record in [
+            HyperParametersRecord::sample(),
+            with_sgd,
+            with_cosine,
+            with_step,
+        ] {
+            let hyperparameters = HyperParameters::try_from(record.clone()).unwrap();
+            assert_eq!(HyperParametersRecord::from(&hyperparameters), record);
+        }
     }
 
     #[test]

--- a/core/src/io/model.rs
+++ b/core/src/io/model.rs
@@ -198,4 +198,125 @@ mod tests {
 
         assert!(result.is_err());
     }
+
+    #[test]
+    fn load_rejects_truncated_or_malformed_files() {
+        use crate::io::tensors::{self, F32Tensor};
+        use ndarray::{Array1, array};
+        use std::collections::HashMap;
+
+        // A well-formed layer 0 (rank-2 weights, rank-1 biases). The activation
+        // value is irrelevant here: every case below fails *before* the activation
+        // is looked up, so any string serves.
+        let weights = || {
+            (
+                "layer0.weights".to_string(),
+                tensors::tensor(&array![[1.0_f32, 2.0]]),
+            )
+        };
+        let biases = || {
+            (
+                "layer0.biases".to_string(),
+                tensors::tensor(&Array1::<f32>::zeros(1)),
+            )
+        };
+        let activation = || ("layer0.activation".to_string(), "relu".to_string());
+        let one_layer = || HashMap::from([("n_layers".to_string(), "1".to_string()), activation()]);
+
+        // Each case is well-formed at the safetensors level but violates the model
+        // schema, so `load` must reject it — exercising the read guards that
+        // `model::load` delegates to `tensors` (missing key / missing tensor /
+        // wrong rank).
+        type Case = (
+            &'static str,
+            Vec<(String, F32Tensor)>,
+            HashMap<String, String>,
+        );
+        let cases: Vec<Case> = vec![
+            (
+                "n_layers metadata absent",
+                vec![weights(), biases()],
+                HashMap::from([activation()]),
+            ),
+            ("weights tensor absent", vec![biases()], one_layer()),
+            ("biases tensor absent", vec![weights()], one_layer()),
+            (
+                "activation metadata absent",
+                vec![weights(), biases()],
+                HashMap::from([("n_layers".to_string(), "1".to_string())]),
+            ),
+            (
+                "weights stored with the wrong rank",
+                vec![
+                    (
+                        "layer0.weights".to_string(),
+                        tensors::tensor(&array![1.0_f32, 2.0]),
+                    ),
+                    biases(),
+                ],
+                one_layer(),
+            ),
+        ];
+
+        for (i, (label, entries, metadata)) in cases.into_iter().enumerate() {
+            let path = temp_path(&format!("malformed_{i}"));
+            tensors::save(&path, entries, metadata).unwrap();
+            let result = NeuralNetwork::load(&path);
+            cleanup(&path);
+            assert!(result.is_err(), "{label} should be rejected");
+        }
+    }
+
+    #[test]
+    fn load_rejects_non_f32_weights() {
+        use safetensors::{Dtype, View, serialize};
+        use std::borrow::Cow;
+        use std::collections::HashMap;
+
+        // A weights tensor whose dtype is not f32 must be refused by the read
+        // guard `model::load` delegates to `tensors::read_f32`.
+        struct U8Tensor;
+        impl View for U8Tensor {
+            fn dtype(&self) -> Dtype {
+                Dtype::U8
+            }
+            fn shape(&self) -> &[usize] {
+                &[1, 1]
+            }
+            fn data(&self) -> Cow<'_, [u8]> {
+                Cow::Owned(vec![0])
+            }
+            fn data_len(&self) -> usize {
+                1
+            }
+        }
+
+        let metadata = HashMap::from([
+            ("n_layers".to_string(), "1".to_string()),
+            ("layer0.activation".to_string(), "relu".to_string()),
+        ]);
+        let bytes = serialize(
+            vec![("layer0.weights".to_string(), U8Tensor)],
+            Some(metadata),
+        )
+        .unwrap();
+
+        let path = temp_path("non_f32_weights").with_extension("safetensors");
+        path.parent().map(std::fs::create_dir_all);
+        std::fs::write(&path, bytes).unwrap();
+        let result = NeuralNetwork::load(path.with_extension(""));
+        let _ = std::fs::remove_file(&path);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn save_rejects_path_traversal() {
+        // Saving through a path that escapes the working directory is refused by
+        // the path guard in `tensors::save`; nothing is written.
+        let specs = NeuronLayerSpec::network_for(vec![2], &*RELU, 2);
+        let model = NeuralNetwork::initialization(2, &specs, 0);
+
+        assert!(model.save("../../nrn_traversal_model").is_err());
+    }
 }

--- a/core/src/io/optimizer.rs
+++ b/core/src/io/optimizer.rs
@@ -81,4 +81,51 @@ mod tests {
             .unwrap();
         assert_eq!(m_weights, &array![[1.0_f32, 2.0], [3.0, 4.0]].into_dyn());
     }
+
+    #[test]
+    fn load_rejects_missing_file() {
+        // No file is written: the read itself must fail, before any parsing.
+        let path = temp_path("absent");
+        assert!(load(&path).is_err());
+    }
+
+    #[test]
+    fn load_rejects_corrupt_file() {
+        let path = temp_path("corrupt");
+        std::fs::write(path.with_extension("safetensors"), b"not safetensors").unwrap();
+
+        assert!(load(&path).is_err());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn load_rejects_non_f32_tensor() {
+        use safetensors::{Dtype, View, serialize};
+        use std::borrow::Cow;
+
+        // A state file whose tensor is not f32 must be refused: the dtype guard in
+        // `read_arrayd` rejects it as the entries are read back.
+        struct U8Tensor;
+        impl View for U8Tensor {
+            fn dtype(&self) -> Dtype {
+                Dtype::U8
+            }
+            fn shape(&self) -> &[usize] {
+                &[1]
+            }
+            fn data(&self) -> Cow<'_, [u8]> {
+                Cow::Owned(vec![0])
+            }
+            fn data_len(&self) -> usize {
+                1
+            }
+        }
+
+        let bytes = serialize(vec![("layer0.m_weights".to_string(), U8Tensor)], None).unwrap();
+        let path = temp_path("non_f32");
+        std::fs::write(path.with_extension("safetensors"), bytes).unwrap();
+
+        assert!(load(&path).is_err());
+        cleanup(&path);
+    }
 }

--- a/core/src/io/run.rs
+++ b/core/src/io/run.rs
@@ -16,19 +16,6 @@ pub struct TrainingMeta {
     pub hyperparams: HyperParametersRecord,
 }
 
-impl TrainingMeta {
-    /// Loads the metadata from `meta.json` inside `dir`.
-    pub fn load<P: AsRef<Path>>(dir: P) -> Result<Self> {
-        let dir = Path::combine_safe_with_cwd(dir)?;
-        json::load(dir.join("meta"))
-    }
-
-    fn save<P: AsRef<Path>>(&self, dir: P) -> Result<PathBuf> {
-        let dir = Path::combine_safe_with_cwd(dir)?;
-        json::save(self, dir.join("meta"))
-    }
-}
-
 /// A handle to a training run directory: its location and run-level metadata.
 /// Produces [`CheckpointRecorder`]s (the pure runtime callback) and
 /// [`CheckpointArchive`]s (read-only access to recorded checkpoints).
@@ -59,7 +46,7 @@ impl TrainingRun {
             }
         }
 
-        meta.save(&dir)?;
+        json::save(meta, dir.join("meta"))?;
 
         Ok(TrainingRun {
             dir,
@@ -72,7 +59,7 @@ impl TrainingRun {
     /// Returns a `NotFound` error if the directory or its `meta.json` doesn't exist.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
         let dir = Path::combine_safe_with_cwd(path)?;
-        let meta = TrainingMeta::load(&dir)?;
+        let meta: TrainingMeta = json::load(dir.join("meta"))?;
         Ok(TrainingRun { dir, meta })
     }
 
@@ -141,10 +128,10 @@ mod tests {
         let dir = temp_dir("meta");
         TrainingRun::create(&dir, &meta("my_dataset"), false).unwrap();
 
-        let loaded = TrainingMeta::load(&dir).unwrap();
+        let loaded = TrainingRun::open(&dir).unwrap();
         cleanup(&dir);
 
-        assert_eq!(loaded.dataset, "my_dataset");
+        assert_eq!(loaded.meta().dataset, "my_dataset");
     }
 
     #[test]

--- a/core/src/io/tensors.rs
+++ b/core/src/io/tensors.rs
@@ -156,72 +156,15 @@ pub fn read_metadata(bytes: &[u8]) -> Result<HashMap<String, String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ndarray::array;
 
+    // The read guards (`read_f32` missing-tensor / wrong-rank / non-f32, `meta`
+    // missing-key, `read_arrayd` non-f32) are exercised through their higher-level
+    // callers — `model::load` and `optimizer::load` — rather than here, so the
+    // failure modes are tested at the API boundary that owns them. Only
+    // `read_metadata`'s own guard has no such caller (every caller reaches it after
+    // a successful `deserialize` of the same bytes), so it is tested directly.
     #[test]
     fn read_metadata_rejects_corrupt_bytes() {
         assert!(read_metadata(b"not a safetensors header").is_err());
-    }
-
-    #[test]
-    fn read_rejects_missing_tensor() {
-        let bytes = serialize(
-            vec![("present".to_string(), tensor(&array![1.0_f32, 2.0]))],
-            None,
-        )
-        .unwrap();
-        let st = SafeTensors::deserialize(&bytes).unwrap();
-
-        assert!(read_array1("absent", &st).is_err());
-    }
-
-    #[test]
-    fn read_rejects_wrong_rank() {
-        // A 2D tensor read back as 1D must fail the rank check.
-        let bytes = serialize(
-            vec![("matrix".to_string(), tensor(&array![[1.0_f32, 2.0]]))],
-            None,
-        )
-        .unwrap();
-        let st = SafeTensors::deserialize(&bytes).unwrap();
-
-        assert!(read_array1("matrix", &st).is_err());
-    }
-
-    #[test]
-    fn read_rejects_non_f32_dtype() {
-        // A tensor stored with a non-f32 dtype must be refused on read.
-        struct U8Tensor {
-            shape: Vec<usize>,
-        }
-        impl View for U8Tensor {
-            fn dtype(&self) -> Dtype {
-                Dtype::U8
-            }
-            fn shape(&self) -> &[usize] {
-                &self.shape
-            }
-            fn data(&self) -> Cow<'_, [u8]> {
-                Cow::Owned(vec![0])
-            }
-            fn data_len(&self) -> usize {
-                1
-            }
-        }
-
-        let bytes = serialize(
-            vec![("byte".to_string(), U8Tensor { shape: vec![1] })],
-            None,
-        )
-        .unwrap();
-        let st = SafeTensors::deserialize(&bytes).unwrap();
-
-        assert!(read_array1("byte", &st).is_err());
-    }
-
-    #[test]
-    fn meta_reports_missing_key() {
-        let metadata = HashMap::new();
-        assert!(meta(&metadata, "interval").is_err());
     }
 }

--- a/core/src/nn/optimizers/mod.rs
+++ b/core/src/nn/optimizers/mod.rs
@@ -23,6 +23,7 @@ use std::fmt;
 /// estimates), shaped like a model: named tensors of arbitrary rank plus
 /// scalar metadata. Serialization lives behind the `io` feature; this type
 /// stays free of serde/safetensors.
+#[derive(Debug)]
 pub struct OptimizerState {
     pub tensors: Vec<(String, ArrayD<f32>)>,
     pub metadata: HashMap<String, String>,

--- a/core/src/nn/schedulers/mod.rs
+++ b/core/src/nn/schedulers/mod.rs
@@ -17,6 +17,7 @@ use crate::learning_rate::LearningRate;
 /// Scheduler-agnostic snapshot of internal state (the current step count),
 /// for checkpointing and resuming. Serialization lives behind the `io`
 /// feature; this type stays free of serde/safetensors.
+#[derive(Debug)]
 pub struct SchedulerState {
     pub current_step: usize,
 }

--- a/core/tests/io_roundtrip.rs
+++ b/core/tests/io_roundtrip.rs
@@ -7,7 +7,6 @@ use nrn::activations::RELU;
 use nrn::data::Dataset;
 use nrn::data::scalers::{MinMaxScaler, Scaler, ScalerMethod};
 use nrn::evaluation::{Evaluation, EvaluationSet};
-use nrn::io::checkpoint::CheckpointArchive;
 use nrn::io::data::{load_inputs, save_inputs};
 use nrn::io::hyperparams::{
     ClippingRecord, HyperParametersRecord, LossRecord, OptimizerRecord, SchedulerRecord,
@@ -97,6 +96,7 @@ fn full_pipeline_roundtrips_through_safetensors() {
         false,
     )
     .unwrap();
+    assert_eq!(run.meta().dataset, "test_dataset");
     let mut recorder = run.recorder();
     let mut last_recorded_predictions = None;
 
@@ -141,7 +141,7 @@ fn full_pipeline_roundtrips_through_safetensors() {
         reloaded_model.predict(model_dataset.inputs.view())
     );
 
-    let archive = CheckpointArchive::load(&run_dir).unwrap();
+    let archive = run.archive().unwrap();
     assert_eq!(archive.len(), 2);
     // Last checkpoint was written at epoch 5, not at the final epoch.
     // Load the model lazily — only one in memory at a time.

--- a/core/tests/io_roundtrip.rs
+++ b/core/tests/io_roundtrip.rs
@@ -50,20 +50,22 @@ fn full_pipeline_roundtrips_through_safetensors() {
     let dir = temp_dir();
 
     // --- Dataset --------------------------------------------------------
-    let dataset = Dataset {
-        features: array![[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]],
-        labels: array![0.0, 1.0, 1.0, 0.0],
-    };
+    let dataset = Dataset::new(
+        array![[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]],
+        array![0.0, 1.0, 1.0, 0.0],
+        None,
+    )
+    .unwrap();
 
     let dataset_path = dir.join("dataset");
     dataset.save(&dataset_path).unwrap();
-    let loaded_dataset = Dataset::load(&dataset_path).unwrap();
-    assert_eq!(dataset.features, loaded_dataset.features);
-    assert_eq!(dataset.labels, loaded_dataset.labels);
+    let loaded = Dataset::load(&dataset_path).unwrap();
+    assert_eq!(dataset.features(), loaded.features());
+    assert_eq!(dataset.labels(), loaded.labels());
 
     // --- Scaler (serialized as JSON, not safetensors) -------------------
-    let scaler = ScalerMethod::MinMax(MinMaxScaler::default().fit(dataset.features.view()));
-    let mut expected = dataset.features.clone();
+    let scaler = ScalerMethod::MinMax(MinMaxScaler::default().fit(dataset.features().view()));
+    let mut expected = dataset.features().clone();
     scaler.apply_inplace(expected.view_mut());
 
     let scaler_path = dir.join("scaler");
@@ -71,7 +73,7 @@ fn full_pipeline_roundtrips_through_safetensors() {
     record.save(&scaler_path).unwrap();
     let reloaded_scaler: ScalerMethod = ScalerRecord::load(&scaler_path).unwrap().into();
 
-    let mut actual = dataset.features.clone();
+    let mut actual = dataset.features().clone();
     reloaded_scaler.apply_inplace(actual.view_mut());
     assert_eq!(expected, actual);
 


### PR DESCRIPTION
## Summary

- **Validated `Dataset` constructor.** Fields are now private behind `Dataset::new`, which checks shape consistency, label validity, and class count up front. The asserts previously scattered in `to_model_dataset` are subsumed by this single boundary.
- **Reworked synthetic generation** around a `SynthParams` (validated sizing) + `Distribution` (per-variant shape knobs) → `SynthDataset` split. Each generator (`uniform` / `ring` / `spiral`) now owns a `validate()` beside its `fill()`, and `SynthDataset::new` dispatches to it. Adds the **spiral** generator (interleaved arms, the canonical non-linearly-separable benchmark).
- **Dataset provenance.** New serde-free `DatasetOrigin` records how a dataset was produced; synthetic datasets are stamped with their distribution + seed. `Dataset::id()` derives a default `synth` output filename from it. The wire-format round-trip lives in `io` (`core` types stay serde-free).
- Extensive added test coverage across `data` and `io`.

## Notes

- The CLI now exposes `--overlap` for rings. `ring::validate` rejects `overlap >= 1.0` and geometries whose rings overflow the feature range, returning a `SynthError` instead of tripping the internal `assert!` guards — generation stays panic-free as documented.
- `uniform::validate` is a deliberate no-op (blobs always fit); it exists for symmetry so every distribution validates itself next to where it fills.
- `Dataset` stays row-major `(samples, features)`; only `ModelDataset` is column-major, per the repo convention.