### PR TITLE
Pretty, task-specific CLI progress bars

### DIFF
--- a/cli/src/commands/encode.rs
+++ b/cli/src/commands/encode.rs
@@ -1,12 +1,12 @@
-use crate::display::{Artifacts, bar, completed, saved, show};
+use crate::display::{Artifacts, Encoding, completed, saved, show};
 use crate::path::PathExt;
 use clap::{Args, Subcommand};
-use console::style;
 use nrn::data::vectorizers::{ImageEncoder, VectorEncoder};
 use nrn::data::{Classes, Dataset, Instance};
 use nrn::io::bytes::secure_read;
 use std::error::Error;
 use std::fs::read_dir;
+use std::io;
 use std::path::PathBuf;
 
 #[derive(Args, Debug)]
@@ -75,37 +75,39 @@ impl DatasetArgs {
 
         let encoder = ImageEncoder::from(&self.encoder);
 
+        // Read every category's directory up front so a single bar can span the
+        // whole run's images with an honest end-to-end ETA.
+        let categories = classes
+            .iter()
+            .map(|(category, label)| {
+                let entries = read_dir(self.input.join(category))?
+                    .filter_map(Result::ok)
+                    .collect::<Vec<_>>();
+                Ok((category, *label, entries))
+            })
+            .collect::<Result<Vec<_>, io::Error>>()?;
+
+        let total = categories.iter().map(|(_, _, entries)| entries.len()).sum();
+
         let mut data = Vec::new();
         let mut labels = Vec::new();
 
-        for (i, (category, label)) in classes.iter().enumerate() {
-            let entries = read_dir(self.input.join(category))?
-                .filter_map(Result::ok)
-                .collect::<Vec<_>>();
-
-            let progression = bar(
-                entries.len(),
-                format!(
-                    "Encoding category [{}/{}]: {}",
-                    i + 1,
-                    classes.len(),
-                    style(category).bright().blue()
-                ),
-            );
+        let progress = Encoding::new(total);
+        for (index, (category, label, entries)) in categories.iter().enumerate() {
+            progress.category(index, classes.len(), category);
 
             for entry in entries {
-                progression.inc(1);
+                progress.advance();
 
                 let img = secure_read(entry.path())?;
 
                 if let Ok(img) = encoder.encode(&img) {
                     data.push(img);
-                    labels.push(label.to_owned());
+                    labels.push(*label);
                 }
             }
-
-            progression.finish_and_clear();
         }
+        progress.finish();
 
         let dataset = Dataset::from_encoded(self.input.file_stem_string(), data, labels)?;
 

--- a/cli/src/commands/plot/run.rs
+++ b/cli/src/commands/plot/run.rs
@@ -1,8 +1,7 @@
 use super::{Format, ImageSize, render};
-use crate::display::{Artifacts, bar, loaded, play_frames, saved, warning};
+use crate::display::{Artifacts, Frames, loaded, play_frames, saved, warning};
 use crate::path::PathExt;
 use clap::Args;
-use indicatif::ProgressIterator;
 use nrn::data::Dataset;
 use nrn::data::scalers::ScalerMethod;
 use nrn::io::checkpoint::CheckpointArchive;
@@ -111,12 +110,13 @@ impl RunArgs {
 
         match self.format {
             Format::Console => {
-                let progress = bar(indices.len(), "Rendering decision boundary frames");
-                let figures = indices
-                    .iter()
-                    .progress_with(progress)
-                    .map(|&index| boundary_at(archive, index, dataset, scaler, resolution))
-                    .collect::<Result<Vec<_>, _>>()?;
+                let progress = Frames::new(indices.len(), "Rendering frames");
+                let mut figures = Vec::with_capacity(indices.len());
+                for &index in indices {
+                    figures.push(boundary_at(archive, index, dataset, scaler, resolution)?);
+                    progress.advance();
+                }
+                progress.finish();
 
                 play_frames(&figures, self.delay);
                 Ok(None)
@@ -132,11 +132,13 @@ impl RunArgs {
                     self.delay,
                 )?;
 
-                let progress = bar(indices.len(), "Rendering decision boundary GIF");
-                for &index in indices.iter().progress_with(progress) {
+                let progress = Frames::new(indices.len(), "Rendering GIF");
+                for &index in indices {
                     let figure = boundary_at(archive, index, dataset, scaler, resolution)?;
                     writer.write_frame(&figure.to_image(&cfg)?)?;
+                    progress.advance();
                 }
+                progress.finish();
 
                 Ok(Some(writer.finish()))
             }

--- a/cli/src/commands/train/callbacks.rs
+++ b/cli/src/commands/train/callbacks.rs
@@ -4,10 +4,9 @@
 //! into a `callbacks/` submodule if this file grows.
 
 use crate::display::{
-    Artifacts, HyperParametersView, completed, completed_with, evaluated, saved, show, styled_bar,
+    Artifacts, Epochs, HyperParametersView, completed, completed_with, evaluated, saved, show,
     warning,
 };
-use indicatif::ProgressBar;
 use nrn::data::ModelSplit;
 use nrn::data::scalers::ScalerMethod;
 use nrn::evaluation::EvaluationSet;
@@ -20,11 +19,12 @@ use std::path::{Path, PathBuf};
 // ─── ConsoleMonitor ─────────────────────────────────────────────────────────
 
 /// Reports the training run lifecycle on the console: a progress bar tracks
-/// epochs, and the run configuration / final outcome are narrated as trace
-/// lines. The bar is suspended while printing so lines never get garbled by
-/// its redraws, and cleared before the final summary.
+/// epochs and surfaces the latest evaluated loss/accuracy, while the run
+/// configuration / final outcome are narrated as trace lines. The bar is
+/// suspended while printing so lines never get garbled by its redraws, and
+/// cleared before the final summary.
 pub struct ConsoleMonitor {
-    bar: ProgressBar,
+    bar: Epochs,
     current: HyperParameters,
     previous: Option<HyperParameters>,
 }
@@ -32,7 +32,7 @@ pub struct ConsoleMonitor {
 impl ConsoleMonitor {
     pub fn new(current: HyperParameters, previous: Option<HyperParameters>) -> Self {
         Self {
-            bar: styled_bar(),
+            bar: Epochs::new(),
             current,
             previous,
         }
@@ -62,15 +62,14 @@ impl TrainerCallback for ConsoleMonitor {
     }
 
     fn on_train_start(&mut self, split: &ModelSplit) -> CallbackResult {
-        self.bar.set_length(self.current.epochs() as u64);
-        self.bar.set_message("Training");
+        self.bar.start(self.current.epochs());
 
         let view = HyperParametersView {
             current: &self.current,
             previous: self.previous.as_ref(),
         };
 
-        self.bar.suspend(|| {
+        self.bar.quiet(|| {
             show(&view);
             show(split);
         });
@@ -79,7 +78,19 @@ impl TrainerCallback for ConsoleMonitor {
     }
 
     fn on_epoch_end(&mut self, _epoch: usize) -> CallbackResult {
-        self.bar.inc(1);
+        self.bar.advance();
+        Ok(())
+    }
+
+    fn on_checkpoint(
+        &mut self,
+        _model: &NeuralNetwork,
+        _optimizer: &dyn Optimizer,
+        _scheduler: &dyn Scheduler,
+        eval: &EvaluationSet,
+        _epoch: usize,
+    ) -> CallbackResult {
+        self.bar.evaluated(eval);
         Ok(())
     }
 
@@ -90,7 +101,7 @@ impl TrainerCallback for ConsoleMonitor {
         eval: Option<&EvaluationSet>,
         epoch: usize,
     ) -> CallbackResult {
-        self.bar.finish_and_clear();
+        self.bar.finish();
 
         match outcome {
             TrainingOutcome::Completed => {

--- a/cli/src/commands/train/resume.rs
+++ b/cli/src/commands/train/resume.rs
@@ -1,7 +1,7 @@
 use super::DivergedRun;
 use super::args::ResumeOverrides;
 use super::callbacks::{ConsoleMonitor, ModelSaver};
-use crate::display::{loaded, recording, warning};
+use crate::display::{Spinner, loaded, recording, warning};
 use clap::Args;
 use nrn::data::Dataset;
 use nrn::io::run::TrainingRun;
@@ -63,7 +63,9 @@ impl ResumeArgs {
             None
         };
 
+        let spinner = Spinner::start("Preparing dataset");
         let data = hyperparameters.prepare(dataset, scaler);
+        spinner.finish();
 
         let callbacks = Callbacks::empty()
             .with(ConsoleMonitor::new(hyperparameters.clone(), Some(previous)))

--- a/cli/src/commands/train/start.rs
+++ b/cli/src/commands/train/start.rs
@@ -1,7 +1,7 @@
 use super::DivergedRun;
 use super::args::TrainArgs;
 use super::callbacks::{ConsoleMonitor, ModelSaver};
-use crate::display::{initialized, loaded, recording};
+use crate::display::{Spinner, initialized, loaded, recording};
 use crate::path::PathExt;
 use clap::Args;
 use nrn::activations::RELU;
@@ -77,7 +77,9 @@ impl StartArgs {
             }
         };
 
+        let spinner = Spinner::start("Preparing dataset");
         let data = hyperparameters.prepare(dataset, None);
+        spinner.finish();
 
         let recorder = if hyperparameters.checkpoint_interval() > 0 {
             let meta = TrainingMeta {

--- a/cli/src/display/mod.rs
+++ b/cli/src/display/mod.rs
@@ -26,7 +26,7 @@ mod theme;
 pub(crate) use artifacts::Artifacts;
 pub(crate) use hyperparameters::HyperParametersView;
 pub(crate) use icons::*;
-pub(crate) use progress::{Encoding, Epochs, bar};
+pub(crate) use progress::{Encoding, Epochs, Frames};
 pub(crate) use terminal::{play_frames, preview};
 
 use console::Emoji;

--- a/cli/src/display/mod.rs
+++ b/cli/src/display/mod.rs
@@ -26,7 +26,7 @@ mod theme;
 pub(crate) use artifacts::Artifacts;
 pub(crate) use hyperparameters::HyperParametersView;
 pub(crate) use icons::*;
-pub(crate) use progress::{Encoding, Epochs, Frames};
+pub(crate) use progress::{Encoding, Epochs, Frames, Spinner};
 pub(crate) use terminal::{play_frames, preview};
 
 use console::Emoji;

--- a/cli/src/display/mod.rs
+++ b/cli/src/display/mod.rs
@@ -26,7 +26,7 @@ mod theme;
 pub(crate) use artifacts::Artifacts;
 pub(crate) use hyperparameters::HyperParametersView;
 pub(crate) use icons::*;
-pub(crate) use progress::{bar, styled_bar};
+pub(crate) use progress::{Encoding, bar, styled_bar};
 pub(crate) use terminal::{play_frames, preview};
 
 use console::Emoji;

--- a/cli/src/display/mod.rs
+++ b/cli/src/display/mod.rs
@@ -145,7 +145,7 @@ pub(crate) fn saved(artifacts: &Artifacts) {
     headed(SAVE_ICON, artifacts);
 }
 
-/// The record icon, then a violet `RECORDING NAME` active header and its
+/// The record icon, then an active `RECORDING NAME` header and its
 /// description.
 pub(crate) fn recording<E: Named + Describe>(entity: &E) {
     action(
@@ -179,7 +179,7 @@ pub(crate) fn emit_completed(message: &str) {
 }
 
 /// Backing implementation for the [`completed_with!`] macro: a success status
-/// line with a dim `· caption` set apart from the green headline — a secondary
+/// line with a dim `· caption` set apart from the success headline — a secondary
 /// fact about the same event. Prefer the macro at call sites.
 #[doc(hidden)]
 pub(crate) fn emit_completed_with(message: &str, caption: Option<&str>) {
@@ -220,7 +220,7 @@ macro_rules! completed {
 }
 
 /// Emit a success status line with a dim `· caption` detail set apart from the
-/// green headline. The `caption` (an `Option<&str>`) comes first; the remaining
+/// success headline. The `caption` (an `Option<&str>`) comes first; the remaining
 /// `format!`-style arguments build the headline.
 macro_rules! completed_with {
     ($caption:expr, $($arg:tt)*) => {

--- a/cli/src/display/mod.rs
+++ b/cli/src/display/mod.rs
@@ -26,7 +26,7 @@ mod theme;
 pub(crate) use artifacts::Artifacts;
 pub(crate) use hyperparameters::HyperParametersView;
 pub(crate) use icons::*;
-pub(crate) use progress::{Encoding, bar, styled_bar};
+pub(crate) use progress::{Encoding, Epochs, bar};
 pub(crate) use terminal::{play_frames, preview};
 
 use console::Emoji;

--- a/cli/src/display/progress.rs
+++ b/cli/src/display/progress.rs
@@ -6,30 +6,7 @@
 use super::theme;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use nrn::evaluation::EvaluationSet;
-use std::borrow::Cow;
 use std::fmt::Display;
-
-// TODO(progress): removed once `plot` migrates to the typed wrappers.
-/// Builds a hidden progress bar with the project's standard style, drawn to stdout.
-fn styled_bar() -> ProgressBar {
-    let bar = ProgressBar::hidden();
-    bar.set_style(
-        ProgressStyle::with_template(
-            "{msg} {spinner:.green} [{elapsed_precise}] {wide_bar} {pos}/{len} {percent}% ({eta})",
-        )
-        .unwrap(),
-    );
-    bar.set_draw_target(ProgressDrawTarget::stdout());
-    bar
-}
-
-/// A standalone progress bar of known length, for use with [`indicatif::ProgressIterator`].
-pub(crate) fn bar(len: usize, msg: impl Into<Cow<'static, str>>) -> ProgressBar {
-    let bar = styled_bar();
-    bar.set_length(len as u64);
-    bar.set_message(msg);
-    bar
-}
 
 /// The fill / head / empty glyphs of every bar — a thin, single-weight rule.
 const PROGRESS_CHARS: &str = "━╸─";
@@ -119,6 +96,30 @@ impl Epochs {
     }
 
     /// Clears the bar at the end of the run.
+    pub(crate) fn finish(&self) {
+        self.0.finish_and_clear();
+    }
+}
+
+/// Tracks decision-boundary frame rendering for an animation.
+pub(crate) struct Frames(ProgressBar);
+
+impl Frames {
+    /// A bar over `count` frames, prefixed with what's being rendered
+    /// (e.g. `"Rendering GIF"`).
+    pub(crate) fn new(count: usize, what: &'static str) -> Self {
+        let bar = styled("{pos}/{len} frames · {eta:.dim}");
+        bar.set_length(count as u64);
+        bar.set_prefix(what);
+        Self(bar)
+    }
+
+    /// Records one rendered frame.
+    pub(crate) fn advance(&self) {
+        self.0.inc(1);
+    }
+
+    /// Clears the bar once every frame is rendered.
     pub(crate) fn finish(&self) {
         self.0.finish_and_clear();
     }

--- a/cli/src/display/progress.rs
+++ b/cli/src/display/progress.rs
@@ -5,7 +5,7 @@
 
 use super::theme;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use nrn::evaluation::EvaluationSet;
+use nrn::evaluation::{Evaluation, EvaluationSet};
 use std::fmt::Display;
 use std::time::Duration;
 
@@ -89,46 +89,85 @@ impl Encoding {
 }
 
 /// Tracks the training loop epoch by epoch, surfacing the latest evaluated
-/// loss and accuracy beside the bar.
-pub(crate) struct Epochs(ProgressBar);
+/// loss and accuracy — each with a trend chevron against the previous
+/// checkpoint — beside the bar.
+pub(crate) struct Epochs {
+    bar: ProgressBar,
+    /// The previous checkpoint's evaluation, for the trend chevrons.
+    previous: Option<Evaluation>,
+}
 
 impl Epochs {
     /// A bar awaiting [`start`](Self::start) — held by the monitor before the
     /// loop's total epoch count is known.
     pub(crate) fn new() -> Self {
-        Self(styled("{pos}/{len} epochs · {msg}{eta:.dim}"))
+        Self {
+            bar: styled("{pos}/{len} epochs · {msg}{eta:.dim}"),
+            previous: None,
+        }
     }
 
     /// Reveals the bar, spanning `epochs` total epochs.
     pub(crate) fn start(&self, epochs: usize) {
-        self.0.set_prefix("Training");
-        self.0.set_length(epochs as u64);
+        self.bar.set_prefix("Training");
+        self.bar.set_length(epochs as u64);
     }
 
     /// Records one finished epoch.
     pub(crate) fn advance(&self) {
-        self.0.inc(1);
+        self.bar.inc(1);
     }
 
-    /// Surfaces the latest evaluation — validation when present, else train.
-    pub(crate) fn evaluated(&self, eval: &EvaluationSet) {
+    /// Surfaces the latest evaluation — validation when present, else train —
+    /// each metric trailed by a [`trend`] chevron against the previous checkpoint.
+    pub(crate) fn evaluated(&mut self, eval: &EvaluationSet) {
         let metrics = eval.validation.unwrap_or(eval.train);
-        self.0.set_message(format!(
-            "loss {:.4} · acc {:.1}% · ",
+
+        let (loss_trend, acc_trend) = match self.previous {
+            Some(previous) => (
+                trend(previous.loss, metrics.loss, false),
+                trend(previous.accuracy, metrics.accuracy, true),
+            ),
+            None => (String::new(), String::new()),
+        };
+
+        self.bar.set_message(format!(
+            "loss {:.4}{loss_trend} · acc {:.1}%{acc_trend} · ",
             metrics.loss, metrics.accuracy
         ));
+
+        self.previous = Some(metrics);
     }
 
     /// Runs `body` with the bar suspended, so printed lines aren't garbled by
     /// its redraws.
     pub(crate) fn quiet<R>(&self, body: impl FnOnce() -> R) -> R {
-        self.0.suspend(body)
+        self.bar.suspend(body)
     }
 
     /// Clears the bar at the end of the run.
     pub(crate) fn finish(&self) {
-        self.0.finish_and_clear();
+        self.bar.finish_and_clear();
     }
+}
+
+/// A coloured trend chevron for a metric moving from `previous` to `current`:
+/// the arrow points the way it moved — green when that's an improvement (loss
+/// falling, accuracy rising), red otherwise — with a leading space. Empty when
+/// unchanged or not comparable (e.g. a diverged `NaN`).
+fn trend(previous: f32, current: f32, higher_is_better: bool) -> String {
+    let delta = current - previous;
+    if !delta.is_normal() {
+        return String::new();
+    }
+    let rising = delta > 0.0;
+    let chevron = if rising { '▲' } else { '▼' };
+    let styled = if rising == higher_is_better {
+        theme::improving(chevron)
+    } else {
+        theme::regressing(chevron)
+    };
+    format!(" {styled}")
 }
 
 /// Tracks decision-boundary frame rendering for an animation.
@@ -152,5 +191,51 @@ impl Frames {
     /// Clears the bar once every frame is rendered.
     pub(crate) fn finish(&self) {
         self.0.finish_and_clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{theme, trend};
+
+    // Comparing against the theme helpers keeps the assertions agnostic to
+    // whether colors are enabled (both sides share that state).
+    #[test]
+    fn falling_loss_improves_with_a_down_chevron() {
+        assert_eq!(
+            trend(1.0, 0.5, false),
+            format!(" {}", theme::improving('▼'))
+        );
+    }
+
+    #[test]
+    fn rising_loss_regresses_with_an_up_chevron() {
+        assert_eq!(
+            trend(0.5, 1.0, false),
+            format!(" {}", theme::regressing('▲'))
+        );
+    }
+
+    #[test]
+    fn rising_accuracy_improves_with_an_up_chevron() {
+        assert_eq!(
+            trend(90.0, 95.0, true),
+            format!(" {}", theme::improving('▲'))
+        );
+    }
+
+    #[test]
+    fn falling_accuracy_regresses_with_a_down_chevron() {
+        assert_eq!(
+            trend(95.0, 90.0, true),
+            format!(" {}", theme::regressing('▼'))
+        );
+    }
+
+    #[test]
+    fn unchanged_or_nan_metrics_show_no_chevron() {
+        assert!(trend(1.0, 1.0, false).is_empty());
+        assert!(trend(1.0, f32::NAN, false).is_empty());
+        assert!(trend(f32::NAN, 1.0, true).is_empty());
     }
 }

--- a/cli/src/display/progress.rs
+++ b/cli/src/display/progress.rs
@@ -1,8 +1,14 @@
-//! The project's standard progress bar, drawn to stdout.
+//! The CLI's progress bars: pretty, task-specific, and the only place the
+//! `indicatif` backend is touched. Each wrapper owns a [`ProgressBar`], styles
+//! itself through [`theme`](super::theme), and exposes domain methods so call
+//! sites never see — or restyle — the bar.
 
+use super::theme;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use std::borrow::Cow;
+use std::fmt::Display;
 
+// TODO(progress): removed once `train` and `plot` migrate to the typed wrappers.
 /// Builds a hidden progress bar with the project's standard style, drawn to stdout.
 pub(crate) fn styled_bar() -> ProgressBar {
     let bar = ProgressBar::hidden();
@@ -22,4 +28,54 @@ pub(crate) fn bar(len: usize, msg: impl Into<Cow<'static, str>>) -> ProgressBar 
     bar.set_length(len as u64);
     bar.set_message(msg);
     bar
+}
+
+/// The fill / head / empty glyphs of every bar — a thin, single-weight rule.
+const PROGRESS_CHARS: &str = "━╸─";
+
+/// A hidden→stdout bar in the project style: a green spinner, a bold blue
+/// prefix label, the accent fill bar, then the caller's `suffix` of contextual
+/// tokens.
+fn styled(suffix: &str) -> ProgressBar {
+    let template = format!(
+        "{{spinner:.{accent}}} {{prefix:.bold.{title}}} {{wide_bar:.{accent}}} {suffix}",
+        accent = theme::ACCENT,
+        title = theme::TITLE,
+    );
+    let bar = ProgressBar::hidden();
+    bar.set_style(
+        ProgressStyle::with_template(&template)
+            .unwrap()
+            .progress_chars(PROGRESS_CHARS),
+    );
+    bar.set_draw_target(ProgressDrawTarget::stdout());
+    bar
+}
+
+/// Tracks image encoding across every category under a single bar: the prefix
+/// names the category being read, the bar fills over the run's total images.
+pub(crate) struct Encoding(ProgressBar);
+
+impl Encoding {
+    /// A bar spanning `total` images across the whole input directory.
+    pub(crate) fn new(total: usize) -> Self {
+        let bar = styled("{pos}/{len} images · {eta:.dim}");
+        bar.set_length(total as u64);
+        Self(bar)
+    }
+
+    /// Announces the category now being read — the `index`-th of `count`.
+    pub(crate) fn category(&self, index: usize, count: usize, name: impl Display) {
+        self.0.set_prefix(format!("[{}/{count}] {name}", index + 1));
+    }
+
+    /// Records one processed image.
+    pub(crate) fn advance(&self) {
+        self.0.inc(1);
+    }
+
+    /// Clears the bar once every category is encoded.
+    pub(crate) fn finish(&self) {
+        self.0.finish_and_clear();
+    }
 }

--- a/cli/src/display/progress.rs
+++ b/cli/src/display/progress.rs
@@ -5,12 +5,13 @@
 
 use super::theme;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use nrn::evaluation::EvaluationSet;
 use std::borrow::Cow;
 use std::fmt::Display;
 
-// TODO(progress): removed once `train` and `plot` migrate to the typed wrappers.
+// TODO(progress): removed once `plot` migrates to the typed wrappers.
 /// Builds a hidden progress bar with the project's standard style, drawn to stdout.
-pub(crate) fn styled_bar() -> ProgressBar {
+fn styled_bar() -> ProgressBar {
     let bar = ProgressBar::hidden();
     bar.set_style(
         ProgressStyle::with_template(
@@ -75,6 +76,49 @@ impl Encoding {
     }
 
     /// Clears the bar once every category is encoded.
+    pub(crate) fn finish(&self) {
+        self.0.finish_and_clear();
+    }
+}
+
+/// Tracks the training loop epoch by epoch, surfacing the latest evaluated
+/// loss and accuracy beside the bar.
+pub(crate) struct Epochs(ProgressBar);
+
+impl Epochs {
+    /// A bar awaiting [`start`](Self::start) — held by the monitor before the
+    /// loop's total epoch count is known.
+    pub(crate) fn new() -> Self {
+        Self(styled("{pos}/{len} epochs · {msg}{eta:.dim}"))
+    }
+
+    /// Reveals the bar, spanning `epochs` total epochs.
+    pub(crate) fn start(&self, epochs: usize) {
+        self.0.set_prefix("Training");
+        self.0.set_length(epochs as u64);
+    }
+
+    /// Records one finished epoch.
+    pub(crate) fn advance(&self) {
+        self.0.inc(1);
+    }
+
+    /// Surfaces the latest evaluation — validation when present, else train.
+    pub(crate) fn evaluated(&self, eval: &EvaluationSet) {
+        let metrics = eval.validation.unwrap_or(eval.train);
+        self.0.set_message(format!(
+            "loss {:.4} · acc {:.1}% · ",
+            metrics.loss, metrics.accuracy
+        ));
+    }
+
+    /// Runs `body` with the bar suspended, so printed lines aren't garbled by
+    /// its redraws.
+    pub(crate) fn quiet<R>(&self, body: impl FnOnce() -> R) -> R {
+        self.0.suspend(body)
+    }
+
+    /// Clears the bar at the end of the run.
     pub(crate) fn finish(&self) {
         self.0.finish_and_clear();
     }

--- a/cli/src/display/progress.rs
+++ b/cli/src/display/progress.rs
@@ -7,6 +7,7 @@ use super::theme;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use nrn::evaluation::EvaluationSet;
 use std::fmt::Display;
+use std::time::Duration;
 
 /// The fill / head / empty glyphs of every bar — a thin, single-weight rule.
 const PROGRESS_CHARS: &str = "━╸─";
@@ -28,6 +29,35 @@ fn styled(suffix: &str) -> ProgressBar {
     );
     bar.set_draw_target(ProgressDrawTarget::stdout());
     bar
+}
+
+/// An indeterminate spinner for a single blocking step with no measurable
+/// progress (e.g. splitting a large dataset). It ticks on a background thread,
+/// so it keeps animating while the calling thread is busy.
+pub(crate) struct Spinner(ProgressBar);
+
+impl Spinner {
+    /// Starts a spinner labelled `message`, animating until [`finish`](Self::finish).
+    pub(crate) fn start(message: &'static str) -> Self {
+        let bar = ProgressBar::new_spinner();
+        bar.set_style(
+            ProgressStyle::with_template(&format!(
+                "{{spinner:.{accent}}} {{msg:.bold.{title}}}",
+                accent = theme::ACCENT,
+                title = theme::TITLE,
+            ))
+            .unwrap(),
+        );
+        bar.set_draw_target(ProgressDrawTarget::stdout());
+        bar.set_message(message);
+        bar.enable_steady_tick(Duration::from_millis(80));
+        Self(bar)
+    }
+
+    /// Stops and clears the spinner.
+    pub(crate) fn finish(&self) {
+        self.0.finish_and_clear();
+    }
 }
 
 /// Tracks image encoding across every category under a single bar: the prefix

--- a/cli/src/display/progress.rs
+++ b/cli/src/display/progress.rs
@@ -12,14 +12,13 @@ use std::time::Duration;
 /// The fill / head / empty glyphs of every bar — a thin, single-weight rule.
 const PROGRESS_CHARS: &str = "━╸─";
 
-/// A hidden→stdout bar in the project style: a green spinner, a bold blue
-/// prefix label, the accent fill bar, then the caller's `suffix` of contextual
-/// tokens.
+/// A hidden→stdout bar in the project style: a spinner, a bold action prefix,
+/// the fill bar, then the caller's `suffix` of contextual tokens.
 fn styled(suffix: &str) -> ProgressBar {
     let template = format!(
-        "{{spinner:.{accent}}} {{prefix:.bold.{title}}} {{wide_bar:.{accent}}} {suffix}",
+        "{{spinner:.{accent}}} {{prefix:.bold.{active}}} {{wide_bar:.{accent}}} {suffix}",
         accent = theme::ACCENT,
-        title = theme::TITLE,
+        active = theme::ACTIVE,
     );
     let bar = ProgressBar::hidden();
     bar.set_style(
@@ -42,9 +41,9 @@ impl Spinner {
         let bar = ProgressBar::new_spinner();
         bar.set_style(
             ProgressStyle::with_template(&format!(
-                "{{spinner:.{accent}}} {{msg:.bold.{title}}}",
+                "{{spinner:.{accent}}} {{msg:.bold.{active}}}",
                 accent = theme::ACCENT,
-                title = theme::TITLE,
+                active = theme::ACTIVE,
             ))
             .unwrap(),
         );
@@ -151,10 +150,11 @@ impl Epochs {
     }
 }
 
-/// A coloured trend chevron for a metric moving from `previous` to `current`:
-/// the arrow points the way it moved — green when that's an improvement (loss
-/// falling, accuracy rising), red otherwise — with a leading space. Empty when
-/// unchanged or not comparable (e.g. a diverged `NaN`).
+/// A trend chevron for a metric moving from `previous` to `current`: the arrow
+/// points the way it moved, styled [`improving`](theme::improving) when that's a
+/// gain (loss falling, accuracy rising) and [`regressing`](theme::regressing)
+/// otherwise, with a leading space. Empty when unchanged or not comparable
+/// (e.g. a diverged `NaN`).
 fn trend(previous: f32, current: f32, higher_is_better: bool) -> String {
     let delta = current - previous;
     if !delta.is_normal() {

--- a/cli/src/display/theme.rs
+++ b/cli/src/display/theme.rs
@@ -9,7 +9,7 @@ use std::fmt::Display;
 /// `indicatif` progress templates (which take color codes as bare strings, so
 /// they can't go through the helpers). Severity icons use named terminal
 /// colors instead, where the convention itself carries the meaning.
-pub(crate) const TITLE: u8 = 33; // entity titles and progress prefixes
+pub(crate) const TITLE: u8 = 33; // entity titles
 pub(crate) const LABEL: u8 = 37; // field labels
 pub(crate) const VALUE: u8 = 172; // field values, inline figures, and diffs
 pub(crate) const ACCENT: u8 = 35; // success lines and the progress fill/spinner
@@ -34,7 +34,7 @@ pub(crate) fn error_icon(glyph: Emoji) -> String {
     style(glyph).bright().red().to_string()
 }
 
-/// The bold blue entity title (e.g. `DATASET`, `TRAINING HYPERPARAMETERS`).
+/// The bold entity title (e.g. `DATASET`, `TRAINING HYPERPARAMETERS`).
 pub(crate) fn title(text: impl Display) -> String {
     style(text).bold().color256(TITLE).to_string()
 }
@@ -44,7 +44,7 @@ pub(crate) fn label(text: impl Display) -> String {
     style(text).color256(LABEL).to_string()
 }
 
-/// A success status line, in bold green — the `completed!` counterpart to the
+/// A success status line, in bold — the `completed!` counterpart to the
 /// bold `warn_label`/`error_label` lead-ins.
 pub(crate) fn success(text: impl Display) -> String {
     style(text).bold().color256(ACCENT).to_string()
@@ -65,7 +65,7 @@ pub(crate) fn value(text: impl Display) -> String {
     style(text).color256(VALUE).to_string()
 }
 
-/// An in-progress action verb (e.g. `RECORDING`), in bold violet.
+/// An in-progress action verb (e.g. `RECORDING`), in bold.
 pub(crate) fn active(text: impl Display) -> String {
     style(text).bold().color256(ACTIVE).to_string()
 }
@@ -75,12 +75,12 @@ pub(crate) fn diff(text: impl Display) -> String {
     style(text).color256(VALUE).to_string()
 }
 
-/// A favorable trend marker — an improving metric — in green.
+/// A favorable trend marker — an improving metric.
 pub(crate) fn improving(text: impl Display) -> String {
     style(text).color256(ACCENT).to_string()
 }
 
-/// An unfavorable trend marker — a worsening metric — in red.
+/// An unfavorable trend marker — a worsening metric.
 pub(crate) fn regressing(text: impl Display) -> String {
     style(text).color256(DANGER).to_string()
 }

--- a/cli/src/display/theme.rs
+++ b/cli/src/display/theme.rs
@@ -15,7 +15,7 @@ pub(crate) const VALUE: u8 = 172; // field values, inline figures, and diffs
 pub(crate) const ACCENT: u8 = 35; // success lines and the progress fill/spinner
 pub(crate) const ACTIVE: u8 = 92; // in-progress action verbs
 pub(crate) const WARN: u8 = 166; // warning lead-ins and bodies
-pub(crate) const ERROR: u8 = 160; // error lead-ins and bodies
+pub(crate) const DANGER: u8 = 160; // errors and worsening-metric markers
 
 /// A leading line icon in the standard accent — the single place ordinary icons
 /// get styled, so verbs pass only the glyph. Severity icons use [`warn_icon`] /
@@ -75,6 +75,16 @@ pub(crate) fn diff(text: impl Display) -> String {
     style(text).color256(VALUE).to_string()
 }
 
+/// A favorable trend marker — an improving metric — in green.
+pub(crate) fn improving(text: impl Display) -> String {
+    style(text).color256(ACCENT).to_string()
+}
+
+/// An unfavorable trend marker — a worsening metric — in red.
+pub(crate) fn regressing(text: impl Display) -> String {
+    style(text).color256(DANGER).to_string()
+}
+
 /// The bold `Warning:` lead-in, in the conventional warning color.
 pub(crate) fn warn_label(text: impl Display) -> String {
     style(text).bold().color256(WARN).to_string()
@@ -87,10 +97,10 @@ pub(crate) fn warn_text(text: impl Display) -> String {
 
 /// The bold `Error:` lead-in, in the conventional error color.
 pub(crate) fn error_label(text: impl Display) -> String {
-    style(text).bold().color256(ERROR).to_string()
+    style(text).bold().color256(DANGER).to_string()
 }
 
 /// An error message body.
 pub(crate) fn error_text(text: impl Display) -> String {
-    style(text).color256(ERROR).to_string()
+    style(text).color256(DANGER).to_string()
 }

--- a/cli/src/display/theme.rs
+++ b/cli/src/display/theme.rs
@@ -4,6 +4,19 @@
 use console::{Emoji, style};
 use std::fmt::Display;
 
+/// The CLI's 256-color palette. Every colored span resolves to one of these
+/// indices, shared between the `style`-wrapping helpers below and the
+/// `indicatif` progress templates (which take color codes as bare strings, so
+/// they can't go through the helpers). Severity icons use named terminal
+/// colors instead, where the convention itself carries the meaning.
+pub(crate) const TITLE: u8 = 33; // entity titles and progress prefixes
+pub(crate) const LABEL: u8 = 37; // field labels
+pub(crate) const VALUE: u8 = 172; // field values, inline figures, and diffs
+pub(crate) const ACCENT: u8 = 35; // success lines and the progress fill/spinner
+pub(crate) const ACTIVE: u8 = 92; // in-progress action verbs
+pub(crate) const WARN: u8 = 166; // warning lead-ins and bodies
+pub(crate) const ERROR: u8 = 160; // error lead-ins and bodies
+
 /// A leading line icon in the standard accent — the single place ordinary icons
 /// get styled, so verbs pass only the glyph. Severity icons use [`warn_icon`] /
 /// [`error_icon`] instead, where the conventional color carries meaning.
@@ -23,18 +36,18 @@ pub(crate) fn error_icon(glyph: Emoji) -> String {
 
 /// The bold blue entity title (e.g. `DATASET`, `TRAINING HYPERPARAMETERS`).
 pub(crate) fn title(text: impl Display) -> String {
-    style(text).bold().color256(33).to_string()
+    style(text).bold().color256(TITLE).to_string()
 }
 
 /// A field label (the left column of a block row).
 pub(crate) fn label(text: impl Display) -> String {
-    style(text).color256(37).to_string()
+    style(text).color256(LABEL).to_string()
 }
 
 /// A success status line, in bold green — the `completed!` counterpart to the
 /// bold `warn_label`/`error_label` lead-ins.
 pub(crate) fn success(text: impl Display) -> String {
-    style(text).bold().color256(35).to_string()
+    style(text).bold().color256(ACCENT).to_string()
 }
 
 /// The dotted leader joining a label to its value.
@@ -49,35 +62,35 @@ pub(crate) fn caption(text: impl Display) -> String {
 
 /// A field value (the right column of a block row, and inline figures).
 pub(crate) fn value(text: impl Display) -> String {
-    style(text).color256(172).to_string()
+    style(text).color256(VALUE).to_string()
 }
 
 /// An in-progress action verb (e.g. `RECORDING`), in bold violet.
 pub(crate) fn active(text: impl Display) -> String {
-    style(text).bold().color256(92).to_string()
+    style(text).bold().color256(ACTIVE).to_string()
 }
 
 /// The `▲ was …` annotation shown when a value differs from a previous run.
 pub(crate) fn diff(text: impl Display) -> String {
-    style(text).color256(172).to_string()
+    style(text).color256(VALUE).to_string()
 }
 
 /// The bold `Warning:` lead-in, in the conventional warning color.
 pub(crate) fn warn_label(text: impl Display) -> String {
-    style(text).bold().color256(166).to_string()
+    style(text).bold().color256(WARN).to_string()
 }
 
 /// A warning message body.
 pub(crate) fn warn_text(text: impl Display) -> String {
-    style(text).color256(166).to_string()
+    style(text).color256(WARN).to_string()
 }
 
 /// The bold `Error:` lead-in, in the conventional error color.
 pub(crate) fn error_label(text: impl Display) -> String {
-    style(text).bold().color256(160).to_string()
+    style(text).bold().color256(ERROR).to_string()
 }
 
 /// An error message body.
 pub(crate) fn error_text(text: impl Display) -> String {
-    style(text).color256(160).to_string()
+    style(text).color256(ERROR).to_string()
 }


### PR DESCRIPTION
## Summary

Reworks the CLI progress indicators so each is pretty, shows information relevant to its task, and keeps `indicatif` confined to `display::progress`:

- **Encode** — one `Encoding` bar spanning *all* categories' images (honest end-to-end ETA) instead of one bar per category; the category name is styled inside `display`, dropping the `console::style` leak from `encode`.
- **Train** — an `Epochs` bar surfacing live loss/accuracy (validation when present, else train), each metric trailed by a trend chevron vs the previous checkpoint: ▼/▲ in the direction of change, green when improving (loss falling, accuracy rising), red otherwise, nothing when unchanged or diverged.
- **Plot** — a typed `Frames` bar replaces the generic bar/`ProgressIterator` for boundary animations.
- **Dataset prep** — a background-ticking `Spinner` covers the previously silent `prepare()` (the large-dataset split, e.g. MNIST, no longer stalls with no feedback).
- The 256-color palette is centralized in `theme`; bar prefixes (an in-progress action) use the `ACTIVE` violet rather than the entity-title blue. The red entry `ERROR` is renamed `DANGER` since it now serves both errors and worsening-metric markers.

## Notes

- `indicatif` (and `console::style`) are no longer referenced anywhere outside `display::progress` — call sites only use domain methods (`advance`, `category`, `evaluated`, `quiet`, `finish`).
- Doc comments describe palette *roles*, not literal colours, so they don't duplicate `theme` or go stale.
- `trend` is unit-tested; comparisons go through the `theme` helpers so they stay agnostic to whether colours are enabled.