### PR TITLE
refactor(data): split-time shuffle, Classes type, output-named encode commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,8 @@ of the scikit-learn convention). `Dataset` (row-major, `(samples, features)`) co
 ### Data (`core/src/data/`)
 
 - **`dataset.rs`** — `Dataset` (raw) → `ModelDataset` (column-major). `batches()` shuffles and chunks
-  for mini-batch SGD; `split()` produces `ModelSplit` (train/val/test) from pre-shuffled data.
+  for mini-batch SGD; `split()` shuffles (seeded) then partitions into `ModelSplit` (train/val/test),
+  so producers store data in natural order and the run seed governs the partition.
 - **`preprocessors/scalers/`** — `Scaler` trait (`MinMax`, `ZScore`); `ScalerKind` names the method,
   `ScalerKind::fit` turns it into a fitted `ScalerMethod` (the dispatch enum carrying parameters).
   Params serialized to JSON for reuse at prediction time.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "console",
+ "image 0.25.10",
  "indicatif",
  "ndarray",
  "ndarray-rand",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,3 +21,4 @@ pathdiff = "0.2.3"
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"
+image = { version = "0.25.10", default-features = false, features = ["png"] }

--- a/cli/src/commands/encode.rs
+++ b/cli/src/commands/encode.rs
@@ -2,7 +2,6 @@ use crate::display::{Artifacts, bar, completed, saved, show};
 use crate::path::PathExt;
 use clap::{Args, Subcommand};
 use console::style;
-use ndarray_rand::rand::random;
 use nrn::data::vectorizers::{ImageEncoder, VectorEncoder};
 use nrn::data::{Classes, Dataset, Instance};
 use nrn::io::bytes::secure_read;
@@ -63,10 +62,6 @@ pub struct ImgDirArgs {
     #[arg(short, long)]
     output: Option<PathBuf>,
 
-    /// Seed for shuffling the dataset (random when omitted)
-    #[arg(long)]
-    seed: Option<u64>,
-
     #[command(flatten)]
     encoder: EncoderArgs,
 }
@@ -110,12 +105,7 @@ impl ImgDirArgs {
             progression.finish_and_clear();
         }
 
-        let dataset = Dataset::from_encoded(
-            self.seed.unwrap_or_else(random),
-            self.input.file_stem_string(),
-            data,
-            labels,
-        )?;
+        let dataset = Dataset::from_encoded(self.input.file_stem_string(), data, labels)?;
 
         completed!("Encoding completed");
 

--- a/cli/src/commands/encode.rs
+++ b/cli/src/commands/encode.rs
@@ -1,17 +1,14 @@
-use crate::display::bar;
-use crate::display::{Artifacts, completed, saved, trace};
+use crate::display::{Artifacts, bar, completed, saved, show};
 use crate::path::PathExt;
 use clap::{Args, Subcommand};
 use console::style;
-use ndarray_rand::rand::SeedableRng;
-use ndarray_rand::rand::prelude::StdRng;
+use ndarray_rand::rand::random;
 use nrn::data::vectorizers::{ImageEncoder, VectorEncoder};
-use nrn::data::{Dataset, DatasetOrigin, Instance};
+use nrn::data::{Classes, Dataset, Instance};
 use nrn::io::bytes::secure_read;
-use nrn::io::classes::extract_classes;
 use std::error::Error;
 use std::fs::read_dir;
-use std::path::Path;
+use std::path::PathBuf;
 
 #[derive(Args, Debug)]
 pub struct EncodeArgs {
@@ -21,9 +18,9 @@ pub struct EncodeArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum EncodeCommand {
-    /// Encode images from a directory into a dataset
+    /// Encode a directory of per-class image folders into a dataset
     ImgDir(ImgDirArgs),
-    /// Encode a single image
+    /// Encode a single image into an instance
     Img(ImgArgs),
 }
 
@@ -36,60 +33,61 @@ impl EncodeArgs {
     }
 }
 
+/// Image-to-vector encoding knobs shared by both subcommands.
 #[derive(Args, Debug)]
