### PR TITLE
ci: parallelize checks and use prebuilt tool binaries

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,29 @@
+name: Setup toolchain
+description: Install Rust (with optional components), Task, build dependencies, and restore the Cargo cache.
+
+inputs:
+  components:
+    description: Space-separated extra rustup components to install (e.g. "clippy rustfmt").
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      shell: bash
+      run: |
+        rustup update stable
+        rustup default stable
+        if [ -n "${{ inputs.components }}" ]; then
+          rustup component add ${{ inputs.components }}
+        fi
+
+    - name: Install system dependencies
+      shell: bash
+      run: sudo apt-get install -y libfontconfig-dev
+
+    - name: Install Task
+      shell: bash
+      run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+
+    - uses: Swatinem/rust-cache@v2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
       ndarray:
         patterns:
           - "ndarray*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,36 +9,53 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  checks:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        run: |
-          rustup update stable
-          rustup default stable
-          rustup component add clippy rustfmt llvm-tools-preview
-
-      - name: Install system dependencies
-        run: sudo apt-get install -y libfontconfig-dev
-
-      - name: Install Task
-        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
-
-      - uses: Swatinem/rust-cache@v2
-
-      # Checks are defined in the Taskfile so CI and local runs stay in sync.
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+        with:
+          components: clippy rustfmt
       - run: task lint
-      - run: task test
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+      - run: cargo test --workspace
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
       - run: task build
 
-      # Run after the build so the toolchain and rust-cache are already warm.
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Task
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
       - run: task audit
 
-      - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --locked
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+        with:
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
       - run: task coverage-check


### PR DESCRIPTION
## Summary

Speeds up CI by splitting the single sequential job into parallel jobs and dropping from-source compilation of tooling.

- **Parallel jobs** — `lint` / `test` / `build` / `audit` / `coverage` now run concurrently; wall-clock is the slowest job instead of the sum. Common setup (Rust + components, Task, `libfontconfig`, Cargo cache) is factored into a composite action at `.github/actions/setup`.
- **Prebuilt tool binaries** — `cargo-audit` and `cargo-llvm-cov` come from `taiki-e/install-action` instead of `cargo install --locked`, removing several minutes of source compilation per run.
- **`concurrency`** cancels superseded runs on the same ref.
- Bumped `actions/checkout` to v5.

## Notes

- `test` runs `cargo test --workspace` (default features) directly rather than `task test`: the coverage job already runs the all-features tests instrumented, so this covers only the default-feature build with no overlap.
- `audit` has no Rust setup — it relies on the runner's preinstalled `cargo` and only reads `Cargo.lock`.
- The repo currently has no `#[cfg(not(feature …))]` code, so the all-features coverage measures every line that exists; no coverage blind spot today.
- `task test` / `task checks` are unchanged for local use (still both feature variants).