### PR TITLE
fix(training): prevent NaN divergence on saturated binary sigmoid

### DIFF
--- a/cli/tests/train_lifecycle.rs
+++ b/cli/tests/train_lifecycle.rs
@@ -305,8 +305,8 @@ fn resume_from_unknown_epoch_fails() {
 
 #[test]
 fn fatal_divergence_without_early_stopping_errors() {
-    // lr=5.0 + no-clip diverges within a few epochs. Without early stopping there
-    // is no best model to recover, so the run must fail with the divergence error.
+    // An enormous lr + no-clip overflows the weights to ±inf. Without early stopping
+    // there is no best model to recover, so the run must fail with the divergence error.
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path();
     let ds = synth_ring(dir, "42", "40");
@@ -325,7 +325,7 @@ fn fatal_divergence_without_early_stopping_errors() {
             "1000",
             "--no-clip",
             "--lr",
-            "5.0",
+            "1e38",
             "--layers",
             "4,4",
         ],

--- a/cli/tests/train_plot.rs
+++ b/cli/tests/train_plot.rs
@@ -978,7 +978,7 @@ fn resume_rejects_val_ratio_override() {
 
 #[test]
 fn divergence_with_early_stopping_recovers_best_model() {
-    // lr=5.0 + no-clip causes divergence at epoch 2-3 for any He-initialized model.
+    // An enormous lr + no-clip overflows the weights to ±inf within a step or two.
     // With --early-stopping + restore_best_model (default), the best model seen before
     // divergence must be saved instead of erroring out.
     let tmp = tempfile::tempdir().unwrap();
@@ -1018,7 +1018,7 @@ fn divergence_with_early_stopping_recovers_best_model() {
             "50",
             "--no-clip",
             "--lr",
-            "5.0",
+            "1e38",
             "--early-stopping",
             "20",
             "--checkpoint-interval",
@@ -1031,18 +1031,16 @@ fn divergence_with_early_stopping_recovers_best_model() {
 
     let stderr = String::from_utf8_lossy(&out.stderr);
 
-    // With --early-stopping + restore_best_model (default), the model must always be
-    // saved: recovery kicks in on divergence, normal save on successful training.
+    // The run diverges, early stopping recovers the best pre-divergence model, and that
+    // recovered model is saved (rather than the run erroring out).
+    assert!(
+        stderr.contains("diverged") && stderr.contains("recovered"),
+        "divergence with early stopping should recover the best model\nstderr: {stderr}"
+    );
     assert!(
         model_exists(dir, ds_name),
-        "model should be saved whether training converges or recovers from divergence\nstderr: {stderr}"
+        "recovered model should be saved\nstderr: {stderr}"
     );
-    if stderr.contains("diverged") {
-        assert!(
-            stderr.contains("recovered"),
-            "divergence with early stopping should print a recovery warning\nstderr: {stderr}"
-        );
-    }
 }
 
 #[test]

--- a/core/src/nn/loss_functions/cross_entropy_loss.rs
+++ b/core/src/nn/loss_functions/cross_entropy_loss.rs
@@ -14,11 +14,18 @@ use std::sync::Arc;
 pub struct CrossEntropyLoss;
 
 impl CrossEntropyLoss {
+    /// Distance kept from the open ends of `(0, 1)` when clamping probabilities.
+    ///
+    /// Sized for `f32`: the largest float below `1.0` is `1 − 2⁻²⁴ ≈ 1 − 6e-8`, so an
+    /// epsilon any smaller than that makes `1.0 − epsilon` round straight back to `1.0`
+    /// and the upper clamp a no-op. A saturated sigmoid output of exactly `1.0` would
+    /// then drive the binary-CE gradient's `p(1 − p)` denominator to zero — `NaN`/`inf`.
+    pub(crate) const PROBABILITY_EPSILON: f32 = 1e-7;
+
     /// Clips the predicted probabilities so that they lie within a safe numerical range
     /// to prevent invalid logarithms during loss computation.
-    fn clip_probabilities(probabilities: &ArrayView2<f32>) -> Array2<f32> {
-        let epsilon = 1e-15;
-        probabilities.mapv(|p| p.clamp(epsilon, 1.0 - epsilon))
+    pub(crate) fn clip_probabilities(probabilities: &ArrayView2<f32>) -> Array2<f32> {
+        probabilities.mapv(|p| p.clamp(Self::PROBABILITY_EPSILON, 1.0 - Self::PROBABILITY_EPSILON))
     }
 }
 
@@ -84,8 +91,31 @@ pub static CROSS_ENTROPY_LOSS: Lazy<Arc<CrossEntropyLoss>> =
 mod tests {
     use super::*;
 
+    use ndarray::array;
+
     #[test]
     fn name_is_cross_entropy() {
         assert_eq!(CrossEntropyLoss.name(), "Cross-Entropy");
+    }
+
+    #[test]
+    fn clip_keeps_saturated_probabilities_off_the_open_ends() {
+        // Regression: a saturated 0.0/1.0 must land strictly inside (0, 1).
+        let clipped = CrossEntropyLoss::clip_probabilities(&array![[0.0, 1.0]].view());
+        assert!(clipped.iter().all(|&p| p > 0.0 && p < 1.0), "{clipped:?}");
+    }
+
+    #[test]
+    fn saturated_binary_predictions_give_finite_loss_and_gradient() {
+        // Correctly classified but saturated: loss ≈ 0 and gradient ≈ 0, not NaN/inf.
+        let predictions = array![[1.0, 0.0]];
+        let targets = array![[1.0, 0.0]];
+        let loss = CrossEntropyLoss.compute(predictions.view(), targets.view());
+        assert!(loss.is_finite() && loss >= 0.0, "loss = {loss}");
+
+        // gradient() expects pre-clipped inputs, mirroring the backward pass.
+        let safe = CrossEntropyLoss::clip_probabilities(&predictions.view());
+        let grad = CrossEntropyLoss.gradient(safe.view(), targets.view());
+        assert!(grad.iter().all(|v| v.is_finite()), "grad = {grad:?}");
     }
 }

--- a/core/src/nn/loss_functions/mod.rs
+++ b/core/src/nn/loss_functions/mod.rs
@@ -1,6 +1,6 @@
 mod cross_entropy_loss;
 
-pub use cross_entropy_loss::CROSS_ENTROPY_LOSS;
+pub use cross_entropy_loss::{CROSS_ENTROPY_LOSS, CrossEntropyLoss};
 
 use ndarray::{Array2, ArrayView2};
 

--- a/core/src/nn/training/backprop.rs
+++ b/core/src/nn/training/backprop.rs
@@ -1,6 +1,6 @@
 use crate::data::ModelDataset;
 use crate::gradients::{GradientClipping, Gradients};
-use crate::loss_functions::LossFunction;
+use crate::loss_functions::{CrossEntropyLoss, LossFunction};
 use crate::model::{NeuralNetwork, last_activation};
 use crate::optimizers::Optimizer;
 use crate::schedulers::Scheduler;
@@ -136,7 +136,7 @@ impl NeuralNetwork {
         let last_act = last_activation(activations);
         // Clip to (0, 1) interior so gradient() and vjp() see the same values;
         // their product then cancels exactly to p − y even near saturation.
-        let safe_act = last_act.mapv(|p| p.clamp(1e-15_f32, 1.0 - 1e-15_f32));
+        let safe_act = CrossEntropyLoss::clip_probabilities(&last_act.view());
         let loss_grad = loss_function.gradient(safe_act.view(), targets);
         let mut dz = self
             .layers
@@ -326,6 +326,36 @@ mod tests {
                     &format!("b[{layer_idx}][{i}]"),
                 );
             }
+        }
+    }
+
+    #[test]
+    fn backward_is_finite_when_binary_sigmoid_saturates() {
+        // Regression: a saturated sigmoid output (exactly 1.0/0.0 in f32) must not
+        // make the binary-CE gradient non-finite via its p(1 - p) divisor.
+        let specs = NeuronLayerSpec::network_for(vec![], &*SIGMOID, 2);
+        let mut model = NeuralNetwork::initialization(2, &specs, 0);
+
+        // Large weights so the single sample's logit saturates the sigmoid.
+        model.layers[0].weights = array![[100.0, 100.0]];
+        model.layers[0].biases = Array1::from_vec(vec![0.0]);
+
+        let inputs = array![[1.0, -1.0], [1.0, -1.0]]; // logits +200 / -200 → 1.0 / 0.0
+        let targets = array![[1.0, 0.0]];
+
+        let loss_fn: Arc<dyn LossFunction> = CROSS_ENTROPY_LOSS.clone();
+        let activations = model.forward(inputs.view());
+        // The forward output is genuinely saturated, so this exercises the clamp.
+        assert_eq!(last_activation(&activations), array![[1.0, 0.0]]);
+
+        let grads = model.backward(&activations, targets.view(), &loss_fn);
+        for g in &grads {
+            assert!(
+                g.dw.iter().chain(g.db.iter()).all(|v| v.is_finite()),
+                "saturated sigmoid produced non-finite gradients: dw={:?} db={:?}",
+                g.dw,
+                g.db
+            );
         }
     }
 }

--- a/core/src/nn/training/trainer.rs
+++ b/core/src/nn/training/trainer.rs
@@ -534,7 +534,7 @@ mod tests {
     #[test]
     fn fatal_divergence_without_recovery_is_reported_as_data() {
         let counts = Rc::new(RefCell::new(Counts::default()));
-        let hyperparameters = sample_hyperparameters(5, 1, 1e30, None, 0.0);
+        let hyperparameters = sample_hyperparameters(5, 1, f32::MAX, None, 0.0);
 
         let report = trainer(hyperparameters, counts.clone()).train().unwrap();
 
@@ -555,7 +555,7 @@ mod tests {
     fn divergence_recovers_seeded_best_model_when_restore_enabled() {
         let counts = Rc::new(RefCell::new(Counts::default()));
         let early_stopping = Some(EarlyStoppingConfig::new(10, true).unwrap());
-        let hyperparameters = sample_hyperparameters(5, 1, 1e30, early_stopping, 0.1);
+        let hyperparameters = sample_hyperparameters(5, 1, f32::MAX, early_stopping, 0.1);
 
         let report = trainer(hyperparameters, counts.clone()).train().unwrap();
 
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     fn into_result_is_err_for_unrecovered_divergence() {
         let counts = Rc::new(RefCell::new(Counts::default()));
-        let hyperparameters = sample_hyperparameters(5, 1, 1e30, None, 0.0);
+        let hyperparameters = sample_hyperparameters(5, 1, f32::MAX, None, 0.0);
         let report = trainer(hyperparameters, counts).train().unwrap();
 
         assert_eq!(


### PR DESCRIPTION
## Summary

Fixes the deterministic mid-training NaN divergence on separable binary-classification problems (the one the README tutorials worked around with `--early-stopping`).

The probability clamp guarding the binary cross-entropy gradient used an f64-scale epsilon (`1e-15`). In **f32, `1.0 - 1e-15` rounds back to `1.0`**, so the upper clamp was a no-op. Once the sigmoid output saturates to exactly `1.0` (logits ≳ 17, reached as the model fits), the `(p − y) / (p(1 − p))` gradient's divisor hits zero → `NaN`/`inf` → divergence. This explains every symptom: deterministic per seed, insensitive to gradient clipping / weight decay (they only delay saturation), delayed but not prevented by a lower lr, and absent on the softmax path.

The fix sizes the epsilon for f32 (`1e-7`) and makes it the single `CrossEntropyLoss::PROBABILITY_EPSILON`, reused by `backprop`'s clamp. The same latent bug in the loss `compute` path (`0·log(0) = NaN`) is fixed by the same change.

Verified end-to-end: `ring c2` with `--layers 16,8 --scale z-score --epochs 1000 --lr 0.005` (which previously NaN'd at epoch 203) now trains to 100% with finite loss.

## Notes

The trainer/CLI divergence tests previously relied on this very bug to blow up (`lr` saturated the sigmoid → NaN). Now that gradients stay finite, they force a *genuine* weight overflow instead (`f32::MAX` / `1e38`, which Adam needs to overshoot the float ceiling), keeping the divergence-recovery paths covered. New regression tests assert finite loss/gradients under saturation.