-pub struct ImgDirArgs {
-    /// Seed for shuffling the dataset
-    #[arg(long)]
-    seed: u64,
-
-    /// Path to the directory containing images
-    #[arg(short, long)]
-    input: String,
-
-    /// Path to save the encoded dataset
-    #[arg(short, long)]
-    output: String,
-
-    /// Indicates whether to convert images to grayscale
+pub struct EncoderArgs {
+    /// Convert images to grayscale instead of keeping RGB
     #[arg(long, default_value_t = false)]
     grayscale: bool,
 
-    /// Specify the image shape for encoding
+    /// Side length, in pixels, to resize each image to before flattening
     #[arg(short, long, default_value_t = 64, value_parser = clap::value_parser!(u32).range(1..=128))]
     shape: u32,
 }
 
+impl From<&EncoderArgs> for ImageEncoder {
+    fn from(args: &EncoderArgs) -> Self {
+        ImageEncoder {
+            img_shape: (args.shape, args.shape),
+            grayscale: args.grayscale,
+        }
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct ImgDirArgs {
+    /// Directory of per-class subfolders of images to encode
+    input: PathBuf,
+
+    /// Name to save the dataset under (defaults to the dataset's identifier)
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Seed for shuffling the dataset (random when omitted)
+    #[arg(long)]
+    seed: Option<u64>,
+
+    #[command(flatten)]
+    encoder: EncoderArgs,
+}
+
 impl ImgDirArgs {
     pub fn run(&self) -> Result<(), Box<dyn Error>> {
-        // Define categories by iterating over directories
-        let root = Path::new(&self.input);
+        let classes = Classes::scan(&self.input)?;
+        show(&classes);
 
-        let classes = extract_classes(&root)?;
-
-        trace(&format!(
-            "{}: {}",
-            style("Classes found").bright().cyan(),
-            classes
-                .iter()
-                .map(|(name, label)| format!(
-                    "{} (as {})",
-                    style(name).bright().blue(),
-                    style(label).yellow()
-                ))
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
+        let encoder = ImageEncoder::from(&self.encoder);
 
         let mut data = Vec::new();
         let mut labels = Vec::new();
 
         for (i, (category, label)) in classes.iter().enumerate() {
-            let total_img = read_dir(root.join(category))?
+            let entries = read_dir(self.input.join(category))?
                 .filter_map(Result::ok)
-                .count();
+                .collect::<Vec<_>>();
 
             let progression = bar(
-                total_img,
+                entries.len(),
                 format!(
                     "Encoding category [{}/{}]: {}",
                     i + 1,
@@ -98,12 +96,7 @@ impl ImgDirArgs {
                 ),
             );
 
-            let encoder = ImageEncoder {
-                img_shape: (self.shape, self.shape),
-                grayscale: self.grayscale,
-            };
-
-            for entry in read_dir(root.join(category))?.filter_map(Result::ok) {
+            for entry in entries {
                 progression.inc(1);
 
                 let img = secure_read(entry.path())?;
@@ -117,21 +110,19 @@ impl ImgDirArgs {
             progression.finish_and_clear();
         }
 
-        if data.is_empty() {
-            return Err("No images found in the specified directory".into());
-        }
-
-        let mut rng = StdRng::seed_from_u64(self.seed);
-        let origin = DatasetOrigin::Encoded {
-            source: Path::new(&self.input).file_stem_string(),
-        };
-        let dataset = Dataset::from_vec(&mut rng, data, labels, Some(origin))?;
+        let dataset = Dataset::from_encoded(
+            self.seed.unwrap_or_else(random),
+            self.input.file_stem_string(),
+            data,
+            labels,
+        )?;
 
         completed!("Encoding completed");
 
+        let filename = self.output.clone().unwrap_or_else(|| dataset.id().into());
         saved(&Artifacts::single(
             "Image Dataset",
-            dataset.save(&self.output)?,
+            dataset.save(&filename)?,
         ));
 
         Ok(())
@@ -140,36 +131,102 @@ impl ImgDirArgs {
 
 #[derive(Args, Debug)]
 pub struct ImgArgs {
-    /// Path to the image file to encode
+    /// Image file to encode
+    input: PathBuf,
+
+    /// Name to save the instance under (defaults to the image's file stem)
     #[arg(short, long)]
-    input: String,
+    output: Option<PathBuf>,
 
-    /// Path to save the encoded image
-    #[arg(short, long)]
-    output: String,
-
-    /// Indicates whether to convert the image to grayscale
-    #[arg(long, default_value_t = false)]
-    grayscale: bool,
-
-    /// Specify the image shape for encoding
-    #[arg(short, long, default_value_t = 64, value_parser = clap::value_parser!(u32).range(1..=128))]
-    shape: u32,
+    #[command(flatten)]
+    encoder: EncoderArgs,
 }
 
 impl ImgArgs {
+    /// The path to save the instance under: the `--output` override, or the input
+    /// image's file stem by default.
+    fn output_path(&self) -> PathBuf {
+        self.output
+            .clone()
+            .unwrap_or_else(|| self.input.file_stem_string().into())
+    }
+
     pub fn run(&self) -> Result<(), Box<dyn Error>> {
-        let encoder = ImageEncoder {
-            img_shape: (self.shape, self.shape),
-            grayscale: self.grayscale,
-        };
+        let encoder = ImageEncoder::from(&self.encoder);
 
-        let image = encoder.encode(&secure_read(Path::new(&self.input))?)?;
+        let image = encoder.encode(&secure_read(&self.input)?)?;
+        let instance = Instance::from(image);
 
-        Instance::from(image).save(&self.output)?;
+        completed!("Encoding completed");
 
-        println!("{}", style("Image encoded").bright().green());
+        saved(&Artifacts::single(
+            "Instance",
+            instance.save(self.output_path())?,
+        ));
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Cli {
+        #[command(flatten)]
+        encoder: EncoderArgs,
+    }
+
+    fn encoder(extra: &[&str]) -> ImageEncoder {
+        let mut argv = vec!["encode"];
+        argv.extend_from_slice(extra);
+        ImageEncoder::from(&Cli::parse_from(argv).encoder)
+    }
+
+    #[test]
+    fn encoder_defaults_to_rgb_64px() {
+        let encoder = encoder(&[]);
+        assert_eq!(encoder.img_shape, (64, 64));
+        assert!(!encoder.grayscale);
+    }
+
+    #[test]
+    fn shape_sets_both_dimensions() {
+        assert_eq!(encoder(&["--shape", "32"]).img_shape, (32, 32));
+    }
+
+    #[test]
+    fn grayscale_flag_selects_single_channel() {
+        assert!(encoder(&["--grayscale"]).grayscale);
+    }
+
+    #[derive(Parser)]
+    struct ImgCli {
+        #[command(flatten)]
+        args: ImgArgs,
+    }
+
+    fn img_args(extra: &[&str]) -> ImgArgs {
+        let mut argv = vec!["img"];
+        argv.extend_from_slice(extra);
+        ImgCli::parse_from(argv).args
+    }
+
+    #[test]
+    fn output_path_defaults_to_the_input_file_stem() {
+        assert_eq!(
+            img_args(&["pics/digit.png"]).output_path(),
+            PathBuf::from("digit")
+        );
+    }
+
+    #[test]
+    fn output_path_honours_the_override() {
+        assert_eq!(
+            img_args(&["pics/digit.png", "--output", "out/encoded"]).output_path(),
+            PathBuf::from("out/encoded")
+        );
     }
 }

--- a/cli/src/commands/encode.rs
+++ b/cli/src/commands/encode.rs
@@ -18,16 +18,18 @@ pub struct EncodeArgs {
 #[derive(Subcommand, Debug)]
 pub enum EncodeCommand {
     /// Encode a directory of per-class image folders into a dataset
-    ImgDir(ImgDirArgs),
+    #[command(visible_alias = "ds")]
+    Dataset(DatasetArgs),
     /// Encode a single image into an instance
-    Img(ImgArgs),
+    #[command(visible_alias = "inst")]
+    Instance(InstanceArgs),
 }
 
 impl EncodeArgs {
     pub fn run(self) -> Result<(), Box<dyn Error>> {
         match self.subcommand {
-            EncodeCommand::ImgDir(args) => args.run(),
-            EncodeCommand::Img(args) => args.run(),
+            EncodeCommand::Dataset(args) => args.run(),
+            EncodeCommand::Instance(args) => args.run(),
         }
     }
 }
@@ -54,7 +56,7 @@ impl From<&EncoderArgs> for ImageEncoder {
 }
 
 #[derive(Args, Debug)]
-pub struct ImgDirArgs {
+pub struct DatasetArgs {
     /// Directory of per-class subfolders of images to encode
     input: PathBuf,
 
@@ -66,7 +68,7 @@ pub struct ImgDirArgs {
     encoder: EncoderArgs,
 }
 
-impl ImgDirArgs {
+impl DatasetArgs {
     pub fn run(&self) -> Result<(), Box<dyn Error>> {
         let classes = Classes::scan(&self.input)?;
         show(&classes);
@@ -120,7 +122,7 @@ impl ImgDirArgs {
 }
 
 #[derive(Args, Debug)]
-pub struct ImgArgs {
+pub struct InstanceArgs {
     /// Image file to encode
     input: PathBuf,
 
@@ -132,7 +134,7 @@ pub struct ImgArgs {
     encoder: EncoderArgs,
 }
 
-impl ImgArgs {
+impl InstanceArgs {
     /// The path to save the instance under: the `--output` override, or the input
     /// image's file stem by default.
     fn output_path(&self) -> PathBuf {
@@ -195,11 +197,11 @@ mod tests {
     #[derive(Parser)]
     struct ImgCli {
         #[command(flatten)]
-        args: ImgArgs,
+        args: InstanceArgs,
     }
 
-    fn img_args(extra: &[&str]) -> ImgArgs {
-        let mut argv = vec!["img"];
+    fn img_args(extra: &[&str]) -> InstanceArgs {
+        let mut argv = vec!["instance"];
         argv.extend_from_slice(extra);
         ImgCli::parse_from(argv).args
     }
@@ -218,5 +220,23 @@ mod tests {
             img_args(&["pics/digit.png", "--output", "out/encoded"]).output_path(),
             PathBuf::from("out/encoded")
         );
+    }
+
+    #[derive(Parser)]
+    struct EncodeCli {
+        #[command(subcommand)]
+        command: EncodeCommand,
+    }
+
+    #[test]
+    fn ds_is_an_alias_for_dataset() {
+        let cli = EncodeCli::try_parse_from(["encode", "ds", "images/"]).unwrap();
+        assert!(matches!(cli.command, EncodeCommand::Dataset(_)));
+    }
+
+    #[test]
+    fn inst_is_an_alias_for_instance() {
+        let cli = EncodeCli::try_parse_from(["encode", "inst", "digit.png"]).unwrap();
+        assert!(matches!(cli.command, EncodeCommand::Instance(_)));
     }
 }

--- a/cli/src/commands/train/resume.rs
+++ b/cli/src/commands/train/resume.rs
@@ -63,7 +63,7 @@ impl ResumeArgs {
             None
         };
 
-        let data = hyperparameters.prepare(dataset.to_model_dataset(), scaler);
+        let data = hyperparameters.prepare(dataset, scaler);
 
         let callbacks = Callbacks::empty()
             .with(ConsoleMonitor::new(hyperparameters.clone(), Some(previous)))

--- a/cli/src/commands/train/start.rs
+++ b/cli/src/commands/train/start.rs
@@ -77,7 +77,7 @@ impl StartArgs {
             }
         };
 
-        let data = hyperparameters.prepare(dataset.to_model_dataset(), None);
+        let data = hyperparameters.prepare(dataset, None);
 
         let recorder = if hyperparameters.checkpoint_interval() > 0 {
             let meta = TrainingMeta {

--- a/cli/src/display/classes.rs
+++ b/cli/src/display/classes.rs
@@ -1,0 +1,19 @@
+use super::{Describe, Named, rows};
+use nrn::data::Classes;
+
+impl Named for Classes {
+    const NAME: &'static str = "CLASSES";
+}
+
+impl Describe for Classes {
+    /// One dotted-leader row per class, the class name labelling its integer
+    /// label, ordered by name.
+    fn describe(&self) -> String {
+        let entries = self
+            .iter()
+            .map(|(name, label)| (name.as_str(), label.to_string()))
+            .collect::<Vec<_>>();
+
+        rows(&entries)
+    }
+}

--- a/cli/src/display/dataset.rs
+++ b/cli/src/display/dataset.rs
@@ -17,8 +17,8 @@ impl Describe for Dataset {
             Some(DatasetOrigin::Synthetic { distribution, seed }) => {
                 entries.push(("Origin", format!("synthetic {distribution} (seed {seed})")));
             }
-            Some(DatasetOrigin::Encoded { source }) => {
-                entries.push(("Origin", format!("encoded from {source}")));
+            Some(DatasetOrigin::Encoded { source, seed }) => {
+                entries.push(("Origin", format!("encoded from {source} (seed {seed})")));
             }
             None => {}
         }

--- a/cli/src/display/dataset.rs
+++ b/cli/src/display/dataset.rs
@@ -17,8 +17,8 @@ impl Describe for Dataset {
             Some(DatasetOrigin::Synthetic { distribution, seed }) => {
                 entries.push(("Origin", format!("synthetic {distribution} (seed {seed})")));
             }
-            Some(DatasetOrigin::Encoded { source, seed }) => {
-                entries.push(("Origin", format!("encoded from {source} (seed {seed})")));
+            Some(DatasetOrigin::Encoded { source }) => {
+                entries.push(("Origin", format!("encoded from {source}")));
             }
             None => {}
         }

--- a/cli/src/display/dataset.rs
+++ b/cli/src/display/dataset.rs
@@ -26,3 +26,43 @@ impl Describe for Dataset {
         rows(&entries)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::display::Describe;
+    use ndarray::{Array2, array};
+    use nrn::data::{Dataset, DatasetOrigin};
+
+    fn dataset(origin: Option<DatasetOrigin>) -> Dataset {
+        // 4 samples (rows), 2 features, 2 classes.
+        Dataset::new(Array2::zeros((4, 2)), array![0.0f32, 1.0, 0.0, 1.0], origin).unwrap()
+    }
+
+    #[test]
+    fn describes_shape_and_omits_the_origin_row_when_absent() {
+        let described = dataset(None).describe();
+        assert!(described.contains("Features"));
+        assert!(described.contains("Classes"));
+        assert!(described.contains("Samples"));
+        assert!(!described.contains("Origin"));
+    }
+
+    #[test]
+    fn describes_a_synthetic_origin() {
+        let described = dataset(Some(DatasetOrigin::Synthetic {
+            distribution: "ring".to_string(),
+            seed: 42,
+        }))
+        .describe();
+        assert!(described.contains("synthetic ring (seed 42)"));
+    }
+
+    #[test]
+    fn describes_an_encoded_origin() {
+        let described = dataset(Some(DatasetOrigin::Encoded {
+            source: "imgs".to_string(),
+        }))
+        .describe();
+        assert!(described.contains("encoded from imgs"));
+    }
+}

--- a/cli/src/display/mod.rs
+++ b/cli/src/display/mod.rs
@@ -10,6 +10,7 @@
 
 mod artifacts;
 mod checkpoint;
+mod classes;
 mod classification;
 mod dataset;
 mod evaluation;
@@ -157,10 +158,6 @@ pub(crate) fn recording<E: Named + Describe>(entity: &E) {
 }
 
 // ─── Message verbs ──────────────────────────────────────────────────────────
-
-pub(crate) fn trace(message: &str) {
-    action(TRACE_ICON, message);
-}
 
 /// The inline prompt for the `index`-th feature value, leaving the cursor on the
 /// same line so the typed value follows it.

--- a/cli/tests/encode.rs
+++ b/cli/tests/encode.rs
@@ -1,0 +1,161 @@
+//! End-to-end coverage of the `encode` command: a directory of per-class image
+//! folders into a dataset (`encode dataset` / `ds`), and a single image into an
+//! instance (`encode instance` / `inst`), plus default output naming, the
+//! non-image skip, and the empty-input guard.
+//!
+//! Fixtures are tiny PNGs written into a temp dir created *under* the crate
+//! directory, so both this process and the `nrn` subprocess resolve them within
+//! the path-safety boundary (paths outside the cwd are rejected).
+
+use assert_cmd::Command;
+use image::{Rgb, RgbImage};
+use nrn::data::{Dataset, Instance};
+use predicates::str::contains;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// A temp dir under the crate directory (within the path-safety boundary).
+fn workspace() -> TempDir {
+    TempDir::new_in(".").unwrap()
+}
+
+/// Writes a 2x2 solid-color PNG at `path` (the encoder resizes, so size is moot).
+fn write_png(path: impl AsRef<Path>, color: [u8; 3]) {
+    let mut img = RgbImage::new(2, 2);
+    for pixel in img.pixels_mut() {
+        *pixel = Rgb(color);
+    }
+    img.save(path).unwrap();
+}
+
+/// A `root/<class>/...` tree of solid-color PNGs, one entry per `(class, file)`.
+fn class_dirs(root: &Path, classes: &[(&str, &[&str])]) {
+    for (class, files) in classes {
+        let dir = root.join(class);
+        fs::create_dir_all(&dir).unwrap();
+        for (i, file) in files.iter().enumerate() {
+            write_png(dir.join(file), [10 * i as u8, 0, 0]);
+        }
+    }
+}
+
+/// A fresh `nrn` invocation rooted at `dir`.
+fn nrn(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("nrn").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+#[test]
+fn encodes_a_directory_into_a_dataset() {
+    let tmp = workspace();
+    class_dirs(
+        &tmp.path().join("imgs"),
+        &[("cat", &["0.png", "1.png"]), ("dog", &["0.png"])],
+    );
+
+    nrn(tmp.path())
+        .args(["encode", "dataset", "imgs", "-o", "out", "--shape", "4"])
+        .assert()
+        .success()
+        .stdout(contains("Encoding completed"));
+
+    // RGB 4x4 = 48 features, 3 samples, 2 classes, origin label "imgs".
+    let dataset = Dataset::load(tmp.path().join("out")).unwrap();
+    assert_eq!(dataset.id(), "imgs-c2-f48-n3");
+}
+
+#[test]
+fn skips_non_image_files_when_encoding_a_dataset() {
+    let tmp = workspace();
+    let root = tmp.path().join("imgs");
+    class_dirs(&root, &[("cat", &["0.png"]), ("dog", &["0.png"])]);
+    // A stray non-image file in a class folder fails to encode and is skipped.
+    fs::write(root.join("cat").join("notes.txt"), b"not an image").unwrap();
+
+    nrn(tmp.path())
+        .args([
+            "encode",
+            "dataset",
+            "imgs",
+            "-o",
+            "out",
+            "--shape",
+            "2",
+            "--grayscale",
+        ])
+        .assert()
+        .success();
+
+    // Grayscale 2x2 = 4 features, only the 2 PNGs counted (the .txt is dropped).
+    let dataset = Dataset::load(tmp.path().join("out")).unwrap();
+    assert_eq!(dataset.id(), "imgs-c2-f4-n2");
+}
+
+#[test]
+fn ds_alias_defaults_the_output_name_to_the_dataset_id() {
+    let tmp = workspace();
+    class_dirs(
+        &tmp.path().join("imgs"),
+        &[("cat", &["0.png"]), ("dog", &["0.png"])],
+    );
+
+    nrn(tmp.path())
+        .args(["encode", "ds", "imgs", "--shape", "2", "--grayscale"])
+        .assert()
+        .success();
+
+    // No `-o`: the dataset is saved under its id.
+    assert!(tmp.path().join("imgs-c2-f4-n2.safetensors").exists());
+}
+
+#[test]
+fn errors_when_a_class_folder_has_no_images() {
+    let tmp = workspace();
+    class_dirs(&tmp.path().join("imgs"), &[("cat", &[]), ("dog", &[])]);
+
+    nrn(tmp.path())
+        .args(["encode", "dataset", "imgs"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn encodes_a_single_image_into_an_instance() {
+    let tmp = workspace();
+    write_png(tmp.path().join("digit.png"), [128, 64, 32]);
+
+    nrn(tmp.path())
+        .args(["encode", "instance", "digit.png", "--shape", "4"])
+        .assert()
+        .success()
+        .stdout(contains("Encoding completed"));
+
+    // No `-o`: the instance is saved under the image's file stem.
+    let instance = Instance::load(tmp.path().join("digit")).unwrap();
+    assert_eq!(instance.len(), 48); // RGB 4x4
+}
+
+#[test]
+fn inst_alias_honours_the_output_override() {
+    let tmp = workspace();
+    write_png(tmp.path().join("digit.png"), [128, 64, 32]);
+
+    nrn(tmp.path())
+        .args([
+            "encode",
+            "inst",
+            "digit.png",
+            "-o",
+            "vec",
+            "--shape",
+            "2",
+            "--grayscale",
+        ])
+        .assert()
+        .success();
+
+    let instance = Instance::load(tmp.path().join("vec")).unwrap();
+    assert_eq!(instance.len(), 4); // grayscale 2x2
+}

--- a/core/src/data/classes.rs
+++ b/core/src/data/classes.rs
@@ -1,0 +1,59 @@
+use std::collections::BTreeMap;
+
+/// A set of named classes, each mapped to a contiguous 0-indexed label.
+///
+/// A pure value object holding the name → label mapping, ordered by class name.
+/// The I/O layer owns how the classes are discovered (see [`Classes::scan`],
+/// behind the `io` feature).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Classes(BTreeMap<String, usize>);
+
+impl Classes {
+    /// Builds the mapping from `(name, label)` pairs.
+    pub fn new(classes: BTreeMap<String, usize>) -> Self {
+        Self(classes)
+    }
+
+    /// The number of classes.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether no class is present.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Iterates over the `(name, label)` pairs, ordered by class name.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &usize)> {
+        self.0.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Classes {
+        Classes::new(BTreeMap::from([
+            ("bird".to_string(), 0),
+            ("cat".to_string(), 1),
+        ]))
+    }
+
+    #[test]
+    fn len_and_emptiness_reflect_the_mapping() {
+        assert_eq!(sample().len(), 2);
+        assert!(!sample().is_empty());
+        assert!(Classes::new(BTreeMap::new()).is_empty());
+    }
+
+    #[test]
+    fn iter_yields_pairs_ordered_by_name() {
+        let pairs: Vec<(String, usize)> = sample()
+            .iter()
+            .map(|(name, &label)| (name.clone(), label))
+            .collect();
+        assert_eq!(pairs, vec![("bird".to_string(), 0), ("cat".to_string(), 1)]);
+    }
+}

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -302,6 +302,62 @@ impl Dataset {
 
         Ok(Dataset::new(features, labels, Some(origin))?)
     }
+
+    /// Shuffles the samples (seeded by `seed`) and partitions them into training,
+    /// validation, and testing sets by the given ratios, each as a [`ModelDataset`].
+    ///
+    /// # Parameters
+    /// - `val_ratio`: The ratio of the dataset to be used for validation (between 0 and 1).
+    /// - `test_ratio`: The ratio of the dataset to be used for testing (between 0 and 1).
+    /// - `seed`: Seeds the shuffle, so the partition is reproducible from it.
+    ///
+    /// # Panics
+    /// - When `val_ratio` is not between 0 and 1.
+    /// - When `test_ratio` is not between 0 and 1 or is equal to 0.
+    /// - When the sum of `val_ratio` and `test_ratio` is greater than or equal to 1.
+    //
+    pub fn split(&self, val_ratio: f32, test_ratio: f32, seed: u64) -> ModelSplit {
+        assert!(
+            (0.0..1.0).contains(&val_ratio),
+            "Validation ratio must be between 0 and 1"
+        );
+
+        assert!(
+            (0.0..1.0).contains(&test_ratio) && test_ratio > 0.0,
+            "Test ratio must be between 0 and 1 and greater than 0"
+        );
+
+        assert!(
+            val_ratio + test_ratio < 1.0,
+            "Sum of ratios must be less than 1"
+        );
+
+        let model = self.to_model_dataset();
+        let n_samples = model.targets.ncols();
+
+        let mut indices: Vec<usize> = (0..n_samples).collect();
+        indices.shuffle(&mut StdRng::seed_from_u64(seed));
+
+        let size = |ratio: f32| (n_samples as f32 * ratio).round() as usize;
+        let select = |idx: &[usize]| ModelDataset {
+            inputs: model.inputs.select(Axis(1), idx),
+            targets: model.targets.select(Axis(1), idx),
+        };
+
+        let test_size = size(test_ratio);
+        let val_size = size(val_ratio);
+        let train_size = n_samples - test_size - val_size;
+
+        ModelSplit {
+            train: select(&indices[..train_size]),
+            validation: if val_size > 0 {
+                Some(select(&indices[train_size..train_size + val_size]))
+            } else {
+                None
+            },
+            test: select(&indices[train_size + val_size..]),
+        }
+    }
 }
 
 impl ModelDataset {
@@ -343,61 +399,6 @@ impl ModelDataset {
     /// for the call.
     pub fn scale_inplace(&mut self, scaler: &dyn Scaler) {
         scaler.apply_inplace(self.inputs.view_mut().reversed_axes());
-    }
-
-    /// Shuffles the samples (seeded by `seed`) and partitions them into training,
-    /// validation, and testing sets by the given ratios.
-    ///
-    /// # Parameters
-    /// - `val_ratio`: The ratio of the dataset to be used for validation (between 0 and 1).
-    /// - `test_ratio`: The ratio of the dataset to be used for testing (between 0 and 1).
-    /// - `seed`: Seeds the shuffle, so the partition is reproducible from it.
-    ///
-    /// # Panics
-    /// - When `val_ratio` is not between 0 and 1.
-    /// - When `test_ratio` is not between 0 and 1 or is equal to 0.
-    /// - When the sum of `val_ratio` and `test_ratio` is greater than or equal to 1.
-    //
-    pub fn split(&self, val_ratio: f32, test_ratio: f32, seed: u64) -> ModelSplit {
-        assert!(
-            (0.0..1.0).contains(&val_ratio),
-            "Validation ratio must be between 0 and 1"
-        );
-
-        assert!(
-            (0.0..1.0).contains(&test_ratio) && test_ratio > 0.0,
-            "Test ratio must be between 0 and 1 and greater than 0"
-        );
-
-        assert!(
-            val_ratio + test_ratio < 1.0,
-            "Sum of ratios must be less than 1"
-        );
-
-        let n_samples = self.targets.ncols();
-
-        let mut indices: Vec<usize> = (0..n_samples).collect();
-        indices.shuffle(&mut StdRng::seed_from_u64(seed));
-
-        let size = |ratio: f32| (n_samples as f32 * ratio).round() as usize;
-        let select = |idx: &[usize]| ModelDataset {
-            inputs: self.inputs.select(Axis(1), idx),
-            targets: self.targets.select(Axis(1), idx),
-        };
-
-        let test_size = size(test_ratio);
-        let val_size = size(val_ratio);
-        let train_size = n_samples - test_size - val_size;
-
-        ModelSplit {
-            train: select(&indices[..train_size]),
-            validation: if val_size > 0 {
-                Some(select(&indices[train_size..train_size + val_size]))
-            } else {
-                None
-            },
-            test: select(&indices[train_size + val_size..]),
-        }
     }
 }
 
@@ -556,9 +557,9 @@ mod tests {
     #[test]
     fn split_ratios_produce_correct_sizes() {
         // 100 samples, 20% test, 10% val → 70 train / 10 val / 20 test
-        let inputs = Array2::zeros((2, 100));
-        let targets = Array2::zeros((1, 100));
-        let dataset = ModelDataset { inputs, targets };
+        let features = Array2::zeros((100, 2));
+        let labels = Array1::from_shape_fn(100, |i| (i % 2) as f32);
+        let dataset = Dataset::new(features, labels, None).unwrap();
         let split = dataset.split(0.1, 0.2, 0);
         assert_eq!(split.train_size(), 70);
         assert_eq!(split.validation_size(), 10);
@@ -568,9 +569,11 @@ mod tests {
     #[test]
     fn split_without_validation_yields_no_validation_set() {
         // val_ratio 0.0 → the validation split is None.
-        let inputs = Array2::from_shape_fn((2, 100), |(_, j)| j as f32);
-        let targets = Array2::zeros((1, 100));
-        let mut split = ModelDataset { inputs, targets }.split(0.0, 0.2, 0);
+        let features = Array2::from_shape_fn((100, 2), |(i, _)| i as f32);
+        let labels = Array1::from_shape_fn(100, |i| (i % 2) as f32);
+        let mut split = Dataset::new(features, labels, None)
+            .unwrap()
+            .split(0.0, 0.2, 0);
         assert!(split.validation.is_none());
         assert_eq!(split.train_size(), 80);
         assert_eq!(split.test_size(), 20);
@@ -674,7 +677,7 @@ mod tests {
         let labels = Array1::from_shape_fn(10, |i| (i % 2) as f32);
         let dataset = Dataset::new(features, labels, None).unwrap();
 
-        let mut split = dataset.to_model_dataset().split(0.2, 0.2, 0);
+        let mut split = dataset.split(0.2, 0.2, 0);
         let scaler = split.train.fit_scaler(ScalerKind::MinMax);
         split.scale_inplace(&scaler);
 

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -2,7 +2,8 @@ use crate::data::origin::DatasetOrigin;
 use crate::data::scalers::{Scaler, ScalerKind, ScalerMethod};
 use ndarray::{Array1, Array2, Axis, s};
 use ndarray_rand::rand::Rng;
-use ndarray_rand::rand::prelude::SliceRandom;
+use ndarray_rand::rand::SeedableRng;
+use ndarray_rand::rand::prelude::{SliceRandom, StdRng};
 use std::collections::HashSet;
 use std::error::Error;
 
@@ -290,22 +291,23 @@ impl Dataset {
         self
     }
 
-    /// Creates a new dataset from a vector of images and their corresponding labels.
+    /// Builds a shuffled dataset from encoded `images` and their `labels`, stamped
+    /// with [`DatasetOrigin::Encoded`] provenance whose sample order is
+    /// reproducible from `seed`.
     /// # Arguments
-    /// - `rng`: A mutable reference to a random number generator for shuffling.
+    /// - `seed`: Seeds the shuffle and is recorded in the origin for reproducibility.
+    /// - `source`: Name of the source the images were encoded from.
     /// - `images`: A vector of images represented as 1D arrays of pixel values.
     /// - `labels`: A vector of labels corresponding to each image.
-    /// - `origin`: Where the images were encoded from, when known.
-    pub fn from_vec<R: Rng>(
-        rng: &mut R,
+    pub fn from_encoded(
+        seed: u64,
+        source: impl Into<String>,
         images: Vec<Array1<f32>>,
         labels: Vec<usize>,
-        origin: Option<DatasetOrigin>,
     ) -> Result<Self, Box<dyn Error>> {
-        assert!(
-            !images.is_empty(),
-            "Images vector must not be empty to create a dataset"
-        );
+        if images.is_empty() {
+            return Err(DatasetError::NoSamples.into());
+        }
 
         let features: Array2<f32> = Array2::from_shape_vec(
             (images.len(), images[0].len()),
@@ -315,7 +317,13 @@ impl Dataset {
         let labels: Array1<f32> =
             Array1::from(labels.into_iter().map(|x| x as f32).collect::<Vec<_>>());
 
-        Ok(Dataset::new(features, labels, origin)?.shuffled(rng))
+        let origin = DatasetOrigin::Encoded {
+            source: source.into(),
+            seed,
+        };
+
+        let mut rng = StdRng::seed_from_u64(seed);
+        Ok(Dataset::new(features, labels, Some(origin))?.shuffled(&mut rng))
     }
 }
 
@@ -447,8 +455,6 @@ impl ModelSplit {
 mod tests {
     use super::*;
     use ndarray::{Array1, Array2, array};
-    use ndarray_rand::rand::SeedableRng;
-    use ndarray_rand::rand::prelude::StdRng;
 
     #[test]
     fn new_rejects_out_of_range_multiclass_label() {
@@ -598,23 +604,30 @@ mod tests {
     }
 
     #[test]
-    fn from_vec_rejects_inconsistent_image_sizes() {
-        // Images of differing lengths cannot form a rectangular matrix → Err.
-        let mut rng = StdRng::seed_from_u64(0);
-        let images = vec![array![0.0f32, 1.0], array![2.0, 3.0, 4.0]];
-        let labels = vec![0usize, 1];
-        assert!(Dataset::from_vec(&mut rng, images, labels, None).is_err());
+    fn from_encoded_rejects_empty_images() {
+        // No images → no samples, surfaced as a Result rather than a panic.
+        let err = Dataset::from_encoded(0, "test", vec![], vec![])
+            .err()
+            .unwrap();
+        assert_eq!(err.to_string(), DatasetError::NoSamples.to_string());
     }
 
     #[test]
-    fn from_vec_propagates_dataset_validation_error() {
-        // The images form a valid rectangular matrix, but `from_vec` does not
+    fn from_encoded_rejects_inconsistent_image_sizes() {
+        // Images of differing lengths cannot form a rectangular matrix → Err.
+        let images = vec![array![0.0f32, 1.0], array![2.0, 3.0, 4.0]];
+        let labels = vec![0usize, 1];
+        assert!(Dataset::from_encoded(0, "test", images, labels).is_err());
+    }
+
+    #[test]
+    fn from_encoded_propagates_dataset_validation_error() {
+        // The images form a valid rectangular matrix, but `from_encoded` does not
         // check that there are as many labels as images — it delegates to
         // `Dataset::new`, which rejects the count mismatch.
-        let mut rng = StdRng::seed_from_u64(0);
         let images = vec![array![0.0f32, 1.0], array![2.0, 3.0]];
         let labels = vec![0usize]; // one label for two images
-        let err = Dataset::from_vec(&mut rng, images, labels, None)
+        let err = Dataset::from_encoded(0, "test", images, labels)
             .err()
             .unwrap();
         assert!(
@@ -704,17 +717,25 @@ mod tests {
     }
 
     #[test]
-    fn from_vec_builds_dataset_from_images() {
-        let mut rng = StdRng::seed_from_u64(42);
+    fn from_encoded_builds_dataset_from_images() {
         let images = vec![array![0.0f32, 1.0], array![2.0, 3.0], array![4.0, 5.0]];
         let labels = vec![0usize, 1, 2];
 
-        let dataset = Dataset::from_vec(&mut rng, images, labels, None).unwrap();
+        let dataset = Dataset::from_encoded(42, "digits", images, labels).unwrap();
         assert_eq!(dataset.features().shape(), &[3, 2]);
         assert_eq!(dataset.labels().len(), 3);
         let mut unique = dataset.unique_labels();
         unique.sort_by(f32::total_cmp);
         assert_eq!(unique, vec![0.0, 1.0, 2.0]);
+
+        // The seed is stamped into the origin, so the dataset is reproducible.
+        assert_eq!(
+            dataset.origin(),
+            Some(&DatasetOrigin::Encoded {
+                source: "digits".to_string(),
+                seed: 42,
+            })
+        );
     }
 
     #[test]

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -1,6 +1,6 @@
 use crate::data::origin::DatasetOrigin;
 use crate::data::scalers::{Scaler, ScalerKind, ScalerMethod};
-use ndarray::{Array1, Array2, Axis, s};
+use ndarray::{Array1, Array2, Axis};
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::prelude::{SliceRandom, StdRng};
@@ -271,36 +271,15 @@ impl Dataset {
         ModelDataset { inputs, targets }
     }
 
-    /// Shuffles the dataset features and labels in unison and returns it, so
-    /// construction and shuffling can be chained (`Dataset::new(..)?.shuffled(rng)`).
-    ///
-    /// Reordering preserves every dataset invariant, so the result needs no
-    /// re-validation.
+    /// Builds a dataset from encoded `images` and their `labels`, stamped with
+    /// [`DatasetOrigin::Encoded`] provenance. Samples are kept in the order they
+    /// were encoded (grouped by class); shuffling is deferred to
+    /// [`ModelDataset::split`], so the stored order carries no randomness.
     /// # Arguments
-    /// - `rng`: A mutable reference to a random number generator.
-    /// # Details
-    /// - Generates a vector of indices over the samples and shuffles it.
-    /// - Reorders both `features` and `labels` by those indices, keeping the
-    ///   feature/label correspondence intact.
-    pub fn shuffled<R: Rng + ?Sized>(mut self, rng: &mut R) -> Self {
-        let mut indices: Vec<usize> = (0..self.features.nrows()).collect();
-        indices.shuffle(rng);
-
-        self.features = self.features.select(Axis(0), &indices);
-        self.labels = self.labels.select(Axis(0), &indices);
-        self
-    }
-
-    /// Builds a shuffled dataset from encoded `images` and their `labels`, stamped
-    /// with [`DatasetOrigin::Encoded`] provenance whose sample order is
-    /// reproducible from `seed`.
-    /// # Arguments
-    /// - `seed`: Seeds the shuffle and is recorded in the origin for reproducibility.
     /// - `source`: Name of the source the images were encoded from.
     /// - `images`: A vector of images represented as 1D arrays of pixel values.
     /// - `labels`: A vector of labels corresponding to each image.
     pub fn from_encoded(
-        seed: u64,
         source: impl Into<String>,
         images: Vec<Array1<f32>>,
         labels: Vec<usize>,
@@ -319,11 +298,9 @@ impl Dataset {
 
         let origin = DatasetOrigin::Encoded {
             source: source.into(),
-            seed,
         };
 
-        let mut rng = StdRng::seed_from_u64(seed);
-        Ok(Dataset::new(features, labels, Some(origin))?.shuffled(&mut rng))
+        Ok(Dataset::new(features, labels, Some(origin))?)
     }
 }
 
@@ -368,22 +345,20 @@ impl ModelDataset {
         scaler.apply_inplace(self.inputs.view_mut().reversed_axes());
     }
 
-    /// Splits the model dataset into training, validation, and testing sets based on the provided ratios.
+    /// Shuffles the samples (seeded by `seed`) and partitions them into training,
+    /// validation, and testing sets by the given ratios.
     ///
     /// # Parameters
     /// - `val_ratio`: The ratio of the dataset to be used for validation (between 0 and 1).
     /// - `test_ratio`: The ratio of the dataset to be used for testing (between 0 and 1).
-    ///
-    /// # Important
-    /// This method does **not** shuffle the dataset. It assumes the dataset has already been shuffled.
-    /// If the dataset is not shuffled, the split may not be representative.
+    /// - `seed`: Seeds the shuffle, so the partition is reproducible from it.
     ///
     /// # Panics
     /// - When `val_ratio` is not between 0 and 1.
     /// - When `test_ratio` is not between 0 and 1 or is equal to 0.
     /// - When the sum of `val_ratio` and `test_ratio` is greater than or equal to 1.
     //
-    pub fn split(&self, val_ratio: f32, test_ratio: f32) -> ModelSplit {
+    pub fn split(&self, val_ratio: f32, test_ratio: f32, seed: u64) -> ModelSplit {
         assert!(
             (0.0..1.0).contains(&val_ratio),
             "Validation ratio must be between 0 and 1"
@@ -401,10 +376,13 @@ impl ModelDataset {
 
         let n_samples = self.targets.ncols();
 
+        let mut indices: Vec<usize> = (0..n_samples).collect();
+        indices.shuffle(&mut StdRng::seed_from_u64(seed));
+
         let size = |ratio: f32| (n_samples as f32 * ratio).round() as usize;
-        let slice = |start: usize, end: usize| ModelDataset {
-            inputs: self.inputs.slice(s![.., start..end]).to_owned(),
-            targets: self.targets.slice(s![.., start..end]).to_owned(),
+        let select = |idx: &[usize]| ModelDataset {
+            inputs: self.inputs.select(Axis(1), idx),
+            targets: self.targets.select(Axis(1), idx),
         };
 
         let test_size = size(test_ratio);
@@ -412,13 +390,13 @@ impl ModelDataset {
         let train_size = n_samples - test_size - val_size;
 
         ModelSplit {
-            train: slice(0, train_size),
+            train: select(&indices[..train_size]),
             validation: if val_size > 0 {
-                Some(slice(train_size, train_size + val_size))
+                Some(select(&indices[train_size..train_size + val_size]))
             } else {
                 None
             },
-            test: slice(train_size + val_size, n_samples),
+            test: select(&indices[train_size + val_size..]),
         }
     }
 }
@@ -581,7 +559,7 @@ mod tests {
         let inputs = Array2::zeros((2, 100));
         let targets = Array2::zeros((1, 100));
         let dataset = ModelDataset { inputs, targets };
-        let split = dataset.split(0.1, 0.2);
+        let split = dataset.split(0.1, 0.2, 0);
         assert_eq!(split.train_size(), 70);
         assert_eq!(split.validation_size(), 10);
         assert_eq!(split.test_size(), 20);
@@ -592,7 +570,7 @@ mod tests {
         // val_ratio 0.0 → the validation split is None.
         let inputs = Array2::from_shape_fn((2, 100), |(_, j)| j as f32);
         let targets = Array2::zeros((1, 100));
-        let mut split = ModelDataset { inputs, targets }.split(0.0, 0.2);
+        let mut split = ModelDataset { inputs, targets }.split(0.0, 0.2, 0);
         assert!(split.validation.is_none());
         assert_eq!(split.train_size(), 80);
         assert_eq!(split.test_size(), 20);
@@ -606,9 +584,7 @@ mod tests {
     #[test]
     fn from_encoded_rejects_empty_images() {
         // No images → no samples, surfaced as a Result rather than a panic.
-        let err = Dataset::from_encoded(0, "test", vec![], vec![])
-            .err()
-            .unwrap();
+        let err = Dataset::from_encoded("test", vec![], vec![]).err().unwrap();
         assert_eq!(err.to_string(), DatasetError::NoSamples.to_string());
     }
 
@@ -617,7 +593,7 @@ mod tests {
         // Images of differing lengths cannot form a rectangular matrix → Err.
         let images = vec![array![0.0f32, 1.0], array![2.0, 3.0, 4.0]];
         let labels = vec![0usize, 1];
-        assert!(Dataset::from_encoded(0, "test", images, labels).is_err());
+        assert!(Dataset::from_encoded("test", images, labels).is_err());
     }
 
     #[test]
@@ -627,9 +603,7 @@ mod tests {
         // `Dataset::new`, which rejects the count mismatch.
         let images = vec![array![0.0f32, 1.0], array![2.0, 3.0]];
         let labels = vec![0usize]; // one label for two images
-        let err = Dataset::from_encoded(0, "test", images, labels)
-            .err()
-            .unwrap();
+        let err = Dataset::from_encoded("test", images, labels).err().unwrap();
         assert!(
             err.to_string().contains("disagree on sample count"),
             "got: {err}"
@@ -700,7 +674,7 @@ mod tests {
         let labels = Array1::from_shape_fn(10, |i| (i % 2) as f32);
         let dataset = Dataset::new(features, labels, None).unwrap();
 
-        let mut split = dataset.to_model_dataset().split(0.2, 0.2);
+        let mut split = dataset.to_model_dataset().split(0.2, 0.2, 0);
         let scaler = split.train.fit_scaler(ScalerKind::MinMax);
         split.scale_inplace(&scaler);
 
@@ -721,19 +695,18 @@ mod tests {
         let images = vec![array![0.0f32, 1.0], array![2.0, 3.0], array![4.0, 5.0]];
         let labels = vec![0usize, 1, 2];
 
-        let dataset = Dataset::from_encoded(42, "digits", images, labels).unwrap();
+        let dataset = Dataset::from_encoded("digits", images, labels).unwrap();
         assert_eq!(dataset.features().shape(), &[3, 2]);
         assert_eq!(dataset.labels().len(), 3);
         let mut unique = dataset.unique_labels();
         unique.sort_by(f32::total_cmp);
         assert_eq!(unique, vec![0.0, 1.0, 2.0]);
 
-        // The seed is stamped into the origin, so the dataset is reproducible.
+        // The source is stamped into the origin.
         assert_eq!(
             dataset.origin(),
             Some(&DatasetOrigin::Encoded {
                 source: "digits".to_string(),
-                seed: 42,
             })
         );
     }

--- a/core/src/data/mod.rs
+++ b/core/src/data/mod.rs
@@ -1,8 +1,10 @@
+mod classes;
 mod dataset;
 mod instance;
 mod origin;
 mod preprocessors;
 
+pub use classes::*;
 pub use dataset::*;
 pub use instance::*;
 pub use origin::*;

--- a/core/src/data/origin.rs
+++ b/core/src/data/origin.rs
@@ -7,8 +7,9 @@
 pub enum DatasetOrigin {
     /// Produced by a synthetic generator, reproducible from `distribution` + `seed`.
     Synthetic { distribution: String, seed: u64 },
-    /// Encoded from a directory of images at `source`.
-    Encoded { source: String },
+    /// Encoded from a directory of images at `source`, its sample order
+    /// reproducible from `seed`.
+    Encoded { source: String, seed: u64 },
 }
 
 impl DatasetOrigin {
@@ -17,7 +18,7 @@ impl DatasetOrigin {
     pub fn label(&self) -> String {
         match self {
             DatasetOrigin::Synthetic { distribution, seed } => format!("{distribution}-seed{seed}"),
-            DatasetOrigin::Encoded { source } => source.clone(),
+            DatasetOrigin::Encoded { source, seed } => format!("{source}-seed{seed}"),
         }
     }
 }
@@ -36,10 +37,11 @@ mod tests {
     }
 
     #[test]
-    fn encoded_label_is_the_source_name() {
+    fn encoded_label_carries_source_and_seed() {
         let origin = DatasetOrigin::Encoded {
             source: "mnist".to_string(),
+            seed: 7,
         };
-        assert_eq!(origin.label(), "mnist");
+        assert_eq!(origin.label(), "mnist-seed7");
     }
 }

--- a/core/src/data/origin.rs
+++ b/core/src/data/origin.rs
@@ -7,9 +7,8 @@
 pub enum DatasetOrigin {
     /// Produced by a synthetic generator, reproducible from `distribution` + `seed`.
     Synthetic { distribution: String, seed: u64 },
-    /// Encoded from a directory of images at `source`, its sample order
-    /// reproducible from `seed`.
-    Encoded { source: String, seed: u64 },
+    /// Encoded from a directory of images at `source`.
+    Encoded { source: String },
 }
 
 impl DatasetOrigin {
@@ -18,7 +17,7 @@ impl DatasetOrigin {
     pub fn label(&self) -> String {
         match self {
             DatasetOrigin::Synthetic { distribution, seed } => format!("{distribution}-seed{seed}"),
-            DatasetOrigin::Encoded { source, seed } => format!("{source}-seed{seed}"),
+            DatasetOrigin::Encoded { source } => source.clone(),
         }
     }
 }
@@ -37,11 +36,10 @@ mod tests {
     }
 
     #[test]
-    fn encoded_label_carries_source_and_seed() {
+    fn encoded_label_is_the_source() {
         let origin = DatasetOrigin::Encoded {
             source: "mnist".to_string(),
-            seed: 7,
         };
-        assert_eq!(origin.label(), "mnist-seed7");
+        assert_eq!(origin.label(), "mnist");
     }
 }

--- a/core/src/data/synth/mod.rs
+++ b/core/src/data/synth/mod.rs
@@ -250,7 +250,6 @@ impl SynthDataset {
 
         Dataset::new(features, labels, Some(origin))
             .expect("synthetic parameters guarantee a valid dataset")
-            .shuffled(&mut rng)
     }
 }
 

--- a/core/src/io/classes.rs
+++ b/core/src/io/classes.rs
@@ -1,3 +1,4 @@
+use crate::data::Classes;
 use crate::io::path::PathExt;
 use fs::read_dir;
 use std::collections::BTreeMap;
@@ -5,29 +6,27 @@ use std::error::Error;
 use std::fs;
 use std::path::Path;
 
-type ClassMap = BTreeMap<String, usize>;
+impl Classes {
+    /// Scans `root` for class subdirectories, mapping each subdirectory name to a
+    /// contiguous 0-indexed label assigned in sorted name order. Stray files are
+    /// ignored: only subdirectories become classes.
+    pub fn scan<P: AsRef<Path>>(root: P) -> Result<Self, Box<dyn Error>> {
+        let mut directories = read_dir(Path::combine_safe_with_cwd(root)?)?
+            .filter_map(Result::ok)
+            .filter(|e| e.path().is_dir())
+            .collect::<Vec<_>>();
 
-/// Extract class names from subdirectory names within the given root directory.
-pub fn extract_classes<P: AsRef<Path>>(root: &P) -> Result<ClassMap, Box<dyn Error>> {
-    let mut classes = BTreeMap::new();
+        directories.sort_by_key(|e| e.file_name());
 
-    let mut directories = read_dir(Path::combine_safe_with_cwd(root)?)?
-        .filter_map(Result::ok)
-        .filter(|e| e.path().is_dir())
-        .collect::<Vec<_>>();
-
-    directories.sort_by_key(|e| e.file_name());
-
-    directories
-        .into_iter()
-        .enumerate()
-        .for_each(|(index, entry)| {
+        let mut classes = BTreeMap::new();
+        for (index, entry) in directories.into_iter().enumerate() {
             if let Some(name) = entry.file_name().to_str() {
                 classes.insert(name.to_string(), index);
             }
-        });
+        }
 
-    Ok(classes)
+        Ok(Classes::new(classes))
+    }
 }
 
 #[cfg(test)]
@@ -43,7 +42,7 @@ mod tests {
     }
 
     #[test]
-    fn extracts_subdirectories_as_sorted_indexed_classes() {
+    fn scans_subdirectories_as_sorted_indexed_classes() {
         let root = temp_dir("sorted");
         for name in ["dog", "bird", "cat"] {
             fs::create_dir_all(root.join(name)).unwrap();
@@ -51,19 +50,23 @@ mod tests {
         // A stray file is ignored: only directories become classes.
         fs::write(root.join("notes.txt"), b"ignored").unwrap();
 
-        let classes = extract_classes(&root).unwrap();
+        let classes = Classes::scan(&root).unwrap();
         fs::remove_dir_all(&root).unwrap();
 
-        assert_eq!(classes.get("bird"), Some(&0));
-        assert_eq!(classes.get("cat"), Some(&1));
-        assert_eq!(classes.get("dog"), Some(&2));
-        assert_eq!(classes.len(), 3);
+        assert_eq!(
+            classes,
+            Classes::new(BTreeMap::from([
+                ("bird".to_string(), 0),
+                ("cat".to_string(), 1),
+                ("dog".to_string(), 2),
+            ]))
+        );
     }
 
     #[test]
     fn errors_when_root_is_missing() {
         let missing = temp_dir("missing");
         fs::remove_dir_all(&missing).unwrap();
-        assert!(extract_classes(&missing).is_err());
+        assert!(Classes::scan(&missing).is_err());
     }
 }

--- a/core/src/io/data.rs
+++ b/core/src/io/data.rs
@@ -31,10 +31,9 @@ fn origin_into_metadata(origin: &DatasetOrigin) -> HashMap<String, String> {
             (ORIGIN_DISTRIBUTION.to_string(), distribution.clone()),
             (ORIGIN_SEED.to_string(), seed.to_string()),
         ]),
-        DatasetOrigin::Encoded { source, seed } => HashMap::from([
+        DatasetOrigin::Encoded { source } => HashMap::from([
             (ORIGIN_KIND.to_string(), KIND_ENCODED.to_string()),
             (ORIGIN_SOURCE.to_string(), source.clone()),
-            (ORIGIN_SEED.to_string(), seed.to_string()),
         ]),
     }
 }
@@ -47,7 +46,6 @@ fn origin_from_metadata(metadata: &HashMap<String, String>) -> Option<DatasetOri
         }),
         KIND_ENCODED => Some(DatasetOrigin::Encoded {
             source: metadata.get(ORIGIN_SOURCE)?.clone(),
-            seed: metadata.get(ORIGIN_SEED)?.parse().ok()?,
         }),
         _ => None,
     }
@@ -140,7 +138,6 @@ mod tests {
     fn dataset_roundtrips_an_encoded_origin() {
         let origin = DatasetOrigin::Encoded {
             source: "images/digits".to_string(),
-            seed: 7,
         };
         let path = temp_path("dataset_encoded");
 

--- a/core/src/io/data.rs
+++ b/core/src/io/data.rs
@@ -31,9 +31,10 @@ fn origin_into_metadata(origin: &DatasetOrigin) -> HashMap<String, String> {
             (ORIGIN_DISTRIBUTION.to_string(), distribution.clone()),
             (ORIGIN_SEED.to_string(), seed.to_string()),
         ]),
-        DatasetOrigin::Encoded { source } => HashMap::from([
+        DatasetOrigin::Encoded { source, seed } => HashMap::from([
             (ORIGIN_KIND.to_string(), KIND_ENCODED.to_string()),
             (ORIGIN_SOURCE.to_string(), source.clone()),
+            (ORIGIN_SEED.to_string(), seed.to_string()),
         ]),
     }
 }
@@ -46,6 +47,7 @@ fn origin_from_metadata(metadata: &HashMap<String, String>) -> Option<DatasetOri
         }),
         KIND_ENCODED => Some(DatasetOrigin::Encoded {
             source: metadata.get(ORIGIN_SOURCE)?.clone(),
+            seed: metadata.get(ORIGIN_SEED)?.parse().ok()?,
         }),
         _ => None,
     }
@@ -138,6 +140,7 @@ mod tests {
     fn dataset_roundtrips_an_encoded_origin() {
         let origin = DatasetOrigin::Encoded {
             source: "images/digits".to_string(),
+            seed: 7,
         };
         let path = temp_path("dataset_encoded");
 

--- a/core/src/nn/training/hyperparams.rs
+++ b/core/src/nn/training/hyperparams.rs
@@ -398,7 +398,7 @@ impl HyperParameters {
     /// unchanged; otherwise this spec's [`scaler`](Self::scaler) kind is fitted on
     /// the train split.
     pub fn prepare(&self, dataset: ModelDataset, scaler: Option<ScalerMethod>) -> TrainingData {
-        let split = dataset.split(self.val_ratio, self.test_ratio);
+        let split = dataset.split(self.val_ratio, self.test_ratio, self.seed);
         let scaler = scaler.or_else(|| self.scaler.map(|kind| split.train.fit_scaler(kind)));
         TrainingData::new(split, scaler)
     }

--- a/core/src/nn/training/hyperparams.rs
+++ b/core/src/nn/training/hyperparams.rs
@@ -2,7 +2,7 @@ use super::callbacks::Callbacks;
 use super::early_stopping::{EarlyStoppingConfig, EarlyStoppingConfigError};
 use super::preprocessing::TrainingData;
 use super::trainer::Trainer;
-use crate::data::ModelDataset;
+use crate::data::Dataset;
 use crate::data::scalers::{ScalerKind, ScalerMethod};
 use crate::gradients::{GradientClipping, GradientClippingError};
 use crate::learning_rate::{LearningRate, LearningRateError};
@@ -397,7 +397,7 @@ impl HyperParameters {
     /// split is always well-formed), then scales it. An explicit `scaler` is applied
     /// unchanged; otherwise this spec's [`scaler`](Self::scaler) kind is fitted on
     /// the train split.
-    pub fn prepare(&self, dataset: ModelDataset, scaler: Option<ScalerMethod>) -> TrainingData {
+    pub fn prepare(&self, dataset: Dataset, scaler: Option<ScalerMethod>) -> TrainingData {
         let split = dataset.split(self.val_ratio, self.test_ratio, self.seed);
         let scaler = scaler.or_else(|| self.scaler.map(|kind| split.train.fit_scaler(kind)));
         TrainingData::new(split, scaler)
@@ -695,7 +695,7 @@ mod tests {
     #[test]
     fn prepare_fits_the_configured_scaler_on_the_train_split() {
         let hp = spec_with_scaler(Some(ScalerKind::MinMax));
-        let data = hp.prepare(ramp_dataset().to_model_dataset(), None);
+        let data = hp.prepare(ramp_dataset(), None);
 
         // A scaler was fitted from the spec's kind, and applying it lands the train
         // inputs in [0, 1] — the signature of the MinMax kind that was configured.
@@ -721,7 +721,7 @@ mod tests {
         );
 
         let hp = spec_with_scaler(None);
-        let data = hp.prepare(ramp_dataset().to_model_dataset(), Some(supplied));
+        let data = hp.prepare(ramp_dataset(), Some(supplied));
 
         assert!(data.split.train.inputs.iter().all(|&v| v < 0.5));
     }

--- a/core/src/nn/training/trainer.rs
+++ b/core/src/nn/training/trainer.rs
@@ -238,7 +238,7 @@ mod tests {
     };
     use super::*;
     use crate::activations::SIGMOID;
-    use crate::data::ModelDataset;
+    use crate::data::Dataset;
     use crate::model::NeuronLayer;
     use crate::optimizers::Optimizer;
     use crate::schedulers::Scheduler;
@@ -250,14 +250,24 @@ mod tests {
     /// A 10-sample, 2-feature dataset — large enough that the ratio split in
     /// [`HyperParameters::build`] yields non-degenerate train/validation/test sets
     /// (e.g. `val_ratio = test_ratio = 0.1` gives 8/1/1).
-    fn sample_dataset() -> ModelDataset {
-        ModelDataset {
-            inputs: array![
-                [0.1, 0.9, 0.2, 0.8, 0.15, 0.85, 0.25, 0.75, 0.3, 0.7],
-                [0.2, 0.8, 0.3, 0.7, 0.25, 0.75, 0.35, 0.65, 0.4, 0.6]
+    fn sample_dataset() -> Dataset {
+        Dataset::new(
+            array![
+                [0.1, 0.2],
+                [0.9, 0.8],
+                [0.2, 0.3],
+                [0.8, 0.7],
+                [0.15, 0.25],
+                [0.85, 0.75],
+                [0.25, 0.35],
+                [0.75, 0.65],
+                [0.3, 0.4],
+                [0.7, 0.6]
             ],
-            targets: array![[1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]],
-        }
+            array![1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
+            None,
+        )
+        .unwrap()
     }
 
     /// A fixed (non-random) 2-input -> 1-output sigmoid network, so loss

--- a/core/tests/convergence.rs
+++ b/core/tests/convergence.rs
@@ -1,6 +1,6 @@
 use ndarray::array;
 use nrn::activations::SIGMOID;
-use nrn::data::ModelDataset;
+use nrn::data::Dataset;
 use nrn::model::{LayerPlan, NeuralNetwork, NeuronLayerSpec};
 use nrn::training::{
     Callbacks, GradientClipping, HyperParameters, LossConfig, OptimizerConfig, SchedulerConfig,
@@ -9,16 +9,25 @@ use nrn::training::{
 #[test]
 fn xor_converges_to_low_loss() {
     // XOR: non-linearly separable, requires at least one hidden layer.
-    // The dataset holds two identical copies of the 4 XOR points; with
-    // `val_ratio = 0.0` and `test_ratio = 0.5` the split's `train` is exactly the
-    // first copy (the full XOR set) and `test` the second — so the model still
-    // trains on all four points.
-    let xor_dataset = || ModelDataset {
-        inputs: array![
-            [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0],
-            [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
-        ], // (2 features, 8 samples = 4 XOR points ×2)
-        targets: array![[0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0]], // (1 output, 8 samples)
+    // The dataset holds two identical copies of the 4 XOR points (8 samples); with
+    // `test_ratio = 0.5` the shuffled split trains on half of them, so every XOR
+    // point is still represented in training.
+    let xor_dataset = || {
+        Dataset::new(
+            array![
+                [0.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 0.0],
+                [1.0, 1.0],
+                [0.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 0.0],
+                [1.0, 1.0]
+            ], // (8 samples = 4 XOR points ×2, 2 features)
+            array![0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+            None,
+        )
+        .unwrap()
     };
 
     let specs = NeuronLayerSpec::plan(LayerPlan::Explicit(vec![8]), 2, &*SIGMOID).unwrap();
@@ -59,12 +68,22 @@ fn xor_converges_with_mini_batch() {
     // Adam's v → 0 after convergence can cause NaN if training continues too long without
     // lr decay, so we stop at 8 000 epochs where loss is reliably < 0.01.
     // See `xor_converges_to_low_loss` for the doubled-dataset / split rationale.
-    let xor_dataset = || ModelDataset {
-        inputs: array![
-            [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0],
-            [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
-        ],
-        targets: array![[0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0]],
+    let xor_dataset = || {
+        Dataset::new(
+            array![
+                [0.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 0.0],
+                [1.0, 1.0],
+                [0.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 0.0],
+                [1.0, 1.0]
+            ],
+            array![0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+            None,
+        )
+        .unwrap()
     };
 
     let specs = NeuronLayerSpec::plan(LayerPlan::Explicit(vec![8]), 2, &*SIGMOID).unwrap();
@@ -105,19 +124,22 @@ fn xor_converges_with_mini_batch() {
 #[test]
 fn three_class_converges_to_low_loss() {
     // 3 linearly separable points, one per class. Exercises the full softmax
-    // output path end-to-end. The dataset holds two copies of the 3 points; with
-    // `val_ratio = 0.0` and `test_ratio = 0.5` the `train` split is exactly the
-    // first copy (one sample per class).
-    let three_class_dataset = || ModelDataset {
-        inputs: array![
-            [0.0, 1.0, 0.0, 0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]
-        ], // (2 features, 6 samples)
-        targets: array![
-            [1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0, 0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]
-        ], // (3 classes, 6 samples)
+    // output path end-to-end. The dataset holds two copies of the 3 points (6
+    // samples); with `test_ratio = 0.5` the shuffled split trains on half of them.
+    let three_class_dataset = || {
+        Dataset::new(
+            array![
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 1.0]
+            ], // (6 samples, 2 features)
+            array![0.0, 1.0, 2.0, 0.0, 1.0, 2.0],
+            None,
+        )
+        .unwrap()
     };
 
     // Sigmoid avoids the dead-neuron risk of ReLU(0)=0 for the [0.0, 0.0] sample


### PR DESCRIPTION
## Summary

Reworks the data/encode path in three coherent moves:

- **Shuffle at split time, not at construction.** Producers now store samples in natural (class-grouped) order; `Dataset::split` owns the shuffle, seeded by the run seed, so the partition is reproducible from it. `HyperParameters::prepare` takes a `Dataset` (hiding the column-major mechanics) and delegates to `split`.
- **`Classes` domain type.** Per-class folder scanning (`Classes::scan`) is now a first-class type with its own display, instead of ad-hoc logic in the encode command.
- **`encode` subcommands named by output.** `img-dir`/`img` → `dataset`/`instance` (aliases `ds`/`inst`), so the name reflects what each produces rather than its input.

Adds end-to-end coverage of both `encode` commands and unit coverage of `display::dataset`.

## Notes

- Moving the shuffle to the split matches mainstream ML practice (data stored in natural order, shuffle parameterised by a seed at split time). As a consequence the `Encoded` origin drops its seed — encoding has no generation randomness — while `Synthetic` keeps its seed (it reproduces generated values).
- `Dataset::split` returns a `ModelSplit` (converting internally) rather than three `Dataset`s, to avoid re-validating the ≥2-classes invariant on a small or unlucky sub-split.
- Stratified split is intentionally deferred.