### PR TITLE
build(test): run the suite through cargo-nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - run: cargo test --workspace
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - run: task test
 
   build:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ The project uses [Task](https://taskfile.dev) (`brew install go-task/tap/go-task
 Useful extras:
 
 ```sh
-cargo test <name>               # single test by name, across workspace
-cargo test -p nrn <name>        # core crate only
+cargo nextest run <name>        # single test by name, across workspace
+cargo nextest run -p nrn <name> # core crate only
 task lint                       # rustfmt --check + clippy (-D warnings), with & without features
 task audit                      # cargo-audit advisory scan
 task coverage / coverage-html   # cargo-llvm-cov summary / HTML report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,11 +50,15 @@ task coverage-check    # fail under the line-coverage threshold (CI gate)
 task audit             # cargo-audit advisory scan
 ```
 
+`task test` runs the suite through [cargo-nextest](https://nexte.st) (a process per test, parallelized)
+plus the doctests, which nextest doesn't cover. Install it with `cargo install cargo-nextest --locked`
+or `brew install cargo-nextest`.
+
 Single tests, as usual:
 
 ```sh
-cargo test <name>           # by name, across the workspace
-cargo test -p nrn <name>    # core crate only
+cargo nextest run <name>        # by name, across the workspace
+cargo nextest run -p nrn <name> # core crate only
 ```
 
 ## Testing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,9 @@ members = ["cli","core"]
 # Floor set by the let-chains used in the code (stabilized in Rust 1.88);
 # edition 2024 alone would only require 1.85.
 rust-version = "1.88"
+
+# Build every dependency optimized while our own crates stay unoptimized for
+# fast, debuggable compiles. The compute-heavy training tests run inside deps
+# (ndarray's matmul), so that is where the speedup lands.
+[profile.dev.package."*"]
+opt-level = 3

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,9 +25,10 @@ tasks:
       - cargo build
 
   test:
-    desc: Run all tests across the workspace
+    desc: Run all tests across the workspace (nextest + doctests; requires cargo-nextest)
     cmds:
-      - cargo test --workspace
+      - cargo nextest run --workspace
+      - cargo test --workspace --doc
 
   fmt:
     desc: Format all source files


### PR DESCRIPTION
## Summary

Two changes to the test workflow:

1. **cargo-nextest** — `task test` runs the workspace through [cargo-nextest](https://nexte.st) (a process per test, parallelized), followed by a separate `cargo test --workspace --doc` pass, since nextest doesn't run doctests. Single-test commands in `CLAUDE.md` / `CONTRIBUTING.md` point at `cargo nextest run`. The CI `test` job installs nextest via `taiki-e/install-action` (prebuilt binary, same pattern as the `audit` and `coverage` jobs) and calls `task test`.

2. **Optimized dependencies in the dev profile** — `[profile.dev.package.\"*\"] opt-level = 3` compiles every dependency optimized while the workspace crates stay unoptimized (fast, debuggable builds). The compute-heavy training tests run inside ndarray's matmul, so this roughly halves the suite wall-clock (~14s → ~7s), most of it the CLI end-to-end training test dropping from 12s to under 6s.

## Notes

Coverage (`task coverage-check`) stays on the default `cargo test` runner on purpose — switching it to nextest would drop doctests from the measurement and could move the line-coverage number under its threshold.