### PR TITLE
ci(coverage): gate merges on a line-coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           rustup update stable
           rustup default stable
-          rustup component add clippy rustfmt
+          rustup component add clippy rustfmt llvm-tools-preview
 
       - name: Install system dependencies
         run: sudo apt-get install -y libfontconfig-dev
@@ -38,3 +38,7 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - run: task audit
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+      - run: task coverage-check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,17 @@ cargo test -p nrn <name>        # core crate only
 task lint                       # rustfmt --check + clippy (-D warnings), with & without features
 task audit                      # cargo-audit advisory scan
 task coverage / coverage-html   # cargo-llvm-cov summary / HTML report
+task coverage-check             # fail under the line-coverage threshold (CI gate)
 ```
 
 All serialization is pure Rust — no system C library is needed to build or run.
+
+## Testing
+
+New public behavior ships with a test; every bug fix ships with a regression test that fails
+before the fix. Unit tests live in-module under `#[cfg(test)]`; CLI behavior is covered
+end-to-end through `assert_cmd` in `cli/tests/`. CI gates merges on a line-coverage threshold
+(`task coverage-check`) — keep coverage from regressing.
 
 ## Commit conventions
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,6 +52,11 @@ tasks:
     cmds:
       - cargo llvm-cov --workspace --all-features --summary-only
 
+  coverage-check:
+    desc: Fail if line coverage drops below the threshold (requires cargo-llvm-cov)
+    cmds:
+      - cargo llvm-cov --workspace --all-features --summary-only --fail-under-lines 99
+
   coverage-html:
     desc: Generate an HTML coverage report for the workspace and open it
     cmds:


### PR DESCRIPTION
## Summary

Add a `coverage-check` task — `cargo llvm-cov --workspace --all-features --summary-only --fail-under-lines 99` — and run it in CI after `audit`. Coverage regressions now fail the build instead of relying on a manual `task coverage`. Also records the test convention in `CLAUDE.md`.

## Notes

- Kept **out** of `task checks` on purpose: `checks` is the inner-loop / pre-commit gate, and instrumented coverage re-runs the whole suite. Keeping it CI-only preserves a fast local loop and leaves `cargo-llvm-cov` optional for everyday development.
- Threshold set at 99% lines as a ratchet just below the current baseline (~99.8%); raise it as coverage climbs. Gated on lines only — the canonical, low-noise metric.
- CI gains the `llvm-tools-preview` component and a `cargo-llvm-cov` install step.
- `CLAUDE.md` now states the convention: new public behavior ships with a test, every fix with a regression test.