### PR TITLE
feat(nn): extract a Layer trait behind the dense layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +990,7 @@ version = "0.1.0"
 dependencies = [
  "blas-src",
  "criterion",
+ "dyn-clone",
  "gif 0.14.2",
  "image 0.25.10",
  "inventory",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ ndarray = { version = "0.17.2" }
 ndarray-rand = "0.16.0"
 once_cell = "1.21.4"
 inventory = "0.3"
+dyn-clone = "1.0.20"
 
 safetensors = { version = "0.8.0", optional = true }
 serde_json = { version = "1.0.150", optional = true }

--- a/core/src/analysis/boundary.rs
+++ b/core/src/analysis/boundary.rs
@@ -245,7 +245,9 @@ fn generate_points_recursive(
 mod tests {
     use super::*;
     use crate::activations::{SIGMOID, SOFTMAX};
-    use crate::model::{NeuralNetwork, NeuronLayer};
+    use crate::data::scalers::{MinMaxScaler, ScalerMethod};
+    use crate::layers::Dense;
+    use crate::model::NeuralNetwork;
     use ndarray::array;
 
     #[test]
@@ -271,13 +273,7 @@ mod tests {
     /// the prediction is `sigmoid(x0)`, which equals exactly 0.5 when x0 == 0.
     fn binary_model() -> Predictor {
         Predictor::new(
-            NeuralNetwork {
-                layers: vec![NeuronLayer {
-                    weights: array![[1.0, 0.0]],
-                    biases: array![0.0],
-                    activation: SIGMOID.clone(),
-                }],
-            },
+            NeuralNetwork::single(Dense::new(array![[1.0, 0.0]], array![0.0], SIGMOID.clone())),
             None,
         )
     }
@@ -286,13 +282,11 @@ mod tests {
     /// classes, so a tie (equal top-two probabilities) occurs along x0 == 0.
     fn multiclass_model() -> Predictor {
         Predictor::new(
-            NeuralNetwork {
-                layers: vec![NeuronLayer {
-                    weights: array![[1.0, 0.0], [-1.0, 0.0], [0.0, 0.0]],
-                    biases: array![0.0, 0.0, -10.0],
-                    activation: SOFTMAX.clone(),
-                }],
-            },
+            NeuralNetwork::single(Dense::new(
+                array![[1.0, 0.0], [-1.0, 0.0], [0.0, 0.0]],
+                array![0.0, 0.0, -10.0],
+                SOFTMAX.clone(),
+            )),
             None,
         )
     }
@@ -317,16 +311,12 @@ mod tests {
 
     #[test]
     fn scaler_shifts_the_boundary_into_raw_coordinates() {
-        use crate::data::scalers::{MinMaxScaler, ScalerMethod};
-
         // Network: sigmoid(scaled_x0 - 0.5) == 0.5 when scaled_x0 == 0.5.
-        let network = NeuralNetwork {
-            layers: vec![NeuronLayer {
-                weights: array![[1.0, 0.0]],
-                biases: array![-0.5],
-                activation: SIGMOID.clone(),
-            }],
-        };
+        let network = NeuralNetwork::single(Dense::new(
+            array![[1.0, 0.0]],
+            array![-0.5],
+            SIGMOID.clone(),
+        ));
         // MinMax fitted on raw x0 ∈ [0, 2]: scaled 0.5 maps back to raw 1.0.
         let scaler = ScalerMethod::MinMax(
             MinMaxScaler::default().fit(array![[0.0, 0.0], [2.0, 2.0]].view()),

--- a/core/src/io/checkpoint.rs
+++ b/core/src/io/checkpoint.rs
@@ -317,13 +317,14 @@ impl CheckpointArchive {
 mod tests {
     use super::*;
     use crate::activations::RELU;
+    use crate::gradients::LayerGradients;
     use crate::io::hyperparams::HyperParametersRecord;
     use crate::io::run::{TrainingMeta, TrainingRun};
     use crate::model::NeuronLayerSpec;
     use crate::optimizers::{Adam, StochasticGradientDescent};
     use crate::schedulers::{ConstantScheduler, Scheduler, StepDecay};
     use crate::weight_decay::WeightDecay;
-    use ndarray::Array2;
+    use ndarray::{Array1, Array2};
 
     fn sample_optimizer() -> Adam {
         Adam::with_defaults(0.01.try_into().unwrap(), WeightDecay::ZERO)
@@ -839,11 +840,13 @@ mod tests {
 
         let mut optimizer = sample_optimizer();
         let mut trained_model = sample_model();
-        let gradients = crate::gradients::Gradients {
-            dw: Array2::from_elem(trained_model.layers[0].weights.dim(), 0.1),
-            db: ndarray::Array1::from_elem(trained_model.layers[0].biases.dim(), 0.1),
-        };
-        optimizer.update(0, &mut trained_model.layers[0], &gradients);
+        let neurons = trained_model.layers()[0].output_size();
+        let inputs = trained_model.layers()[0].input_size();
+        let gradients = LayerGradients(vec![
+            Array2::from_elem((neurons, inputs), 0.1).into_dyn(),
+            Array1::from_elem(neurons, 0.1).into_dyn(),
+        ]);
+        optimizer.update_layer(0, &mut *trained_model.layers_mut()[0], &gradients);
         optimizer.step();
 
         recorder

--- a/core/src/io/model.rs
+++ b/core/src/io/model.rs
@@ -1,6 +1,7 @@
 use crate::activations::ActivationProvider;
 use crate::io::tensors::{self, F32Tensor};
-use crate::model::{NeuralNetwork, NeuronLayer};
+use crate::layers::{Dense, Layer};
+use crate::model::NeuralNetwork;
 use safetensors::SafeTensors;
 use std::collections::HashMap;
 use std::io::ErrorKind::InvalidData;
@@ -14,15 +15,16 @@ impl NeuralNetwork {
         entries: &mut Vec<(String, F32Tensor)>,
         metadata: &mut HashMap<String, String>,
     ) {
-        metadata.insert("n_layers".to_string(), self.layers.len().to_string());
+        metadata.insert("n_layers".to_string(), self.layers().len().to_string());
 
-        for (i, layer) in self.layers.iter().enumerate() {
-            metadata.insert(
-                format!("layer{i}.activation"),
-                layer.activation.name().to_string(),
-            );
-            entries.push((format!("layer{i}.weights"), tensors::tensor(&layer.weights)));
-            entries.push((format!("layer{i}.biases"), tensors::tensor(&layer.biases)));
+        for (i, layer) in self.layers().iter().enumerate() {
+            metadata.insert(format!("layer{i}.kind"), layer.kind().to_string());
+            if let Some(activation) = layer.activation_name() {
+                metadata.insert(format!("layer{i}.activation"), activation.to_string());
+            }
+            for (name, tensor) in layer.named_tensors() {
+                entries.push((format!("layer{i}.{name}"), tensors::tensor(&tensor)));
+            }
         }
     }
 
@@ -36,28 +38,23 @@ impl NeuralNetwork {
             return Err(Error::new(InvalidData, "model has no layers"));
         }
 
-        let mut layers = Vec::with_capacity(n_layers);
+        let mut layers: Vec<Box<dyn Layer>> = Vec::with_capacity(n_layers);
 
         for i in 0..n_layers {
-            let weights = tensors::read_array2(&format!("layer{i}.weights"), st)?;
-            let biases = tensors::read_array1(&format!("layer{i}.biases"), st)?;
-
-            let activation_name = tensors::meta(metadata, &format!("layer{i}.activation"))?;
-            let activation = ActivationProvider::get_by_name(activation_name).ok_or_else(|| {
-                Error::new(
-                    InvalidData,
-                    format!("Unknown activation function: {activation_name}"),
-                )
-            })?;
-
-            layers.push(NeuronLayer {
-                weights,
-                biases,
-                activation,
-            });
+            let kind = tensors::meta(metadata, &format!("layer{i}.kind"))?;
+            let layer = match kind {
+                "dense" => dense_from_tensors(i, st, metadata)?,
+                other => {
+                    return Err(Error::new(
+                        InvalidData,
+                        format!("Unknown layer kind: {other}"),
+                    ));
+                }
+            };
+            layers.push(layer);
         }
 
-        Ok(NeuralNetwork { layers })
+        Ok(NeuralNetwork::new(layers))
     }
 
     /// Saves the neural network to a `.safetensors` file.
@@ -80,6 +77,26 @@ impl NeuralNetwork {
         let metadata = tensors::read_metadata(&bytes)?;
         NeuralNetwork::from_tensors(&st, &metadata)
     }
+}
+
+/// Reconstructs a [`Dense`] layer at index `i` from its weights, biases, and activation name.
+fn dense_from_tensors(
+    i: usize,
+    st: &SafeTensors,
+    metadata: &HashMap<String, String>,
+) -> Result<Box<dyn Layer>> {
+    let weights = tensors::read_array2(&format!("layer{i}.weights"), st)?;
+    let biases = tensors::read_array1(&format!("layer{i}.biases"), st)?;
+
+    let activation_name = tensors::meta(metadata, &format!("layer{i}.activation"))?;
+    let activation = ActivationProvider::get_by_name(activation_name).ok_or_else(|| {
+        Error::new(
+            InvalidData,
+            format!("Unknown activation function: {activation_name}"),
+        )
+    })?;
+
+    Ok(Box::new(Dense::new(weights, biases, activation)))
 }
 
 #[cfg(test)]
@@ -136,6 +153,7 @@ mod tests {
         ];
         let mut metadata = HashMap::new();
         metadata.insert("n_layers".to_string(), "1".to_string());
+        metadata.insert("layer0.kind".to_string(), "dense".to_string());
         metadata.insert(
             "layer0.activation".to_string(),
             "not_an_activation".to_string(),
@@ -221,7 +239,14 @@ mod tests {
             )
         };
         let activation = || ("layer0.activation".to_string(), "relu".to_string());
-        let one_layer = || HashMap::from([("n_layers".to_string(), "1".to_string()), activation()]);
+        let kind = || ("layer0.kind".to_string(), "dense".to_string());
+        let one_layer = || {
+            HashMap::from([
+                ("n_layers".to_string(), "1".to_string()),
+                kind(),
+                activation(),
+            ])
+        };
 
         // Each case is well-formed at the safetensors level but violates the model
         // schema, so `load` must reject it — exercising the read guards that
@@ -243,7 +268,7 @@ mod tests {
             (
                 "activation metadata absent",
                 vec![weights(), biases()],
-                HashMap::from([("n_layers".to_string(), "1".to_string())]),
+                HashMap::from([("n_layers".to_string(), "1".to_string()), kind()]),
             ),
             (
                 "weights stored with the wrong rank",
@@ -293,6 +318,7 @@ mod tests {
 
         let metadata = HashMap::from([
             ("n_layers".to_string(), "1".to_string()),
+            ("layer0.kind".to_string(), "dense".to_string()),
             ("layer0.activation".to_string(), "relu".to_string()),
         ]);
         let bytes = serialize(

--- a/core/src/nn/gradients.rs
+++ b/core/src/nn/gradients.rs
@@ -1,5 +1,6 @@
-use ndarray::{Array1, Array2};
+use ndarray::ArrayD;
 use std::fmt;
+use std::ops::{Deref, DerefMut};
 
 /// Small constant to prevent division by zero in gradient clipping.
 /// This value was chosen to be sufficiently small to avoid affecting the clipping behavior
@@ -67,37 +68,54 @@ impl GradientClipping {
     }
 }
 
-/// Represents the gradients computed during backpropagation for a single layer.
-pub struct Gradients {
-    /// A 2D array where each element represents the gradient of the corresponding weight.
-    pub dw: Array2<f32>,
-    /// A 1D array where each element represents the gradient of the corresponding bias.
-    pub db: Array1<f32>,
+/// The gradients computed during backpropagation for a single layer: one tensor per
+/// trainable parameter, in the layer's parameter order (see
+/// [`Layer::parameters_mut`](crate::layers::Layer::parameters_mut)). Ranks are dynamic,
+/// so parameters of any shape share one gradient type.
+pub struct LayerGradients(pub Vec<ArrayD<f32>>);
+
+impl Deref for LayerGradients {
+    type Target = Vec<ArrayD<f32>>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
-impl Gradients {
-    /// Clips the gradients to a maximum norm, using the L2 norm.
+impl DerefMut for LayerGradients {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl LayerGradients {
+    /// Clips the gradients to a maximum norm, using the L2 norm over every parameter
+    /// tensor jointly (the concatenation), so the layer's whole gradient is rescaled by
+    /// a single factor.
     /// # Arguments
     /// - `max_norm`: The maximum norm to clip the gradients to.
     pub fn clip(&mut self, max_norm: f32) {
-        let dw_norm = self.dw.mapv(|x| x.powi(2)).sum();
-        let db_norm = self.db.mapv(|x| x.powi(2)).sum();
-        let norm = (dw_norm + db_norm).sqrt();
+        let sum_sq: f32 = self
+            .iter()
+            .map(|g| g.iter().map(|x| x * x).sum::<f32>())
+            .sum();
+        let norm = sum_sq.sqrt();
 
         if norm > max_norm {
             let scale = max_norm / (norm + EPSILON);
-            self.dw.mapv_inplace(|x| x * scale);
-            self.db.mapv_inplace(|x| x * scale);
+            for grad in self.iter_mut() {
+                grad.mapv_inplace(|x| x * scale);
+            }
         }
     }
 
-    /// Clips the gradients to a specified range element-wise.
+    /// Clips the gradients to a specified range element-wise, across every parameter tensor.
     /// # Arguments
     /// - `min`: The minimum value to clip the gradients to.
     /// - `max`: The maximum value to clip the gradients to.
     pub fn clip_value(&mut self, min: f32, max: f32) {
-        self.dw.mapv_inplace(|x| x.clamp(min, max));
-        self.db.mapv_inplace(|x| x.clamp(min, max));
+        for grad in self.iter_mut() {
+            grad.mapv_inplace(|x| x.clamp(min, max));
+        }
     }
 
     /// Clips the gradients based on the specified `GradientClipping` strategy.
@@ -117,67 +135,70 @@ mod tests {
     use super::*;
     use ndarray::array;
 
+    /// Builds layer gradients from a rank-2 weight gradient and a rank-1 bias gradient,
+    /// the shape a dense layer produces.
+    fn dense_grads(dw: ndarray::Array2<f32>, db: ndarray::Array1<f32>) -> LayerGradients {
+        LayerGradients(vec![dw.into_dyn(), db.into_dyn()])
+    }
+
+    fn total_norm(grads: &LayerGradients) -> f32 {
+        grads
+            .iter()
+            .map(|g| g.iter().map(|x| x * x).sum::<f32>())
+            .sum::<f32>()
+            .sqrt()
+    }
+
     #[test]
     fn clip_rescales_gradients_above_the_max_norm() {
         // dw norm = sqrt(3^2 + 4^2) = 5, db = 0 → total norm 5, clipped to 1.0.
-        let mut grads = Gradients {
-            dw: array![[3.0, 4.0]],
-            db: array![0.0],
-        };
+        let mut grads = dense_grads(array![[3.0, 4.0]], array![0.0]);
         grads.clip(1.0);
-        let norm = (grads.dw.mapv(|x| x.powi(2)).sum() + grads.db.mapv(|x| x.powi(2)).sum()).sqrt();
+        let norm = total_norm(&grads);
         assert!((norm - 1.0).abs() < 1e-4, "norm was {}", norm);
     }
 
     #[test]
+    fn clip_uses_the_joint_norm_across_parameters() {
+        // Norm spread across two tensors: sqrt(3^2 + 4^2) = 5 jointly, clipped to 1.0.
+        let mut grads = dense_grads(array![[3.0]], array![4.0]);
+        grads.clip(1.0);
+        assert!((total_norm(&grads) - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
     fn clip_leaves_gradients_below_the_max_norm_untouched() {
-        let mut grads = Gradients {
-            dw: array![[0.3, 0.4]],
-            db: array![0.0],
-        };
+        let mut grads = dense_grads(array![[0.3, 0.4]], array![0.0]);
         grads.clip(10.0);
-        assert_eq!(grads.dw, array![[0.3, 0.4]]);
+        assert_eq!(grads[0], array![[0.3, 0.4]].into_dyn());
     }
 
     #[test]
     fn clip_value_clamps_element_wise() {
-        let mut grads = Gradients {
-            dw: array![[-5.0, 0.5, 5.0]],
-            db: array![-3.0, 3.0],
-        };
+        let mut grads = dense_grads(array![[-5.0, 0.5, 5.0]], array![-3.0, 3.0]);
         grads.clip_value(-1.0, 1.0);
-        assert_eq!(grads.dw, array![[-1.0, 0.5, 1.0]]);
-        assert_eq!(grads.db, array![-1.0, 1.0]);
+        assert_eq!(grads[0], array![[-1.0, 0.5, 1.0]].into_dyn());
+        assert_eq!(grads[1], array![-1.0, 1.0].into_dyn());
     }
 
     #[test]
     fn clip_by_dispatches_to_the_selected_strategy() {
         // None leaves gradients unchanged.
-        let mut none = Gradients {
-            dw: array![[5.0]],
-            db: array![5.0],
-        };
+        let mut none = dense_grads(array![[5.0]], array![5.0]);
         none.clip_by(&GradientClipping::None);
-        assert_eq!(none.dw, array![[5.0]]);
+        assert_eq!(none[0], array![[5.0]].into_dyn());
 
         // Value clamps element-wise.
-        let mut value = Gradients {
-            dw: array![[5.0]],
-            db: array![5.0],
-        };
+        let mut value = dense_grads(array![[5.0]], array![5.0]);
         value.clip_by(&GradientClipping::Value {
             min: -1.0,
             max: 1.0,
         });
-        assert_eq!(value.dw, array![[1.0]]);
+        assert_eq!(value[0], array![[1.0]].into_dyn());
 
         // Norm rescales to the max norm.
-        let mut norm = Gradients {
-            dw: array![[3.0, 4.0]],
-            db: array![0.0],
-        };
+        let mut norm = dense_grads(array![[3.0, 4.0]], array![0.0]);
         norm.clip_by(&GradientClipping::Norm { max_norm: 1.0 });
-        let total = (norm.dw.mapv(|x| x.powi(2)).sum() + norm.db.mapv(|x| x.powi(2)).sum()).sqrt();
-        assert!((total - 1.0).abs() < 1e-4);
+        assert!((total_norm(&norm) - 1.0).abs() < 1e-4);
     }
 }

--- a/core/src/nn/layers/dense.rs
+++ b/core/src/nn/layers/dense.rs
@@ -1,0 +1,321 @@
+use crate::activations::Activation;
+use crate::gradients::LayerGradients;
+use crate::layers::{BackwardPass, Layer, Parameter};
+use crate::model::NeuronLayerSpec;
+use ndarray::{Array1, Array2, ArrayD, ArrayView1, ArrayView2, Axis};
+use ndarray_rand::rand::RngCore;
+use std::any::Any;
+use std::sync::Arc;
+
+/// A fully connected layer: an affine map `weights · input + bias` followed by an
+/// activation, applied to every sample in the batch.
+#[derive(Clone, Debug)]
+pub struct Dense {
+    /// A 2D array where each row corresponds to a neuron and each column corresponds to an input feature.
+    weights: Array2<f32>,
+    /// A 1D array where each element is the bias for the corresponding neuron.
+    biases: Array1<f32>,
+    /// The activation function applied to the output of this layer.
+    activation: Arc<dyn Activation>,
+}
+
+impl Dense {
+    /// Assembles a `Dense` layer from explicit weights, biases, and activation.
+    /// # Panics
+    /// - When `weights` or `biases` are empty.
+    /// - When the number of weight rows does not match the number of biases.
+    /// # Arguments
+    /// - `weights`: A `(neurons, inputs)` array, one row per neuron.
+    /// - `biases`: A `(neurons)` array, one bias per neuron.
+    /// - `activation`: The activation applied to this layer's output.
+    pub fn new(weights: Array2<f32>, biases: Array1<f32>, activation: Arc<dyn Activation>) -> Self {
+        assert!(
+            weights.nrows() > 0 && weights.ncols() > 0,
+            "Dense layer weights must be non-empty."
+        );
+        assert_eq!(
+            weights.nrows(),
+            biases.len(),
+            "Dense layer needs one bias per neuron."
+        );
+
+        Dense {
+            weights,
+            biases,
+            activation,
+        }
+    }
+
+    /// Initializes a new `Dense` layer with random weights and biases drawn from `rng`.
+    /// # Panics
+    /// - When `spec.neurons` or `inputs` are less than or equal to zero.
+    /// # Arguments
+    /// - `inputs`: The number of inputs to this layer (i.e., the number of neurons in the previous layer).
+    /// - `spec`: The specifications for this layer, including the number of neurons and the activation method.
+    /// - `rng`: The random number generator the weights are drawn from. Passing a seeded
+    ///   generator makes the initialization reproducible.
+    pub fn initialization(inputs: usize, spec: &NeuronLayerSpec, rng: &mut dyn RngCore) -> Self {
+        assert!(
+            spec.neurons > 0 && inputs > 0,
+            "Neurons and inputs must be greater than zero."
+        );
+
+        let (weights, biases) = spec
+            .activation
+            .initialization()
+            .apply((spec.neurons, inputs), rng);
+
+        Self::new(weights, biases, spec.activation.clone())
+    }
+
+    /// Returns the specifications of this layer.
+    pub fn spec(&self) -> NeuronLayerSpec {
+        NeuronLayerSpec {
+            neurons: self.weights.nrows(),
+            activation: self.activation.clone(),
+        }
+    }
+
+    /// This layer's weight matrix `(neurons, inputs)`.
+    pub fn weights(&self) -> ArrayView2<'_, f32> {
+        self.weights.view()
+    }
+
+    /// This layer's biases, one per neuron.
+    pub fn biases(&self) -> ArrayView1<'_, f32> {
+        self.biases.view()
+    }
+
+    /// The activation applied to this layer's output.
+    pub fn activation(&self) -> &Arc<dyn Activation> {
+        &self.activation
+    }
+
+    /// Mutable access to this layer's weight matrix.
+    #[cfg(test)]
+    pub(crate) fn weights_mut(&mut self) -> &mut Array2<f32> {
+        &mut self.weights
+    }
+
+    /// Mutable access to this layer's biases.
+    #[cfg(test)]
+    pub(crate) fn biases_mut(&mut self) -> &mut Array1<f32> {
+        &mut self.biases
+    }
+}
+
+impl Layer for Dense {
+    fn forward(&self, input: ArrayView2<f32>) -> Array2<f32> {
+        assert_eq!(
+            input.nrows(),
+            self.weights.ncols(),
+            "Input shape does not match weights shape."
+        );
+
+        // Broadcasting bias to match the shape of the output
+        let broadcasted_biases: Array2<f32> = self.biases.view().insert_axis(Axis(1)).to_owned();
+
+        self.activation
+            .apply((self.weights.dot(&input) + &broadcasted_biases).view())
+    }
+
+    fn backward(
+        &self,
+        da: ArrayView2<f32>,
+        input: ArrayView2<f32>,
+        output: ArrayView2<f32>,
+        compute_input_gradient: bool,
+    ) -> BackwardPass {
+        let m = input.ncols() as f32;
+
+        // dz = dL/d(pre-activation); the activation's VJP turns dL/d(output) into it.
+        let dz = self.activation.vjp(da, output);
+        let dw = dz.dot(&input.t()) / m;
+        let db = dz.sum_axis(Axis(1)) / m;
+        // dL/d(input), the gradient handed back to the upstream layer.
+        let input_gradient = compute_input_gradient.then(|| self.weights.t().dot(&dz));
+
+        BackwardPass {
+            gradients: LayerGradients(vec![dw.into_dyn(), db.into_dyn()]),
+            input_gradient,
+        }
+    }
+
+    fn parameters_mut(&mut self) -> Vec<Parameter<'_>> {
+        vec![
+            Parameter {
+                value: self.weights.view_mut().into_dyn(),
+                decays: true,
+            },
+            Parameter {
+                value: self.biases.view_mut().into_dyn(),
+                decays: false,
+            },
+        ]
+    }
+
+    fn input_size(&self) -> usize {
+        self.weights.ncols()
+    }
+
+    fn output_size(&self) -> usize {
+        self.weights.nrows()
+    }
+
+    fn is_finite(&self) -> bool {
+        self.weights.iter().all(|v| v.is_finite()) && self.biases.iter().all(|v| v.is_finite())
+    }
+
+    fn kind(&self) -> &'static str {
+        "dense"
+    }
+
+    fn named_tensors(&self) -> Vec<(String, ArrayD<f32>)> {
+        vec![
+            ("weights".to_string(), self.weights.clone().into_dyn()),
+            ("biases".to_string(), self.biases.clone().into_dyn()),
+        ]
+    }
+
+    fn activation_name(&self) -> Option<&str> {
+        Some(self.activation.name())
+    }
+
+    fn weight_matrix(&self) -> Option<ArrayView2<'_, f32>> {
+        Some(self.weights.view())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::activations::{RELU, SIGMOID};
+    use ndarray::array;
+
+    #[test]
+    fn accessors_report_dimensions_and_activation() {
+        // 2 neurons, each taking 3 inputs.
+        let layer = Dense {
+            weights: Array2::zeros((2, 3)),
+            biases: Array1::zeros(2),
+            activation: RELU.clone(),
+        };
+        assert_eq!(layer.output_size(), 2);
+        assert_eq!(layer.input_size(), 3);
+        assert_eq!(layer.kind(), "dense");
+        assert_eq!(layer.activation_name(), Some("relu"));
+        assert_eq!(layer.weight_matrix().unwrap().dim(), (2, 3));
+
+        let spec = layer.spec();
+        assert_eq!(spec.neurons, 2);
+        assert_eq!(spec.activation.name(), "relu");
+    }
+
+    #[test]
+    fn parameters_are_weights_then_bias_with_decay_flags() {
+        let mut layer = Dense {
+            weights: array![[1.0, 2.0], [3.0, 4.0]],
+            biases: array![5.0, 6.0],
+            activation: RELU.clone(),
+        };
+        let params = layer.parameters_mut();
+        assert_eq!(params.len(), 2);
+        // Weights decay, the bias does not.
+        assert!(params[0].decays);
+        assert_eq!(params[0].value.shape(), &[2, 2]);
+        assert!(!params[1].decays);
+        assert_eq!(params[1].value.shape(), &[2]);
+    }
+
+    #[test]
+    fn named_tensors_are_weights_and_biases() {
+        let layer = Dense {
+            weights: array![[1.0, 2.0]],
+            biases: array![3.0],
+            activation: RELU.clone(),
+        };
+        let tensors = layer.named_tensors();
+        assert_eq!(tensors[0].0, "weights");
+        assert_eq!(tensors[0].1, array![[1.0, 2.0]].into_dyn());
+        assert_eq!(tensors[1].0, "biases");
+        assert_eq!(tensors[1].1, array![3.0].into_dyn());
+    }
+
+    #[test]
+    fn backward_gradients_match_numerical_approximation() {
+        // Isolated single dense layer: with an upstream gradient of all ones, the loss
+        // is L = sum(output), so finite differences of that sum recover the analytical
+        // gradients. backward divides the parameter gradients by the sample count, so
+        // the numerical estimate (which does not) is compared against `grad * m`.
+        let layer = Dense {
+            weights: array![[0.2, -0.4, 0.1], [0.5, 0.3, -0.2]],
+            biases: array![0.05, -0.1],
+            activation: SIGMOID.clone(),
+        };
+        let input = array![
+            [0.5, -0.3, 0.8, 0.1],
+            [0.2, 0.7, -0.5, 0.4],
+            [-0.1, 0.6, 0.3, -0.4]
+        ];
+        let m = input.ncols() as f32;
+
+        let output = layer.forward(input.view());
+        let da = Array2::<f32>::ones(output.dim());
+        let pass = layer.backward(da.view(), input.view(), output.view(), true);
+        let grads = pass.gradients;
+        let da_prev = pass.input_gradient.expect("input gradient requested");
+
+        let loss = |layer: &Dense| layer.forward(input.view()).sum();
+        let eps = 1e-3_f32;
+        let tolerance = 5e-2_f32;
+        let check = |analytical: f32, numerical: f32, label: &str| {
+            let rel = (numerical - analytical).abs()
+                / (numerical.abs().max(analytical.abs()).max(1e-2) + 1e-8);
+            assert!(
+                rel < tolerance,
+                "{label}: analytical={analytical:.6}, numerical={numerical:.6}"
+            );
+        };
+
+        // Weight and bias gradients: perturb each parameter, take the central difference
+        // of the loss, and compare to `grad * m`.
+        for i in 0..layer.output_size() {
+            for j in 0..layer.input_size() {
+                let mut plus = layer.clone();
+                plus.weights[[i, j]] += eps;
+                let mut minus = layer.clone();
+                minus.weights[[i, j]] -= eps;
+                let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
+                check(grads[0][[i, j]] * m, numerical, &format!("dw[{i},{j}]"));
+            }
+            let mut plus = layer.clone();
+            plus.biases[i] += eps;
+            let mut minus = layer.clone();
+            minus.biases[i] -= eps;
+            let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
+            check(grads[1][i] * m, numerical, &format!("db[{i}]"));
+        }
+
+        // Gradient with respect to the input: perturb each input entry.
+        for k in 0..layer.input_size() {
+            for s in 0..input.ncols() {
+                let mut plus = input.clone();
+                plus[[k, s]] += eps;
+                let mut minus = input.clone();
+                minus[[k, s]] -= eps;
+                let numerical = (layer.forward(plus.view()).sum()
+                    - layer.forward(minus.view()).sum())
+                    / (2.0 * eps);
+                check(da_prev[[k, s]], numerical, &format!("da_prev[{k},{s}]"));
+            }
+        }
+    }
+}

--- a/core/src/nn/layers/mod.rs
+++ b/core/src/nn/layers/mod.rs
@@ -1,0 +1,99 @@
+//! Layer abstraction for a neural network.
+//!
+//! A [`Layer`] is one stage of the network: it maps a batch of inputs to a batch of
+//! outputs in the forward pass and, in the backward pass, turns the gradient of the loss
+//! with respect to its output into the gradients of its parameters and the gradient with
+//! respect to its input. Layers are stateless with respect to the forward activations —
+//! the network threads those between layers — so a layer holds only its parameters.
+
+mod dense;
+
+pub use dense::Dense;
+
+use crate::gradients::LayerGradients;
+use dyn_clone::DynClone;
+use ndarray::{Array2, ArrayD, ArrayView2, ArrayViewMutD};
+use std::any::Any;
+use std::fmt::Debug;
+
+/// One trainable parameter of a layer, exposed for an optimizer to update in place.
+pub struct Parameter<'a> {
+    /// A mutable view of the parameter's values.
+    pub value: ArrayViewMutD<'a, f32>,
+    /// Whether weight decay applies to this parameter: weights decay, biases do not.
+    pub decays: bool,
+}
+
+/// The result of a layer's backward pass.
+pub struct BackwardPass {
+    /// The gradients of the layer's parameters, in parameter order.
+    pub gradients: LayerGradients,
+    /// The gradient of the loss with respect to the layer's input, or `None` when the
+    /// caller did not request it.
+    pub input_gradient: Option<Array2<f32>>,
+}
+
+/// One stage of a neural network, mapping a batch of inputs to a batch of outputs.
+///
+/// Arrays are `(features, samples)`: columns are samples, rows are features.
+pub trait Layer: DynClone + Debug {
+    /// Computes the forward pass of this layer given the inputs.
+    /// # Arguments
+    /// - `input`: A 2D array `(input_size, samples)` representing the inputs to this layer.
+    /// # Returns
+    /// - A 2D array `(output_size, samples)` representing the outputs of this layer.
+    fn forward(&self, input: ArrayView2<f32>) -> Array2<f32>;
+
+    /// Computes the backward pass of this layer for one batch, propagating the gradient
+    /// back one stage.
+    /// # Arguments
+    /// - `da`: A 2D array, the gradient of the loss with respect to this layer's output.
+    /// - `input`: The batch that was fed to this layer in the forward pass.
+    /// - `output`: This layer's output from the forward pass.
+    /// - `compute_input_gradient`: Whether to also compute the gradient with respect to `input`.
+    /// # Returns
+    /// - A [`BackwardPass`] carrying the parameter gradients and, when
+    ///   `compute_input_gradient` is set, the gradient of the loss with respect to `input` —
+    ///   the `da` the upstream layer receives.
+    fn backward(
+        &self,
+        da: ArrayView2<f32>,
+        input: ArrayView2<f32>,
+        output: ArrayView2<f32>,
+        compute_input_gradient: bool,
+    ) -> BackwardPass;
+
+    /// The layer's trainable parameters, in a stable order matching the gradient order
+    /// returned by [`backward`](Layer::backward).
+    fn parameters_mut(&mut self) -> Vec<Parameter<'_>>;
+
+    /// The number of input features this layer expects.
+    fn input_size(&self) -> usize;
+
+    /// The number of output features this layer produces.
+    fn output_size(&self) -> usize;
+
+    /// Whether every parameter value is finite (no NaN or Inf).
+    fn is_finite(&self) -> bool;
+
+    /// A short identifier for the layer type, such as `"dense"`.
+    fn kind(&self) -> &'static str;
+
+    /// The layer's parameters as named tensors.
+    fn named_tensors(&self) -> Vec<(String, ArrayD<f32>)>;
+
+    /// The name of the activation this layer applies, or `None` for a layer without one.
+    fn activation_name(&self) -> Option<&str>;
+
+    /// The layer's weight matrix `(output_size, input_size)`, or `None` for a layer
+    /// that is not an affine map and carries no weights.
+    fn weight_matrix(&self) -> Option<ArrayView2<'_, f32>>;
+
+    /// The layer as `&dyn Any`, for downcasting to a concrete layer type.
+    fn as_any(&self) -> &dyn Any;
+
+    /// The layer as `&mut dyn Any`, for downcasting to a concrete layer type.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+dyn_clone::clone_trait_object!(Layer);

--- a/core/src/nn/mod.rs
+++ b/core/src/nn/mod.rs
@@ -5,6 +5,7 @@ pub mod evaluation;
 pub mod evaluation_history;
 pub mod gradients;
 pub mod initializations;
+pub mod layers;
 pub mod learning_rate;
 pub mod loss_functions;
 pub mod model;

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -6,30 +6,19 @@
 
 use crate::activations::{Activation, SIGMOID, SOFTMAX};
 use crate::data::scalers::{Scaler, ScalerFeatureMismatch, ScalerMethod};
+use crate::layers::{Dense, Layer};
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Axis};
-use ndarray_rand::rand::RngCore;
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::rngs::StdRng;
 use std::fmt;
 use std::iter::once;
 use std::sync::Arc;
 
-/// Represents a single layer in a neural network, containing weights and biases.
-#[derive(Clone, Debug)]
-pub struct NeuronLayer {
-    /// A 2D array where each row corresponds to a neuron and each column corresponds to an input feature.
-    pub weights: Array2<f32>,
-    /// A 1D array where each element is the bias for the corresponding neuron.
-    pub biases: Array1<f32>,
-    /// The activation function applied to the output of this layer.
-    pub activation: Arc<dyn Activation>,
-}
-
-/// Represents a neural network composed of multiple layers of neurons.
+/// Represents a neural network composed of a stack of layers.
 #[derive(Clone, Debug)]
 pub struct NeuralNetwork {
-    /// A vector of [`NeuronLayer`] instances, defining the architecture of the network.
-    pub layers: Vec<NeuronLayer>,
+    /// The layers of the network, applied in order from input to output.
+    layers: Vec<Box<dyn Layer>>,
 }
 
 /// Represents the specifications for a neuron layer in a neural network.
@@ -84,79 +73,45 @@ pub fn last_activation(activations: &[Array2<f32>]) -> Array2<f32> {
         .to_owned()
 }
 
-impl NeuronLayer {
-    /// Initializes a new `NeuronLayer` with random weights and biases drawn from `rng`.
-    /// # Panics
-    /// - When `neurons` or `inputs` are less than or equal to zero.
-    /// # Arguments
-    /// - `inputs`: The number of inputs to this layer (i.e., the number of neurons in the previous layer).
-    /// - `spec`: The specifications for this layer, including the number of neurons and the activation method.
-    /// - `rng`: The random number generator the weights are drawn from. Passing a seeded
-    ///   generator makes the initialization reproducible.
-    pub fn initialization(inputs: usize, spec: &NeuronLayerSpec, rng: &mut dyn RngCore) -> Self {
-        assert!(
-            spec.neurons > 0 && inputs > 0,
-            "Neurons and inputs must be greater than zero."
-        );
-
-        let (weights, biases) = spec
-            .activation
-            .initialization()
-            .apply((spec.neurons, inputs), rng);
-
-        NeuronLayer {
-            weights,
-            biases,
-            activation: spec.activation.clone(),
-        }
-    }
-
-    /// Computes the forward pass of this layer given the inputs.
-    /// # Arguments
-    /// - `inputs`: A 2D array representing the inputs to this layer.
-    /// # Returns
-    /// - A 2D array representing the outputs of this layer after applying the configured activation function.
-    pub fn forward(&self, inputs: &Array2<f32>) -> Array2<f32> {
-        assert_eq!(
-            inputs.nrows(),
-            self.weights.ncols(),
-            "Input shape does not match weights shape."
-        );
-
-        // Broadcasting bias to match the shape of the output
-        let broadcasted_biases: Array2<f32> = self.biases.view().insert_axis(Axis(1)).to_owned();
-
-        self.activation
-            .apply((self.weights.dot(inputs) + &broadcasted_biases).view())
-    }
-
-    /// Returns the number of neurons in this layer.
-    pub fn size(&self) -> usize {
-        self.weights.nrows()
-    }
-
-    /// Returns `true` when all weights and biases in this layer are finite (no NaN or Inf).
-    pub fn is_finite(&self) -> bool {
-        self.weights.iter().all(|v| v.is_finite()) && self.biases.iter().all(|v| v.is_finite())
-    }
-
-    /// Returns the number of inputs to this layer.
-    /// For example, this is the number of neurons in the previous layer,
-    /// or the input size for the first layer.
-    pub fn input_size(&self) -> usize {
-        self.weights.ncols()
-    }
-
-    /// Returns the specifications of this layer.
-    pub fn spec(&self) -> NeuronLayerSpec {
-        NeuronLayerSpec {
-            neurons: self.size(),
-            activation: self.activation.clone(),
-        }
-    }
-}
-
 impl NeuralNetwork {
+    /// Assembles a network from a stack of layers, applied in order from input to output.
+    /// # Panics
+    /// When `layers` is empty.
+    pub fn new(layers: Vec<Box<dyn Layer>>) -> Self {
+        assert!(!layers.is_empty(), "a network must have at least one layer");
+        NeuralNetwork { layers }
+    }
+
+    /// Assembles a single-layer network from one layer.
+    pub fn single(layer: impl Layer + 'static) -> Self {
+        Self::new(vec![Box::new(layer)])
+    }
+
+    /// Appends a layer to the network, returning the network for chaining.
+    /// # Panics
+    /// When the layer's input size does not match the current output size.
+    pub fn with_layer(mut self, layer: impl Layer + 'static) -> Self {
+        if let Some(last) = self.layers.last() {
+            assert_eq!(
+                layer.input_size(),
+                last.output_size(),
+                "layer input size must match the previous layer's output size"
+            );
+        }
+        self.layers.push(Box::new(layer));
+        self
+    }
+
+    /// The network's layers, in order from input to output.
+    pub fn layers(&self) -> &[Box<dyn Layer>] {
+        &self.layers
+    }
+
+    /// The network's layers, mutably, in order from input to output.
+    pub(crate) fn layers_mut(&mut self) -> &mut [Box<dyn Layer>] {
+        &mut self.layers
+    }
+
     /// Creates a new `NeuralNetwork` with the specified input size and layer specifications.
     ///
     /// The weights are drawn from a generator seeded with `seed`, so initialization is
@@ -181,19 +136,14 @@ impl NeuralNetwork {
         let mut layer_input = inputs;
 
         for layer_spec in layer_specs {
-            layers.push(NeuronLayer::initialization(
-                layer_input,
-                layer_spec,
-                &mut rng,
-            ));
+            layers.push(
+                Box::new(Dense::initialization(layer_input, layer_spec, &mut rng))
+                    as Box<dyn Layer>,
+            );
             layer_input = layer_spec.neurons;
         }
 
-        NeuralNetwork { layers }
-    }
-
-    pub fn specs(&self) -> Vec<NeuronLayerSpec> {
-        self.layers.iter().map(|layer| layer.spec()).collect()
+        Self::new(layers)
     }
 
     /// Returns the input size of the network, which is the number of inputs to the first layer.
@@ -208,19 +158,21 @@ impl NeuralNetwork {
             .layers
             .last()
             .expect("network has at least one layer")
-            .size();
+            .output_size();
         if out == 1 { 2 } else { out }
     }
 
     /// Returns a summary of the network's architecture as a string,
     /// showing the number of neurons in each layer, including the input layer.
     pub fn summary(&self) -> String {
-        once(self.input_size())
-            .map(|size| format!("[{}]", size))
+        once(format!("[{}]", self.input_size()))
             .chain(
-                self.specs()
+                self.layers
                     .iter()
-                    .map(|spec| format!("{}-{}", spec.neurons, spec.activation.name())),
+                    .map(|layer| match layer.activation_name() {
+                        Some(activation) => format!("{}-{}", layer.output_size(), activation),
+                        None => layer.output_size().to_string(),
+                    }),
             )
             .collect::<Vec<String>>()
             .join(" -> ")
@@ -241,7 +193,7 @@ impl NeuralNetwork {
             .layers
             .iter()
             .fold(vec![inputs.to_owned()], |mut acc, layer| {
-                acc.push(layer.forward(acc.last().unwrap()));
+                acc.push(layer.forward(acc.last().unwrap().view()));
                 acc
             }))
     }
@@ -546,43 +498,28 @@ mod tests {
         biases: Array1<f32>,
         activation: Arc<dyn Activation>,
     ) -> NeuralNetwork {
-        NeuralNetwork {
-            layers: vec![NeuronLayer {
-                weights,
-                biases,
-                activation,
-            }],
-        }
+        NeuralNetwork::single(Dense::new(weights, biases, activation))
+    }
+
+    /// Downcasts a network's layer back to the concrete [`Dense`] to read or perturb its
+    /// weights and biases in tests.
+    fn dense_mut(model: &mut NeuralNetwork, index: usize) -> &mut Dense {
+        model.layers[index]
+            .as_any_mut()
+            .downcast_mut::<Dense>()
+            .unwrap()
     }
 
     #[test]
-    fn layer_accessors_report_dimensions_and_spec() {
-        // 2 neurons, each taking 3 inputs.
-        let layer = NeuronLayer {
-            weights: Array2::zeros((2, 3)),
-            biases: Array1::zeros(2),
-            activation: RELU.clone(),
-        };
-        assert_eq!(layer.size(), 2);
-        assert_eq!(layer.input_size(), 3);
-
-        let spec = layer.spec();
-        assert_eq!(spec.neurons, 2);
-        assert_eq!(spec.activation.name(), "relu");
-    }
-
-    #[test]
-    fn network_reports_specs_input_size_and_summary() {
+    fn network_reports_input_size_and_summary() {
         // 3 inputs -> 4 relu -> 3 softmax
         let specs = NeuronLayerSpec::network_for(vec![4], &*RELU, 3);
         let model = NeuralNetwork::initialization(3, &specs, 0);
 
         assert_eq!(model.input_size(), 3);
-
-        let reported = model.specs();
-        assert_eq!(reported.len(), 2);
-        assert_eq!(reported[0].neurons, 4);
-        assert_eq!(reported[1].neurons, 3);
+        assert_eq!(model.layers.len(), 2);
+        assert_eq!(model.layers[0].output_size(), 4);
+        assert_eq!(model.layers[1].output_size(), 3);
 
         assert_eq!(model.summary(), "[3] -> 4-relu -> 3-softmax");
     }
@@ -660,7 +597,7 @@ mod tests {
     #[should_panic(expected = "non-finite predictions")]
     fn predict_panics_when_model_has_diverged() {
         let mut model = make_network(Array2::zeros((1, 2)), Array1::zeros(1), SIGMOID.clone());
-        model.layers[0].weights = array![[f32::NAN, 0.0]];
+        *dense_mut(&mut model, 0).weights_mut() = array![[f32::NAN, 0.0]];
         let inputs = array![[1.0], [1.0]];
         let _ = model.predict(inputs.view());
     }
@@ -674,14 +611,14 @@ mod tests {
     #[test]
     fn is_finite_detects_nan_in_weights() {
         let mut model = make_network(Array2::zeros((1, 2)), Array1::zeros(1), SIGMOID.clone());
-        model.layers[0].weights[[0, 0]] = f32::NAN;
+        dense_mut(&mut model, 0).weights_mut()[[0, 0]] = f32::NAN;
         assert!(!model.is_finite());
     }
 
     #[test]
     fn is_finite_detects_inf_in_biases() {
         let mut model = make_network(Array2::zeros((1, 2)), Array1::zeros(1), SIGMOID.clone());
-        model.layers[0].biases[0] = f32::INFINITY;
+        dense_mut(&mut model, 0).biases_mut()[0] = f32::INFINITY;
         assert!(!model.is_finite());
     }
 

--- a/core/src/nn/optimizers/adam.rs
+++ b/core/src/nn/optimizers/adam.rs
@@ -1,24 +1,25 @@
-use crate::gradients::Gradients;
 use crate::learning_rate::LearningRate;
-use crate::model::NeuronLayer;
-use crate::optimizers::{Optimizer, OptimizerState, OptimizerStateError};
+use crate::optimizers::{Optimizer, OptimizerState, OptimizerStateError, ParameterUpdates};
 use crate::weight_decay::WeightDecay;
-use ndarray::{Array1, Array2};
-use std::collections::HashMap;
+use ndarray::{ArrayD, Zip};
+use std::collections::{BTreeMap, HashMap};
 
-/// Adam optimizer state, maintaining first and second moment estimates.
-struct AdamState {
-    /// First moment estimates for weights, averaging past gradients.
-    m_weights: Array2<f32>,
-    /// Second moment estimates for weights, variances of past gradients.
-    v_weights: Array2<f32>,
-    /// First moment estimates for biases, averaging past gradients.
-    m_biases: Array1<f32>,
-    /// Second moment estimates for biases, variances of past gradients.
-    v_biases: Array1<f32>,
+/// Adam moment estimates for a single parameter: the first moment (average of past
+/// gradients) and the second moment (average of their squares).
+struct AdamMoments {
+    /// First moment estimate, averaging past gradients.
+    m: ArrayD<f32>,
+    /// Second moment estimate, the variance of past gradients.
+    v: ArrayD<f32>,
 }
 
-/// Provides the Adam optimization algorithm for updating neural network weights and biases.
+/// Which moment estimate a state tensor name refers to.
+enum MomentField {
+    M,
+    V,
+}
+
+/// Provides the Adam optimization algorithm for updating neural network parameters.
 pub struct Adam {
     /// Learning rate for the optimizer.
     learning_rate: LearningRate,
@@ -28,13 +29,12 @@ pub struct Adam {
     beta2: f32,
     /// Small constant for numerical stability.
     epsilon: f32,
-    /// Decoupled weight-decay coefficient (AdamW). Applied to weights only, never
-    /// biases.
+    /// Decoupled weight-decay coefficient (AdamW). Applied to decaying parameters only.
     weight_decay: WeightDecay,
     /// Step counter for bias correction.
     time_step: u32,
-    /// Internal state for each layer, storing moment estimates.
-    states: HashMap<usize, AdamState>,
+    /// Internal state for each layer: one [`AdamMoments`] per parameter, in parameter order.
+    states: HashMap<usize, Vec<AdamMoments>>,
 }
 
 impl Adam {
@@ -71,23 +71,6 @@ impl Adam {
         // to 0, leaving epsilon as the sole denominator and inflating the effective step.
         Self::new(learning_rate, 0.9, 0.999, 1e-5, weight_decay)
     }
-
-    fn init_state(&mut self, layer_index: usize, layer: &NeuronLayer) {
-        let m_weights = Array2::<f32>::zeros(layer.weights.dim());
-        let v_weights = Array2::<f32>::zeros(layer.weights.dim());
-        let m_biases = Array1::<f32>::zeros(layer.biases.dim());
-        let v_biases = Array1::<f32>::zeros(layer.biases.dim());
-
-        self.states.insert(
-            layer_index,
-            AdamState {
-                m_weights,
-                v_weights,
-                m_biases,
-                v_biases,
-            },
-        );
-    }
 }
 
 impl Optimizer for Adam {
@@ -107,42 +90,65 @@ impl Optimizer for Adam {
         self.learning_rate = learning_rate;
     }
 
-    fn update(&mut self, layer_index: usize, layer: &mut NeuronLayer, gradients: &Gradients) {
-        if !self.states.contains_key(&layer_index) {
-            self.init_state(layer_index, layer);
+    fn update(&mut self, layer_index: usize, updates: &mut ParameterUpdates<'_>) {
+        let lr = self.learning_rate.value();
+        let (beta1, beta2, epsilon, weight_decay) =
+            (self.beta1, self.beta2, self.epsilon, self.weight_decay);
+        let beta1_correction = 1.0 - beta1.powi(self.time_step as i32);
+        let beta2_correction = 1.0 - beta2.powi(self.time_step as i32);
+
+        let moments = self.states.entry(layer_index).or_insert_with(|| {
+            updates
+                .iter()
+                .map(|update| AdamMoments {
+                    m: ArrayD::zeros(update.parameter.value.raw_dim()),
+                    v: ArrayD::zeros(update.parameter.value.raw_dim()),
+                })
+                .collect()
+        });
+
+        // A restored state must describe exactly this layer's parameters; a shorter or
+        // longer moment list means the checkpoint does not belong to this model, which
+        // would otherwise leave some parameters silently un-updated.
+        assert_eq!(
+            moments.len(),
+            updates.len(),
+            "Adam state for layer {layer_index} has {} parameters, but the layer has {}",
+            moments.len(),
+            updates.len(),
+        );
+
+        for (update, moment) in updates.iter_mut().zip(moments.iter_mut()) {
+            assert_eq!(
+                moment.m.shape(),
+                update.parameter.value.shape(),
+                "Adam moment shape does not match parameter shape for layer {layer_index}",
+            );
+            // Decoupled weight decay (AdamW): shrink decaying parameters before the
+            // gradient step. A factor of `1.0` leaves non-decaying parameters untouched.
+            let decay = if weight_decay.is_active() && update.parameter.decays {
+                1.0 - lr * weight_decay.value()
+            } else {
+                1.0
+            };
+
+            // Fuse the moment updates, bias correction, decay, and parameter step into a
+            // single in-place pass. On tiny parameters this pays the array traversal once
+            // instead of allocating a temporary per sub-expression.
+            Zip::from(update.parameter.value.view_mut())
+                .and(&mut moment.m)
+                .and(&mut moment.v)
+                .and(update.gradient)
+                .for_each(|param, m, v, &g| {
+                    // Biased first and second moment estimates.
+                    *m = *m * beta1 + g * (1.0 - beta1);
+                    *v = *v * beta2 + g * g * (1.0 - beta2);
+                    // Bias-corrected estimates.
+                    let m_hat = *m / beta1_correction;
+                    let v_hat = *v / beta2_correction;
+                    *param = *param * decay - m_hat * lr / (v_hat.sqrt() + epsilon);
+                });
         }
-
-        let state = self.states.get_mut(&layer_index).unwrap();
-        let (dw, db) = (&gradients.dw, &gradients.db);
-
-        // Update biased first moment estimate
-        state.m_weights = &state.m_weights * self.beta1 + dw * (1.0 - self.beta1);
-        state.m_biases = &state.m_biases * self.beta1 + db * (1.0 - self.beta1);
-
-        // Update biased second moment estimate
-        state.v_weights = &state.v_weights * self.beta2 + &(dw * dw) * (1.0 - self.beta2);
-        state.v_biases = &state.v_biases * self.beta2 + &(db * db) * (1.0 - self.beta2);
-
-        let beta1_correction = 1.0 - self.beta1.powi(self.time_step as i32);
-        let beta2_correction = 1.0 - self.beta2.powi(self.time_step as i32);
-
-        // Compute bias-corrected first and second moment estimates
-        let m_hat_weights = &state.m_weights / beta1_correction;
-        let m_hat_biases = &state.m_biases / beta1_correction;
-        let v_hat_weights = &state.v_weights / beta2_correction;
-        let v_hat_biases = &state.v_biases / beta2_correction;
-
-        // Decoupled weight decay (AdamW): shrink the weights before the gradient
-        // step. Biases are not decayed.
-        if self.weight_decay.is_active() {
-            layer.weights *= 1.0 - self.learning_rate.value() * self.weight_decay.value();
-        }
-
-        // Update weights and biases
-        layer.weights -= &(m_hat_weights * self.learning_rate.value()
-            / (v_hat_weights.mapv(f32::sqrt) + self.epsilon));
-        layer.biases -= &(m_hat_biases * self.learning_rate.value()
-            / (v_hat_biases.mapv(f32::sqrt) + self.epsilon));
     }
 
     fn step(&mut self) {
@@ -150,24 +156,18 @@ impl Optimizer for Adam {
     }
 
     fn to_state(&self) -> Option<OptimizerState> {
-        let mut tensors = Vec::with_capacity(self.states.len() * 4);
-        for (layer_index, state) in &self.states {
-            tensors.push((
-                format!("layer{layer_index}.m_weights"),
-                state.m_weights.clone().into_dyn(),
-            ));
-            tensors.push((
-                format!("layer{layer_index}.v_weights"),
-                state.v_weights.clone().into_dyn(),
-            ));
-            tensors.push((
-                format!("layer{layer_index}.m_biases"),
-                state.m_biases.clone().into_dyn(),
-            ));
-            tensors.push((
-                format!("layer{layer_index}.v_biases"),
-                state.v_biases.clone().into_dyn(),
-            ));
+        let mut tensors = Vec::with_capacity(self.states.len() * 2);
+        for (layer_index, moments) in &self.states {
+            for (param_index, moment) in moments.iter().enumerate() {
+                tensors.push((
+                    format!("layer{layer_index}.param{param_index}.m"),
+                    moment.m.clone(),
+                ));
+                tensors.push((
+                    format!("layer{layer_index}.param{param_index}.v"),
+                    moment.v.clone(),
+                ));
+            }
         }
 
         let mut metadata = HashMap::new();
@@ -186,91 +186,96 @@ impl Optimizer for Adam {
                 key: "time_step".to_string(),
             })?;
 
-        let mut partials: HashMap<usize, PartialAdamState> = HashMap::new();
+        // Group tensors by layer, then by parameter index (kept sorted for a stable
+        // parameter order) before assembling the per-parameter moments.
+        let mut partials: HashMap<usize, BTreeMap<usize, PartialMoments>> = HashMap::new();
 
         for (name, array) in &state.tensors {
-            let Some((layer, field)) = name.split_once('.') else {
+            let Some((layer_index, param_index, field)) = parse_moment_name(name) else {
                 continue;
             };
-            let Some(layer_index) = layer.strip_prefix("layer").and_then(|s| s.parse().ok()) else {
-                continue;
-            };
-
-            let partial = partials.entry(layer_index).or_default();
+            let partial = partials
+                .entry(layer_index)
+                .or_default()
+                .entry(param_index)
+                .or_default();
             match field {
-                "m_weights" => partial.m_weights = Some(to_array2(name, array)?),
-                "v_weights" => partial.v_weights = Some(to_array2(name, array)?),
-                "m_biases" => partial.m_biases = Some(to_array1(name, array)?),
-                "v_biases" => partial.v_biases = Some(to_array1(name, array)?),
-                _ => continue,
+                MomentField::M => partial.m = Some(array.clone()),
+                MomentField::V => partial.v = Some(array.clone()),
             }
         }
 
-        for (layer_index, partial) in partials {
-            self.states
-                .insert(layer_index, partial.into_state(layer_index)?);
+        for (layer_index, params) in partials {
+            let mut moments = Vec::with_capacity(params.len());
+            for (param_index, partial) in params {
+                moments.push(partial.into_moments(layer_index, param_index)?);
+            }
+            self.states.insert(layer_index, moments);
         }
 
         Ok(())
     }
 }
 
-/// Per-layer Adam moment tensors collected from an [`OptimizerState`] while
-/// loading, before being assembled into an [`AdamState`].
-#[derive(Default)]
-struct PartialAdamState {
-    m_weights: Option<Array2<f32>>,
-    v_weights: Option<Array2<f32>>,
-    m_biases: Option<Array1<f32>>,
-    v_biases: Option<Array1<f32>>,
+/// Parses a moment tensor name of the form `layer{L}.param{J}.{m|v}` into its layer
+/// index, parameter index, and field. Returns `None` for any other shape.
+fn parse_moment_name(name: &str) -> Option<(usize, usize, MomentField)> {
+    let mut parts = name.split('.');
+    let layer_index = parts.next()?.strip_prefix("layer")?.parse().ok()?;
+    let param_index = parts.next()?.strip_prefix("param")?.parse().ok()?;
+    let field = match parts.next()? {
+        "m" => MomentField::M,
+        "v" => MomentField::V,
+        _ => return None,
+    };
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((layer_index, param_index, field))
 }
 
-impl PartialAdamState {
-    fn into_state(self, layer_index: usize) -> Result<AdamState, OptimizerStateError> {
-        let missing =
-            |field: &str| OptimizerStateError::MissingTensor(format!("layer{layer_index}.{field}"));
+/// Per-parameter Adam moment tensors collected from an [`OptimizerState`] while loading,
+/// before being assembled into an [`AdamMoments`].
+#[derive(Default)]
+struct PartialMoments {
+    m: Option<ArrayD<f32>>,
+    v: Option<ArrayD<f32>>,
+}
 
-        Ok(AdamState {
-            m_weights: self.m_weights.ok_or_else(|| missing("m_weights"))?,
-            v_weights: self.v_weights.ok_or_else(|| missing("v_weights"))?,
-            m_biases: self.m_biases.ok_or_else(|| missing("m_biases"))?,
-            v_biases: self.v_biases.ok_or_else(|| missing("v_biases"))?,
+impl PartialMoments {
+    fn into_moments(
+        self,
+        layer_index: usize,
+        param_index: usize,
+    ) -> Result<AdamMoments, OptimizerStateError> {
+        let missing = |field: &str| {
+            OptimizerStateError::MissingTensor(format!(
+                "layer{layer_index}.param{param_index}.{field}"
+            ))
+        };
+
+        Ok(AdamMoments {
+            m: self.m.ok_or_else(|| missing("m"))?,
+            v: self.v.ok_or_else(|| missing("v"))?,
         })
     }
-}
-
-fn to_array2(name: &str, array: &ndarray::ArrayD<f32>) -> Result<Array2<f32>, OptimizerStateError> {
-    array
-        .clone()
-        .into_dimensionality()
-        .map_err(|_| OptimizerStateError::WrongRank {
-            tensor: name.to_string(),
-            expected: 2,
-        })
-}
-
-fn to_array1(name: &str, array: &ndarray::ArrayD<f32>) -> Result<Array1<f32>, OptimizerStateError> {
-    array
-        .clone()
-        .into_dimensionality()
-        .map_err(|_| OptimizerStateError::WrongRank {
-            tensor: name.to_string(),
-            expected: 1,
-        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::activations::RELU;
+    use crate::gradients::LayerGradients;
+    use crate::layers::Dense;
     use ndarray::{Array1, Array2, array};
 
-    fn layer(weights: Array2<f32>, biases: Array1<f32>) -> NeuronLayer {
-        NeuronLayer {
-            weights,
-            biases,
-            activation: RELU.clone(),
-        }
+    fn layer(weights: Array2<f32>, biases: Array1<f32>) -> Dense {
+        Dense::new(weights, biases, RELU.clone())
+    }
+
+    /// Layer gradients for a dense layer: a rank-2 weight gradient and a rank-1 bias gradient.
+    fn grads(dw: Array2<f32>, db: Array1<f32>) -> LayerGradients {
+        LayerGradients(vec![dw.into_dyn(), db.into_dyn()])
     }
 
     #[test]
@@ -303,28 +308,20 @@ mod tests {
         assert_eq!(opt.name(), "Adam");
         assert_eq!(opt.learning_rate().value(), lr);
         let mut l = layer(array![[1.0, 1.0]], array![1.0]);
-        let grads = Gradients {
-            dw: array![[2.0, -3.0]],
-            db: array![0.5],
-        };
-        opt.update(0, &mut l, &grads);
-        assert!((l.weights[[0, 0]] - (1.0 - lr)).abs() < 1e-4); // +grad → decrease
-        assert!((l.weights[[0, 1]] - (1.0 + lr)).abs() < 1e-4); // -grad → increase
-        assert!((l.biases[0] - (1.0 - lr)).abs() < 1e-4);
+        opt.update_layer(0, &mut l, &grads(array![[2.0, -3.0]], array![0.5]));
+        assert!((l.weights()[[0, 0]] - (1.0 - lr)).abs() < 1e-4); // +grad → decrease
+        assert!((l.weights()[[0, 1]] - (1.0 + lr)).abs() < 1e-4); // -grad → increase
+        assert!((l.biases()[0] - (1.0 - lr)).abs() < 1e-4);
     }
 
     #[test]
     fn adam_zero_gradient_leaves_params_unchanged() {
         let mut opt = Adam::with_defaults(0.1.try_into().unwrap(), WeightDecay::ZERO);
         let mut l = layer(array![[1.0, -2.0]], array![3.0]);
-        let grads = Gradients {
-            dw: Array2::zeros((1, 2)),
-            db: Array1::zeros(1),
-        };
-        opt.update(0, &mut l, &grads);
-        assert!((l.weights[[0, 0]] - 1.0).abs() < 1e-6);
-        assert!((l.weights[[0, 1]] - (-2.0)).abs() < 1e-6);
-        assert!((l.biases[0] - 3.0).abs() < 1e-6);
+        opt.update_layer(0, &mut l, &grads(Array2::zeros((1, 2)), Array1::zeros(1)));
+        assert!((l.weights()[[0, 0]] - 1.0).abs() < 1e-6);
+        assert!((l.weights()[[0, 1]] - (-2.0)).abs() < 1e-6);
+        assert!((l.biases()[0] - 3.0).abs() < 1e-6);
     }
 
     #[test]
@@ -333,15 +330,11 @@ mod tests {
         let mut opt = Adam::with_defaults(0.1.try_into().unwrap(), WeightDecay::ZERO);
         let mut l = layer(array![[5.0]], array![0.0]);
         for _ in 0..200 {
-            let w = l.weights[[0, 0]];
-            let grads = Gradients {
-                dw: array![[w]],
-                db: array![0.0],
-            };
-            opt.update(0, &mut l, &grads);
+            let w = l.weights()[[0, 0]];
+            opt.update_layer(0, &mut l, &grads(array![[w]], array![0.0]));
             opt.step();
         }
-        let w = l.weights[[0, 0]];
+        let w = l.weights()[[0, 0]];
         assert!(w.abs() < 0.5, "weight should approach 0, got {w}");
     }
 
@@ -362,27 +355,20 @@ mod tests {
         let wd = WeightDecay::new(0.1).unwrap();
         let mut opt = Adam::with_defaults(lr.try_into().unwrap(), wd);
         let mut l = layer(array![[2.0, -4.0]], array![3.0]);
-        let grads = Gradients {
-            dw: Array2::zeros((1, 2)),
-            db: Array1::zeros(1),
-        };
-        opt.update(0, &mut l, &grads);
+        opt.update_layer(0, &mut l, &grads(Array2::zeros((1, 2)), Array1::zeros(1)));
 
         // Each weight is scaled by (1 - lr*wd) = 0.99; the bias is not decayed.
-        assert!((l.weights[[0, 0]] - 2.0 * 0.99).abs() < 1e-5);
-        assert!((l.weights[[0, 1]] - (-4.0) * 0.99).abs() < 1e-5);
-        assert!((l.biases[0] - 3.0).abs() < 1e-6);
+        assert!((l.weights()[[0, 0]] - 2.0 * 0.99).abs() < 1e-5);
+        assert!((l.weights()[[0, 1]] - (-4.0) * 0.99).abs() < 1e-5);
+        assert!((l.biases()[0] - 3.0).abs() < 1e-6);
     }
 
     #[test]
     fn to_state_restore_roundtrip_preserves_moments_and_time_step() {
         let mut opt = Adam::with_defaults(0.01.try_into().unwrap(), WeightDecay::ZERO);
         let mut l = layer(array![[1.0, 1.0]], array![1.0]);
-        let grads = Gradients {
-            dw: array![[2.0, -3.0]],
-            db: array![0.5],
-        };
-        opt.update(0, &mut l, &grads);
+        let gradients = grads(array![[2.0, -3.0]], array![0.5]);
+        opt.update_layer(0, &mut l, &gradients);
         opt.step();
 
         let state = opt.to_state().unwrap();
@@ -394,11 +380,11 @@ mod tests {
         // the same step as continuing with the original optimizer.
         let mut from_original = l.clone();
         let mut from_restored = l.clone();
-        opt.update(0, &mut from_original, &grads);
-        restored.update(0, &mut from_restored, &grads);
+        opt.update_layer(0, &mut from_original, &gradients);
+        restored.update_layer(0, &mut from_restored, &gradients);
 
-        assert_eq!(from_original.weights, from_restored.weights);
-        assert_eq!(from_original.biases, from_restored.biases);
+        assert_eq!(from_original.weights(), from_restored.weights());
+        assert_eq!(from_original.biases(), from_restored.biases());
     }
 
     /// Metadata carrying a valid `time_step`, the precondition for parsing tensors.
@@ -439,32 +425,32 @@ mod tests {
         let mut opt = Adam::with_defaults(0.01.try_into().unwrap(), WeightDecay::ZERO);
         let state = OptimizerState {
             tensors: vec![
-                // A complete, valid layer-0 state...
+                // A complete, valid layer-0 state (two parameters)...
                 (
-                    "layer0.m_weights".to_string(),
+                    "layer0.param0.m".to_string(),
                     Array2::<f32>::zeros((1, 1)).into_dyn(),
                 ),
                 (
-                    "layer0.v_weights".to_string(),
+                    "layer0.param0.v".to_string(),
                     Array2::<f32>::zeros((1, 1)).into_dyn(),
                 ),
                 (
-                    "layer0.m_biases".to_string(),
+                    "layer0.param1.m".to_string(),
                     Array1::<f32>::zeros(1).into_dyn(),
                 ),
                 (
-                    "layer0.v_biases".to_string(),
+                    "layer0.param1.v".to_string(),
                     Array1::<f32>::zeros(1).into_dyn(),
                 ),
                 // ...alongside entries that are each skipped: no `.` separator, an
                 // unparseable layer index, and an unknown field.
                 ("nodot".to_string(), Array1::<f32>::zeros(1).into_dyn()),
                 (
-                    "layerX.m_weights".to_string(),
+                    "layerX.param0.m".to_string(),
                     Array2::<f32>::zeros((1, 1)).into_dyn(),
                 ),
                 (
-                    "layer0.unknown".to_string(),
+                    "layer0.param0.unknown".to_string(),
                     Array2::<f32>::zeros((1, 1)).into_dyn(),
                 ),
             ],
@@ -474,63 +460,58 @@ mod tests {
         assert!(opt.restore(&state).is_ok());
     }
 
-    /// A correctly-shaped tensor for an Adam moment field (rank 2 for weights,
-    /// rank 1 for biases).
-    fn tensor_for(field: &str) -> ndarray::ArrayD<f32> {
-        if field.ends_with("weights") {
-            Array2::<f32>::zeros((1, 1)).into_dyn()
-        } else {
-            Array1::<f32>::zeros(1).into_dyn()
-        }
-    }
-
     #[test]
-    fn restore_reports_each_missing_layer_tensor() {
-        const FIELDS: [&str; 4] = ["m_weights", "v_weights", "m_biases", "v_biases"];
+    fn restore_reports_each_missing_parameter_tensor() {
+        const FIELDS: [&str; 2] = ["m", "v"];
 
-        // Dropping any one field of an otherwise-complete layer is reported by name.
+        // Dropping either moment of an otherwise-complete parameter is reported by name.
         for missing in FIELDS {
             let mut opt = Adam::with_defaults(0.01.try_into().unwrap(), WeightDecay::ZERO);
             let state = OptimizerState {
                 tensors: FIELDS
                     .iter()
                     .filter(|f| **f != missing)
-                    .map(|f| (format!("layer0.{f}"), tensor_for(f)))
+                    .map(|f| {
+                        (
+                            format!("layer0.param0.{f}"),
+                            Array2::<f32>::zeros((1, 1)).into_dyn(),
+                        )
+                    })
                     .collect(),
                 metadata: metadata_with_time_step("1"),
             };
 
             assert_eq!(
                 opt.restore(&state).unwrap_err().to_string(),
-                format!("optimizer state is missing `layer0.{missing}`")
+                format!("optimizer state is missing `layer0.param0.{missing}`")
             );
         }
     }
 
     #[test]
-    fn restore_reports_wrong_rank_for_each_tensor() {
-        // Each field is given the opposite rank to the one it expects.
-        for (field, expected_rank) in [
-            ("m_weights", 2),
-            ("v_weights", 2),
-            ("m_biases", 1),
-            ("v_biases", 1),
-        ] {
-            let mut opt = Adam::with_defaults(0.01.try_into().unwrap(), WeightDecay::ZERO);
-            let wrong = if expected_rank == 2 {
-                Array1::<f32>::zeros(1).into_dyn()
-            } else {
-                Array2::<f32>::zeros((1, 1)).into_dyn()
-            };
-            let state = OptimizerState {
-                tensors: vec![(format!("layer0.{field}"), wrong)],
-                metadata: metadata_with_time_step("1"),
-            };
+    #[should_panic(expected = "has 1 parameters, but the layer has 2")]
+    fn update_rejects_restored_state_that_omits_a_parameter() {
+        // A checkpoint describing only the first parameter of layer 0 (the bias is absent).
+        let state = OptimizerState {
+            tensors: vec![
+                (
+                    "layer0.param0.m".to_string(),
+                    Array2::<f32>::zeros((1, 2)).into_dyn(),
+                ),
+                (
+                    "layer0.param0.v".to_string(),
+                    Array2::<f32>::zeros((1, 2)).into_dyn(),
+                ),
+            ],
+            metadata: metadata_with_time_step("5"),
+        };
 
-            assert_eq!(
-                opt.restore(&state).unwrap_err().to_string(),
-                format!("tensor `layer0.{field}` is not rank {expected_rank}")
-            );
-        }
+        let mut opt = Adam::with_defaults(0.01.try_into().unwrap(), WeightDecay::ZERO);
+        opt.restore(&state).unwrap();
+
+        // The dense layer has two parameters (weights and bias); the restored state has one,
+        // so stepping it must fail loudly instead of silently skipping the bias.
+        let mut l = layer(array![[1.0, 1.0]], array![1.0]);
+        opt.update_layer(0, &mut l, &grads(array![[0.1, 0.1]], array![0.1]));
     }
 }

--- a/core/src/nn/optimizers/mod.rs
+++ b/core/src/nn/optimizers/mod.rs
@@ -12,12 +12,60 @@ mod sgd;
 pub use adam::*;
 pub use sgd::*;
 
-use crate::gradients::Gradients;
+use crate::gradients::LayerGradients;
+use crate::layers::{Layer, Parameter};
 use crate::learning_rate::LearningRate;
-use crate::model::NeuronLayer;
 use ndarray::ArrayD;
 use std::collections::HashMap;
 use std::fmt;
+use std::ops::{Deref, DerefMut};
+
+/// A layer parameter paired with its gradient — the unit an [`Optimizer`] steps.
+pub struct ParameterUpdate<'a> {
+    /// The parameter to update in place.
+    pub parameter: Parameter<'a>,
+    /// The gradient of the loss with respect to that parameter.
+    pub gradient: &'a ArrayD<f32>,
+}
+
+/// A layer's parameters, each paired with its gradient, in parameter order.
+pub struct ParameterUpdates<'a>(Vec<ParameterUpdate<'a>>);
+
+impl<'a> ParameterUpdates<'a> {
+    /// Pairs each parameter with its gradient.
+    /// # Panics
+    /// When the number of parameters and gradients differ.
+    pub fn new(parameters: Vec<Parameter<'a>>, gradients: &'a LayerGradients) -> Self {
+        assert_eq!(
+            parameters.len(),
+            gradients.len(),
+            "each parameter must have exactly one gradient"
+        );
+        Self(
+            parameters
+                .into_iter()
+                .zip(gradients.iter())
+                .map(|(parameter, gradient)| ParameterUpdate {
+                    parameter,
+                    gradient,
+                })
+                .collect(),
+        )
+    }
+}
+
+impl<'a> Deref for ParameterUpdates<'a> {
+    type Target = [ParameterUpdate<'a>];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for ParameterUpdates<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 /// Optimizer-agnostic snapshot of internal state (e.g. Adam's moment
 /// estimates), shaped like a model: named tensors of arbitrary rank plus
@@ -37,8 +85,6 @@ pub enum OptimizerStateError {
     MissingMetadata(String),
     /// A metadata entry could not be parsed into the expected type.
     InvalidMetadata { key: String },
-    /// A tensor was present but did not have the expected rank.
-    WrongRank { tensor: String, expected: usize },
     /// A required tensor was missing from the state.
     MissingTensor(String),
 }
@@ -51,9 +97,6 @@ impl fmt::Display for OptimizerStateError {
             }
             OptimizerStateError::InvalidMetadata { key } => {
                 write!(f, "optimizer state has an invalid `{key}`")
-            }
-            OptimizerStateError::WrongRank { tensor, expected } => {
-                write!(f, "tensor `{tensor}` is not rank {expected}")
             }
             OptimizerStateError::MissingTensor(name) => {
                 write!(f, "optimizer state is missing `{name}`")
@@ -75,13 +118,28 @@ pub trait Optimizer {
     /// This allows dynamic adjustment of the learning rate during training.
     fn set_learning_rate(&mut self, learning_rate: LearningRate);
 
-    /// Updates the weights and biases of a layer using the provided gradients.
+    /// Updates a layer's parameters in place, each from its paired gradient.
     ///
     /// # Arguments
     /// * `layer_index` - The index of the layer being updated, inside the neural network.
-    /// * `layer` - The layer whose weights and biases are to be updated.
-    /// * `gradients` - The gradients computed during backpropagation for this layer.
-    fn update(&mut self, layer_index: usize, layer: &mut NeuronLayer, gradients: &Gradients);
+    /// * `updates` - The layer's trainable parameters, each paired with its gradient.
+    fn update(&mut self, layer_index: usize, updates: &mut ParameterUpdates<'_>);
+
+    /// Updates a layer in place, pairing its parameters with `gradients` before stepping.
+    ///
+    /// # Arguments
+    /// * `layer_index` - The index of the layer being updated, inside the neural network.
+    /// * `layer` - The layer whose parameters are updated.
+    /// * `gradients` - The gradients computed during backpropagation, in parameter order.
+    fn update_layer(
+        &mut self,
+        layer_index: usize,
+        layer: &mut dyn Layer,
+        gradients: &LayerGradients,
+    ) {
+        let mut updates = ParameterUpdates::new(layer.parameters_mut(), gradients);
+        self.update(layer_index, &mut updates);
+    }
 
     /// Performs any necessary state updates after each training step.
     /// This is useful for optimizers that maintain internal state, such as Adam.

--- a/core/src/nn/optimizers/sgd.rs
+++ b/core/src/nn/optimizers/sgd.rs
@@ -1,17 +1,15 @@
 //! Stochastic Gradient Descent (SGD) optimizer implementation.
 //!
 //! This module provides the `StochasticGradientDescent` struct, which implements the `Optimizer` trait
-//! for the classic stochastic gradient descent algorithm. SGD updates the weights and biases of a layer
+//! for the classic stochastic gradient descent algorithm. SGD updates the parameters of a layer
 //! by subtracting the product of the learning rate and the computed gradients. It is simple, efficient,
 //! and widely used for many machine learning problems.
 //!
 //! - Does not maintain any internal state (unlike Adam, RMSProp, etc.).
 //!
 
-use crate::gradients::Gradients;
 use crate::learning_rate::LearningRate;
-use crate::model::NeuronLayer;
-use crate::optimizers::Optimizer;
+use crate::optimizers::{Optimizer, ParameterUpdates};
 use crate::weight_decay::WeightDecay;
 
 pub struct StochasticGradientDescent {
@@ -41,15 +39,15 @@ impl Optimizer for StochasticGradientDescent {
         self.learning_rate = learning_rate;
     }
 
-    fn update(&mut self, _: usize, layer: &mut NeuronLayer, gradients: &Gradients) {
-        let (dw, db) = (&gradients.dw, &gradients.db);
-        // L2 weight decay: shrink the weights before the gradient step. Biases are
-        // not decayed.
-        if self.weight_decay.is_active() {
-            layer.weights *= 1.0 - self.learning_rate.value() * self.weight_decay.value();
+    fn update(&mut self, _: usize, updates: &mut ParameterUpdates<'_>) {
+        let lr = self.learning_rate.value();
+        for update in updates.iter_mut() {
+            // L2 weight decay: shrink decaying parameters before the gradient step.
+            if self.weight_decay.is_active() && update.parameter.decays {
+                update.parameter.value *= 1.0 - lr * self.weight_decay.value();
+            }
+            update.parameter.value.scaled_add(-lr, update.gradient);
         }
-        layer.weights -= &(dw * self.learning_rate.value());
-        layer.biases -= &(db * self.learning_rate.value());
     }
 }
 
@@ -57,14 +55,17 @@ impl Optimizer for StochasticGradientDescent {
 mod tests {
     use super::*;
     use crate::activations::RELU;
+    use crate::gradients::LayerGradients;
+    use crate::layers::Dense;
     use ndarray::{Array1, Array2, array};
 
-    fn layer(weights: Array2<f32>, biases: Array1<f32>) -> NeuronLayer {
-        NeuronLayer {
-            weights,
-            biases,
-            activation: RELU.clone(),
-        }
+    fn layer(weights: Array2<f32>, biases: Array1<f32>) -> Dense {
+        Dense::new(weights, biases, RELU.clone())
+    }
+
+    /// Layer gradients for a dense layer: a rank-2 weight gradient and a rank-1 bias gradient.
+    fn grads(dw: Array2<f32>, db: Array1<f32>) -> LayerGradients {
+        LayerGradients(vec![dw.into_dyn(), db.into_dyn()])
     }
 
     #[test]
@@ -73,28 +74,20 @@ mod tests {
         assert_eq!(opt.name(), "Stochastic Gradient Descent (SGD)");
         assert_eq!(opt.learning_rate().value(), 0.1);
         let mut l = layer(array![[1.0, 2.0]], array![1.0]);
-        let grads = Gradients {
-            dw: array![[0.5, 1.0]],
-            db: array![2.0],
-        };
-        opt.update(0, &mut l, &grads);
+        opt.update_layer(0, &mut l, &grads(array![[0.5, 1.0]], array![2.0]));
         // params -= learning_rate * gradient
-        assert!((l.weights[[0, 0]] - 0.95).abs() < 1e-6);
-        assert!((l.weights[[0, 1]] - 1.9).abs() < 1e-6);
-        assert!((l.biases[0] - 0.8).abs() < 1e-6);
+        assert!((l.weights()[[0, 0]] - 0.95).abs() < 1e-6);
+        assert!((l.weights()[[0, 1]] - 1.9).abs() < 1e-6);
+        assert!((l.biases()[0] - 0.8).abs() < 1e-6);
     }
 
     #[test]
     fn sgd_zero_gradient_leaves_params_unchanged() {
         let mut opt = StochasticGradientDescent::new(0.5.try_into().unwrap(), WeightDecay::ZERO);
         let mut l = layer(array![[1.0, -2.0]], array![3.0]);
-        let grads = Gradients {
-            dw: Array2::zeros((1, 2)),
-            db: Array1::zeros(1),
-        };
-        opt.update(0, &mut l, &grads);
-        assert_eq!(l.weights, array![[1.0, -2.0]]);
-        assert_eq!(l.biases, array![3.0]);
+        opt.update_layer(0, &mut l, &grads(Array2::zeros((1, 2)), Array1::zeros(1)));
+        assert_eq!(l.weights(), array![[1.0, -2.0]]);
+        assert_eq!(l.biases(), array![3.0]);
     }
 
     #[test]
@@ -103,13 +96,9 @@ mod tests {
         opt.set_learning_rate(LearningRate::new(1.0).unwrap());
 
         let mut l = layer(array![[1.0]], array![0.0]);
-        let grads = Gradients {
-            dw: array![[0.5]],
-            db: array![0.0],
-        };
-        opt.update(0, &mut l, &grads);
+        opt.update_layer(0, &mut l, &grads(array![[0.5]], array![0.0]));
         // With learning rate 1.0 the full gradient is subtracted: 1.0 - 1.0 * 0.5.
-        assert!((l.weights[[0, 0]] - 0.5).abs() < 1e-6);
+        assert!((l.weights()[[0, 0]] - 0.5).abs() < 1e-6);
     }
 
     #[test]
@@ -118,14 +107,10 @@ mod tests {
         let wd = WeightDecay::new(0.5).unwrap();
         let mut opt = StochasticGradientDescent::new(lr.try_into().unwrap(), wd);
         let mut l = layer(array![[2.0]], array![3.0]);
-        let grads = Gradients {
-            dw: array![[1.0]],
-            db: array![1.0],
-        };
-        opt.update(0, &mut l, &grads);
+        opt.update_layer(0, &mut l, &grads(array![[1.0]], array![1.0]));
         // w = w*(1 - lr*wd) - lr*dw = 2*0.95 - 0.1*1 = 1.8; bias = 3 - 0.1*1 = 2.9 (no decay).
-        assert!((l.weights[[0, 0]] - 1.8).abs() < 1e-6);
-        assert!((l.biases[0] - 2.9).abs() < 1e-6);
+        assert!((l.weights()[[0, 0]] - 1.8).abs() < 1e-6);
+        assert!((l.biases()[0] - 2.9).abs() < 1e-6);
     }
 
     #[test]

--- a/core/src/nn/training/backprop.rs
+++ b/core/src/nn/training/backprop.rs
@@ -1,10 +1,10 @@
 use crate::data::ModelDataset;
-use crate::gradients::{GradientClipping, Gradients};
+use crate::gradients::{GradientClipping, LayerGradients};
 use crate::loss_functions::{CrossEntropyLoss, LossFunction};
 use crate::model::{FeatureCountMismatch, NeuralNetwork, last_activation};
 use crate::optimizers::Optimizer;
 use crate::schedulers::Scheduler;
-use ndarray::{Array2, ArrayView2, Axis};
+use ndarray::{Array2, ArrayView2};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::rngs::StdRng;
 use std::sync::Arc;
@@ -106,17 +106,21 @@ impl NeuralNetwork {
         let gradients = self.backward(activations, targets, loss_function);
 
         for (layer_index, (layer, mut layer_gradients)) in
-            self.layers.iter_mut().zip(gradients).enumerate()
+            self.layers_mut().iter_mut().zip(gradients).enumerate()
         {
             layer_gradients.clip_by(clipping);
 
-            optimizer.update(layer_index, layer, &layer_gradients);
+            optimizer.update_layer(layer_index, layer.as_mut(), &layer_gradients);
         }
 
         optimizer.step();
     }
 
     /// Computes the gradients for each layer using backpropagation.
+    ///
+    /// Each layer turns the gradient of the loss with respect to its output into its own
+    /// parameter gradients and the gradient with respect to its input, which becomes the
+    /// upstream layer's incoming gradient.
     /// # Arguments
     /// - `activations`: A vector of 2D arrays representing the activations of each layer.
     /// - `targets`: A 2D array representing the true labels for the inputs.
@@ -125,38 +129,35 @@ impl NeuralNetwork {
         activations: &[Array2<f32>],
         targets: ArrayView2<f32>,
         loss_function: &Arc<dyn LossFunction>,
-    ) -> Vec<Gradients> {
-        let m = targets.ncols() as f32;
-
+    ) -> Vec<LayerGradients> {
         let last_act = last_activation(activations);
         // Clip to (0, 1) interior so gradient() and vjp() see the same values;
         // their product then cancels exactly to p − y even near saturation.
         let safe_act = CrossEntropyLoss::clip_probabilities(&last_act.view());
-        let loss_grad = loss_function.gradient(safe_act.view(), targets);
-        let mut dz = self
-            .layers
-            .last()
-            .unwrap()
-            .activation
-            .vjp(loss_grad.view(), safe_act.view());
+        // dL/d(output) handed to the output layer.
+        let mut da = loss_function.gradient(safe_act.view(), targets);
 
-        let mut gradients = Vec::with_capacity(activations.len() - 1);
+        let layers = self.layers();
+        let mut gradients = Vec::with_capacity(layers.len());
+        let last = layers.len() - 1;
 
-        for i in (1..self.layers.len() + 1).rev() {
-            let previous_activations = activations[i - 1].view();
-            let dw = dz.dot(&previous_activations.t()) / m;
-            let db = dz.sum_axis(Axis(1)) / m;
-
-            gradients.insert(0, Gradients { dw, db });
-
-            if i > 1 {
-                let next_layer = &self.layers[i - 1];
-                let da = next_layer.weights.t().dot(&dz);
-                dz = self.layers[i - 2]
-                    .activation
-                    .vjp(da.view(), previous_activations);
+        for i in (0..layers.len()).rev() {
+            let input = activations[i].view();
+            let output = if i == last {
+                safe_act.view()
+            } else {
+                activations[i + 1].view()
+            };
+            // The input layer (i == 0) has no upstream layer to receive an input gradient.
+            let pass = layers[i].backward(da.view(), input, output, i > 0);
+            gradients.push(pass.gradients);
+            if let Some(input_gradient) = pass.input_gradient {
+                da = input_gradient;
             }
         }
+
+        // Collected from the output layer back to the input; restore input-to-output order.
+        gradients.reverse();
 
         gradients
     }
@@ -166,9 +167,31 @@ impl NeuralNetwork {
 mod tests {
     use super::*;
     use crate::activations::SIGMOID;
+    use crate::layers::Dense;
+    use crate::learning_rate::LearningRate;
     use crate::loss_functions::CROSS_ENTROPY_LOSS;
     use crate::model::{NeuralNetwork, NeuronLayerSpec};
+    use crate::optimizers::StochasticGradientDescent;
+    use crate::schedulers::ConstantScheduler;
+    use crate::weight_decay::WeightDecay;
     use ndarray::{Array1, array};
+
+    /// Downcasts a network's layer to the concrete [`Dense`] to read its weights and biases.
+    fn dense(model: &NeuralNetwork, index: usize) -> &Dense {
+        model.layers()[index]
+            .as_any()
+            .downcast_ref::<Dense>()
+            .unwrap()
+    }
+
+    /// Downcasts a network's layer to the concrete [`Dense`] to set or perturb its
+    /// weights and biases.
+    fn dense_mut(model: &mut NeuralNetwork, index: usize) -> &mut Dense {
+        model.layers_mut()[index]
+            .as_any_mut()
+            .downcast_mut::<Dense>()
+            .unwrap()
+    }
 
     fn compute_loss(
         model: &NeuralNetwork,
@@ -188,10 +211,10 @@ mod tests {
         let mut model = NeuralNetwork::initialization(2, &specs, 0);
 
         // Fixed weights for reproducibility
-        model.layers[0].weights = array![[0.1, -0.2], [0.3, 0.1]];
-        model.layers[0].biases = Array1::from_vec(vec![0.05, -0.05]);
-        model.layers[1].weights = array![[0.4, -0.1]];
-        model.layers[1].biases = Array1::from_vec(vec![0.1]);
+        *dense_mut(&mut model, 0).weights_mut() = array![[0.1, -0.2], [0.3, 0.1]];
+        *dense_mut(&mut model, 0).biases_mut() = Array1::from_vec(vec![0.05, -0.05]);
+        *dense_mut(&mut model, 1).weights_mut() = array![[0.4, -0.1]];
+        *dense_mut(&mut model, 1).biases_mut() = Array1::from_vec(vec![0.1]);
 
         let inputs = array![[0.5, -0.3, 0.8], [0.2, 0.7, -0.5]]; // (2 features, 3 samples)
         let targets = array![[1.0, 0.0, 1.0]]; // (1 output, 3 samples)
@@ -217,34 +240,34 @@ mod tests {
         };
 
         for (layer_idx, layer_grads) in analytical_grads.iter().enumerate() {
-            let (rows, cols) = model.layers[layer_idx].weights.dim();
+            let (rows, cols) = dense(&model, layer_idx).weights().dim();
             for i in 0..rows {
                 for j in 0..cols {
                     let mut m_plus = model.clone();
-                    m_plus.layers[layer_idx].weights[[i, j]] += eps;
+                    dense_mut(&mut m_plus, layer_idx).weights_mut()[[i, j]] += eps;
                     let mut m_minus = model.clone();
-                    m_minus.layers[layer_idx].weights[[i, j]] -= eps;
+                    dense_mut(&mut m_minus, layer_idx).weights_mut()[[i, j]] -= eps;
                     let numerical = (compute_loss(&m_plus, &inputs, &targets, &loss_fn)
                         - compute_loss(&m_minus, &inputs, &targets, &loss_fn))
                         / (2.0 * eps);
                     check(
-                        layer_grads.dw[[i, j]],
+                        layer_grads[0][[i, j]],
                         numerical,
                         &format!("W[{layer_idx}][{i},{j}]"),
                     );
                 }
             }
 
-            for i in 0..model.layers[layer_idx].biases.len() {
+            for i in 0..dense(&model, layer_idx).biases().len() {
                 let mut m_plus = model.clone();
-                m_plus.layers[layer_idx].biases[i] += eps;
+                dense_mut(&mut m_plus, layer_idx).biases_mut()[i] += eps;
                 let mut m_minus = model.clone();
-                m_minus.layers[layer_idx].biases[i] -= eps;
+                dense_mut(&mut m_minus, layer_idx).biases_mut()[i] -= eps;
                 let numerical = (compute_loss(&m_plus, &inputs, &targets, &loss_fn)
                     - compute_loss(&m_minus, &inputs, &targets, &loss_fn))
                     / (2.0 * eps);
                 check(
-                    layer_grads.db[i],
+                    layer_grads[1][[i]],
                     numerical,
                     &format!("b[{layer_idx}][{i}]"),
                 );
@@ -262,8 +285,8 @@ mod tests {
         let specs = NeuronLayerSpec::network_for(vec![], &*SIGMOID, 3);
         let mut model = NeuralNetwork::initialization(2, &specs, 0);
 
-        model.layers[0].weights = array![[0.5, -0.3], [0.2, 0.8], [-0.4, 0.1]];
-        model.layers[0].biases = Array1::from_vec(vec![0.1, -0.2, 0.1]);
+        *dense_mut(&mut model, 0).weights_mut() = array![[0.5, -0.3], [0.2, 0.8], [-0.4, 0.1]];
+        *dense_mut(&mut model, 0).biases_mut() = Array1::from_vec(vec![0.1, -0.2, 0.1]);
 
         // 4 samples across 3 classes
         let inputs = array![[1.0, -1.0, 0.5, -0.5], [0.5, 0.5, -0.5, -0.5]];
@@ -290,33 +313,33 @@ mod tests {
         };
 
         for (layer_idx, layer_grads) in analytical_grads.iter().enumerate() {
-            let (rows, cols) = model.layers[layer_idx].weights.dim();
+            let (rows, cols) = dense(&model, layer_idx).weights().dim();
             for i in 0..rows {
                 for j in 0..cols {
                     let mut m_plus = model.clone();
-                    m_plus.layers[layer_idx].weights[[i, j]] += eps;
+                    dense_mut(&mut m_plus, layer_idx).weights_mut()[[i, j]] += eps;
                     let mut m_minus = model.clone();
-                    m_minus.layers[layer_idx].weights[[i, j]] -= eps;
+                    dense_mut(&mut m_minus, layer_idx).weights_mut()[[i, j]] -= eps;
                     let numerical = (compute_loss(&m_plus, &inputs, &targets, &loss_fn)
                         - compute_loss(&m_minus, &inputs, &targets, &loss_fn))
                         / (2.0 * eps);
                     check(
-                        layer_grads.dw[[i, j]],
+                        layer_grads[0][[i, j]],
                         numerical,
                         &format!("W[{layer_idx}][{i},{j}]"),
                     );
                 }
             }
-            for i in 0..model.layers[layer_idx].biases.len() {
+            for i in 0..dense(&model, layer_idx).biases().len() {
                 let mut m_plus = model.clone();
-                m_plus.layers[layer_idx].biases[i] += eps;
+                dense_mut(&mut m_plus, layer_idx).biases_mut()[i] += eps;
                 let mut m_minus = model.clone();
-                m_minus.layers[layer_idx].biases[i] -= eps;
+                dense_mut(&mut m_minus, layer_idx).biases_mut()[i] -= eps;
                 let numerical = (compute_loss(&m_plus, &inputs, &targets, &loss_fn)
                     - compute_loss(&m_minus, &inputs, &targets, &loss_fn))
                     / (2.0 * eps);
                 check(
-                    layer_grads.db[i],
+                    layer_grads[1][[i]],
                     numerical,
                     &format!("b[{layer_idx}][{i}]"),
                 );
@@ -332,8 +355,8 @@ mod tests {
         let mut model = NeuralNetwork::initialization(2, &specs, 0);
 
         // Large weights so the single sample's logit saturates the sigmoid.
-        model.layers[0].weights = array![[100.0, 100.0]];
-        model.layers[0].biases = Array1::from_vec(vec![0.0]);
+        *dense_mut(&mut model, 0).weights_mut() = array![[100.0, 100.0]];
+        *dense_mut(&mut model, 0).biases_mut() = Array1::from_vec(vec![0.0]);
 
         let inputs = array![[1.0, -1.0], [1.0, -1.0]]; // logits +200 / -200 → 1.0 / 0.0
         let targets = array![[1.0, 0.0]];
@@ -346,10 +369,11 @@ mod tests {
         let grads = model.backward(&activations, targets.view(), &loss_fn);
         for g in &grads {
             assert!(
-                g.dw.iter().chain(g.db.iter()).all(|v| v.is_finite()),
-                "saturated sigmoid produced non-finite gradients: dw={:?} db={:?}",
-                g.dw,
-                g.db
+                g.iter()
+                    .flat_map(|tensor| tensor.iter())
+                    .all(|v| v.is_finite()),
+                "saturated sigmoid produced non-finite gradients: {:?}",
+                g.0
             );
         }
     }
@@ -357,11 +381,6 @@ mod tests {
     #[test]
     fn training_is_deterministic_for_a_fixed_seed() {
         // Two runs with the same seed and data produce bit-identical weights.
-        use crate::learning_rate::LearningRate;
-        use crate::optimizers::StochasticGradientDescent;
-        use crate::schedulers::ConstantScheduler;
-        use crate::weight_decay::WeightDecay;
-
         fn run() -> NeuralNetwork {
             let specs = NeuronLayerSpec::network_for(vec![8, 4], &*SIGMOID, 3);
             let mut model = NeuralNetwork::initialization(5, &specs, 7);
@@ -395,13 +414,15 @@ mod tests {
 
         let a = run();
         let b = run();
-        for (la, lb) in a.layers.iter().zip(&b.layers) {
+        for i in 0..a.layers().len() {
             assert_eq!(
-                la.weights, lb.weights,
+                dense(&a, i).weights(),
+                dense(&b, i).weights(),
                 "weights diverged between identical runs"
             );
             assert_eq!(
-                la.biases, lb.biases,
+                dense(&a, i).biases(),
+                dense(&b, i).biases(),
                 "biases diverged between identical runs"
             );
         }

--- a/core/src/nn/training/early_stopping.rs
+++ b/core/src/nn/training/early_stopping.rs
@@ -119,8 +119,24 @@ impl EarlyStopping {
 mod tests {
     use super::*;
     use crate::activations::SIGMOID;
+    use crate::layers::Dense;
     use crate::model::NeuronLayerSpec;
     use ndarray::Array1;
+
+    /// Downcasts a network's layer to the concrete [`Dense`] for reading or perturbing it.
+    fn dense(model: &NeuralNetwork, index: usize) -> &Dense {
+        model.layers()[index]
+            .as_any()
+            .downcast_ref::<Dense>()
+            .unwrap()
+    }
+
+    fn dense_mut(model: &mut NeuralNetwork, index: usize) -> &mut Dense {
+        model.layers_mut()[index]
+            .as_any_mut()
+            .downcast_mut::<Dense>()
+            .unwrap()
+    }
 
     #[test]
     fn early_stopping_restores_best_model() {
@@ -133,7 +149,7 @@ mod tests {
 
         let mut model_at_best = model_initial.clone();
         // Give model_at_best a distinctive bias so we can tell it apart
-        model_at_best.layers[0].biases = Array1::from_vec(vec![42.0, 42.0]);
+        *dense_mut(&mut model_at_best, 0).biases_mut() = Array1::from_vec(vec![42.0, 42.0]);
 
         assert!(!es.observe(1.0, &model_initial)); // improvement: saved
         assert!(!es.observe(0.5, &model_at_best)); // new best: overwrites saved
@@ -144,7 +160,8 @@ mod tests {
             .best_model
             .expect("best_model should be Some after early stopping");
         assert_eq!(
-            best.layers[0].biases, model_at_best.layers[0].biases,
+            dense(&best, 0).biases(),
+            dense(&model_at_best, 0).biases(),
             "best_model should be the epoch with loss=0.5, not the final state"
         );
     }

--- a/core/src/nn/training/evaluator.rs
+++ b/core/src/nn/training/evaluator.rs
@@ -69,20 +69,14 @@ mod tests {
     use super::*;
     use crate::accuracies::BINARY_ACCURACY;
     use crate::activations::SIGMOID;
+    use crate::layers::Dense;
     use crate::loss_functions::CROSS_ENTROPY_LOSS;
-    use crate::model::NeuronLayer;
     use ndarray::array;
 
     /// A 2-input → 1-output sigmoid network whose weights/bias are zeroed,
     /// so every prediction is exactly 0.5 regardless of the input.
     fn constant_half_model() -> NeuralNetwork {
-        NeuralNetwork {
-            layers: vec![NeuronLayer {
-                weights: array![[0.0, 0.0]],
-                biases: array![0.0],
-                activation: SIGMOID.clone(),
-            }],
-        }
+        NeuralNetwork::single(Dense::new(array![[0.0, 0.0]], array![0.0], SIGMOID.clone()))
     }
 
     fn dataset(inputs: ndarray::Array2<f32>, targets: ndarray::Array2<f32>) -> ModelDataset {

--- a/core/src/nn/training/mod.rs
+++ b/core/src/nn/training/mod.rs
@@ -7,7 +7,7 @@ pub mod outcome;
 pub mod preprocessing;
 pub mod trainer;
 
-pub use crate::gradients::{GradientClipping, GradientClippingError, Gradients};
+pub use crate::gradients::{GradientClipping, GradientClippingError, LayerGradients};
 pub use crate::learning_rate::LearningRate;
 pub use backprop::MiniBatch;
 pub use callbacks::{CallbackError, CallbackResult, Callbacks, TrainerCallback};

--- a/core/src/nn/training/trainer.rs
+++ b/core/src/nn/training/trainer.rs
@@ -250,7 +250,7 @@ mod tests {
     use super::*;
     use crate::activations::SIGMOID;
     use crate::data::Dataset;
-    use crate::model::NeuronLayer;
+    use crate::layers::Dense;
     use crate::optimizers::Optimizer;
     use crate::schedulers::Scheduler;
     use crate::training::GradientClipping;
@@ -284,13 +284,11 @@ mod tests {
     /// A fixed (non-random) 2-input -> 1-output sigmoid network, so loss
     /// sequences are fully deterministic across runs.
     fn sample_model() -> NeuralNetwork {
-        NeuralNetwork {
-            layers: vec![NeuronLayer {
-                weights: array![[0.1, -0.2]],
-                biases: array![0.05],
-                activation: SIGMOID.clone(),
-            }],
-        }
+        NeuralNetwork::single(Dense::new(
+            array![[0.1, -0.2]],
+            array![0.05],
+            SIGMOID.clone(),
+        ))
     }
 
     fn sample_hyperparameters(
@@ -687,20 +685,18 @@ mod tests {
 
     #[test]
     fn restore_reinstates_state_and_resumes_from_epoch_start() {
-        use crate::gradients::Gradients;
+        use crate::gradients::LayerGradients;
         use crate::optimizers::Adam;
         use crate::schedulers::CosineAnnealing;
         use crate::weight_decay::WeightDecay;
 
         // Stateful optimizer/scheduler snapshots, as a checkpoint would hold them.
         let mut adam = Adam::with_defaults(0.01.try_into().unwrap(), WeightDecay::ZERO);
-        adam.update(
+        let mut layer = Dense::new(array![[0.1, -0.2]], array![0.05], SIGMOID.clone());
+        adam.update_layer(
             0,
-            &mut sample_model().layers.swap_remove(0),
-            &Gradients {
-                dw: array![[0.1, 0.1]],
-                db: array![0.1],
-            },
+            &mut layer,
+            &LayerGradients(vec![array![[0.1, 0.1]].into_dyn(), array![0.1].into_dyn()]),
         );
         adam.step();
         let optimizer_state = adam.to_state();

--- a/core/src/plot/activations.rs
+++ b/core/src/plot/activations.rs
@@ -11,7 +11,7 @@ use crate::classification::Classification;
 use crate::data::scalers::Scaler;
 use crate::model::{FeatureCountMismatch, NeuralNetwork, PredictionError, Predictor};
 use crate::plot::scene::Color;
-use ndarray::{Array2, ArrayView1, Axis};
+use ndarray::{ArrayView1, ArrayView2, Axis};
 
 /// Activation magnitudes at or below this count as a silent neuron.
 const FIRING_EPSILON: f32 = 1e-6;
@@ -193,16 +193,21 @@ impl NeuralNetwork {
                 let (role, edges) = if stage == 0 {
                     (LayerRole::Input, Vec::new())
                 } else {
-                    let layer = &self.layers[stage - 1];
-                    let edges = edges_for(
-                        &layer.weights,
-                        activations[stage - 1].column(0),
-                        &shown[stage - 1],
-                        &shown[stage],
-                        options.min_edge_magnitude,
-                    );
+                    let layer = &self.layers()[stage - 1];
+                    let edges = match layer.weight_matrix() {
+                        Some(weights) => edges_for(
+                            weights,
+                            activations[stage - 1].column(0),
+                            &shown[stage - 1],
+                            &shown[stage],
+                            options.min_edge_magnitude,
+                        ),
+                        None => Vec::new(),
+                    };
                     (
-                        LayerRole::Activated(layer.activation.name().to_string()),
+                        LayerRole::Activated(
+                            layer.activation_name().unwrap_or_default().to_string(),
+                        ),
                         edges,
                     )
                 };
@@ -307,7 +312,7 @@ fn label_output_classes(units: &mut [Unit], output_count: usize) {
 /// `(this layer's neurons, previous layer's neurons)` and `prev_activations`
 /// carries every source neuron's activation.
 fn edges_for(
-    weights: &Array2<f32>,
+    weights: ArrayView2<f32>,
     prev_activations: ArrayView1<f32>,
     shown_prev: &[usize],
     shown_cur: &[usize],
@@ -350,17 +355,12 @@ fn edges_for(
 mod tests {
     use super::*;
     use crate::activations::{Activation, RELU};
-    use crate::model::{NeuralNetwork, NeuronLayer};
+    use crate::layers::Dense;
+    use crate::model::NeuralNetwork;
     use ndarray::{Array1, Array2, array};
 
-    fn relu_layer(weights: Array2<f32>, biases: Array1<f32>) -> NeuralNetwork {
-        NeuralNetwork {
-            layers: vec![NeuronLayer {
-                weights,
-                biases,
-                activation: RELU.clone(),
-            }],
-        }
+    fn relu_network(weights: Array2<f32>, biases: Array1<f32>) -> NeuralNetwork {
+        NeuralNetwork::single(Dense::new(weights, biases, RELU.clone()))
     }
 
     #[test]
@@ -387,7 +387,7 @@ mod tests {
 
     #[test]
     fn diagram_has_an_input_layer_then_one_layer_per_neuron_layer() {
-        let net = relu_layer(array![[1.0, 0.0], [2.0, 0.0]], array![0.0, 0.0]);
+        let net = relu_network(array![[1.0, 0.0], [2.0, 0.0]], array![0.0, 0.0]);
         let diagram = net
             .activation_diagram(array![1.0, 1.0].view(), &DiagramOptions::default())
             .unwrap();
@@ -403,7 +403,7 @@ mod tests {
 
     #[test]
     fn input_layer_carries_the_raw_instance_values() {
-        let net = relu_layer(array![[1.0, 0.0]], array![0.0]);
+        let net = relu_network(array![[1.0, 0.0]], array![0.0]);
         let diagram = net
             .activation_diagram(array![-0.5, 2.0].view(), &DiagramOptions::default())
             .unwrap();
@@ -422,20 +422,16 @@ mod tests {
         // Row 1's negative pre-activation is clamped to zero by ReLU. Tested on a
         // hidden layer, whose intensity is peak-normalized (an output layer's
         // intensity tracks its probability instead).
-        let net = NeuralNetwork {
-            layers: vec![
-                NeuronLayer {
-                    weights: array![[1.0, 0.0], [-1.0, 0.0], [2.0, 0.0]],
-                    biases: array![0.0, 0.0, 0.0],
-                    activation: RELU.clone(),
-                },
-                NeuronLayer {
-                    weights: array![[1.0, 0.0, 0.0]],
-                    biases: array![0.0],
-                    activation: RELU.clone(),
-                },
-            ],
-        };
+        let net = NeuralNetwork::single(Dense::new(
+            array![[1.0, 0.0], [-1.0, 0.0], [2.0, 0.0]],
+            array![0.0, 0.0, 0.0],
+            RELU.clone(),
+        ))
+        .with_layer(Dense::new(
+            array![[1.0, 0.0, 0.0]],
+            array![0.0],
+            RELU.clone(),
+        ));
         let diagram = net
             .activation_diagram(array![1.0, 1.0].view(), &DiagramOptions::default())
             .unwrap();
@@ -454,7 +450,7 @@ mod tests {
 
     #[test]
     fn edges_keep_weight_sign_and_normalize_magnitude_by_layer_peak() {
-        let net = relu_layer(
+        let net = relu_network(
             array![[1.0, 0.0], [-1.0, 0.0], [2.0, 0.0]],
             array![0.0, 0.0, 0.0],
         );
@@ -486,7 +482,7 @@ mod tests {
     #[test]
     fn large_layers_are_sampled_down_to_the_cap() {
         let weights = Array2::from_shape_fn((50, 2), |(r, _)| r as f32);
-        let net = relu_layer(weights, Array1::zeros(50));
+        let net = relu_network(weights, Array1::zeros(50));
         let options = DiagramOptions {
             max_units: 8,
             ..DiagramOptions::default()
@@ -511,7 +507,7 @@ mod tests {
 
     #[test]
     fn a_weak_edge_threshold_prunes_low_magnitude_connections() {
-        let net = relu_layer(
+        let net = relu_network(
             array![[1.0, 0.0], [-1.0, 0.0], [2.0, 0.0]],
             array![0.0, 0.0, 0.0],
         );
@@ -536,20 +532,12 @@ mod tests {
         // weights a tiny link from the firing neuron and a strong one from the
         // silent one: contribution flows only through neuron 0, so that is the
         // edge a weight-only threshold would have wrongly dropped.
-        let net = NeuralNetwork {
-            layers: vec![
-                NeuronLayer {
-                    weights: array![[1.0], [-1.0]],
-                    biases: array![0.0, 0.0],
-                    activation: RELU.clone(),
-                },
-                NeuronLayer {
-                    weights: array![[0.1, 5.0]],
-                    biases: array![0.0],
-                    activation: RELU.clone(),
-                },
-            ],
-        };
+        let net = NeuralNetwork::single(Dense::new(
+            array![[1.0], [-1.0]],
+            array![0.0, 0.0],
+            RELU.clone(),
+        ))
+        .with_layer(Dense::new(array![[0.1, 5.0]], array![0.0], RELU.clone()));
         let options = DiagramOptions {
             min_edge_magnitude: 0.5,
             ..DiagramOptions::default()
@@ -612,7 +600,7 @@ mod tests {
 
     #[test]
     fn the_classification_ranks_the_output_activations() {
-        let net = relu_layer(array![[1.0, 0.0], [3.0, 0.0]], array![0.0, 0.0]);
+        let net = relu_network(array![[1.0, 0.0], [3.0, 0.0]], array![0.0, 0.0]);
         let diagram = net
             .activation_diagram(array![1.0, 0.0].view(), &DiagramOptions::default())
             .unwrap();
@@ -623,7 +611,7 @@ mod tests {
 
     #[test]
     fn multi_output_neurons_carry_their_own_class() {
-        let net = relu_layer(array![[1.0, 0.0], [3.0, 0.0]], array![0.0, 0.0]);
+        let net = relu_network(array![[1.0, 0.0], [3.0, 0.0]], array![0.0, 0.0]);
         let diagram = net
             .activation_diagram(array![1.0, 0.0].view(), &DiagramOptions::default())
             .unwrap();
@@ -641,7 +629,7 @@ mod tests {
         // Output activations [0.3, 0.4]: read as probabilities, each neuron's
         // intensity is its own value, not the smaller one scaled up against the
         // peak (which would make the 0.3 class render at 0.75 intensity).
-        let net = relu_layer(array![[0.3, 0.0], [0.4, 0.0]], array![0.0, 0.0]);
+        let net = relu_network(array![[0.3, 0.0], [0.4, 0.0]], array![0.0, 0.0]);
         let diagram = net
             .activation_diagram(array![1.0, 0.0].view(), &DiagramOptions::default())
             .unwrap();
@@ -653,7 +641,7 @@ mod tests {
 
     #[test]
     fn a_single_output_neuron_carries_the_binary_positive_class() {
-        let net = relu_layer(array![[1.0, 0.0]], array![0.0]);
+        let net = relu_network(array![[1.0, 0.0]], array![0.0]);
         let diagram = net
             .activation_diagram(array![1.0, 1.0].view(), &DiagramOptions::default())
             .unwrap();
@@ -666,7 +654,7 @@ mod tests {
 
     #[test]
     fn a_scaler_free_predictor_diagram_matches_the_bare_network() {
-        let net = relu_layer(array![[1.0, 0.0], [3.0, 0.0]], array![0.0, 0.0]);
+        let net = relu_network(array![[1.0, 0.0], [3.0, 0.0]], array![0.0, 0.0]);
         let predictor = Predictor::new(net.clone(), None);
         let options = DiagramOptions::default();
 
@@ -684,7 +672,7 @@ mod tests {
 
     #[test]
     fn a_predictor_diagram_rejects_an_instance_of_the_wrong_size() {
-        let net = relu_layer(array![[1.0, 0.0], [3.0, 0.0]], array![0.0, 0.0]);
+        let net = relu_network(array![[1.0, 0.0], [3.0, 0.0]], array![0.0, 0.0]);
         let predictor = Predictor::new(net, None);
 
         // The network expects two features; a one-feature instance is rejected.

--- a/core/src/plot/build.rs
+++ b/core/src/plot/build.rs
@@ -213,7 +213,8 @@ mod tests {
     use crate::data::Dataset;
     use crate::evaluation::{Evaluation, EvaluationSet};
     use crate::evaluation_history::{EpochEvaluation, EvaluationHistory};
-    use crate::model::{NeuralNetwork, NeuronLayer};
+    use crate::layers::Dense;
+    use crate::model::NeuralNetwork;
     use ndarray::array;
 
     /// A two-feature, two-class dataset.
@@ -239,13 +240,7 @@ mod tests {
     /// A 2-input → 1-output sigmoid predictor.
     fn binary_predictor() -> Predictor {
         Predictor::new(
-            NeuralNetwork {
-                layers: vec![NeuronLayer {
-                    weights: array![[1.0, 0.0]],
-                    biases: array![0.0],
-                    activation: SIGMOID.clone(),
-                }],
-            },
+            NeuralNetwork::single(Dense::new(array![[1.0, 0.0]], array![0.0], SIGMOID.clone())),
             None,
         )
     }

--- a/core/src/plot/console/diagram.rs
+++ b/core/src/plot/console/diagram.rs
@@ -82,27 +82,24 @@ fn bold(text: &str) -> String {
 mod tests {
     use super::*;
     use crate::activations::{Activation, RELU};
-    use crate::model::{NeuralNetwork, NeuronLayer};
+    use crate::layers::Dense;
+    use crate::model::NeuralNetwork;
     use crate::plot::activations::DiagramOptions;
     use ndarray::{Array1, Array2, array};
 
     /// A hidden ReLU layer whose middle neuron dies, then a two-class output
     /// layer resolving to probabilities `[0.3, 0.4]`.
     fn diagram() -> ActivationDiagram {
-        let net = NeuralNetwork {
-            layers: vec![
-                NeuronLayer {
-                    weights: array![[1.0, 0.0], [-1.0, 0.0], [2.0, 0.0]],
-                    biases: array![0.0, 0.0, 0.0],
-                    activation: RELU.clone(),
-                },
-                NeuronLayer {
-                    weights: array![[0.3, 0.0, 0.0], [0.0, 0.0, 0.2]],
-                    biases: array![0.0, 0.0],
-                    activation: RELU.clone(),
-                },
-            ],
-        };
+        let net = NeuralNetwork::single(Dense::new(
+            array![[1.0, 0.0], [-1.0, 0.0], [2.0, 0.0]],
+            array![0.0, 0.0, 0.0],
+            RELU.clone(),
+        ))
+        .with_layer(Dense::new(
+            array![[0.3, 0.0, 0.0], [0.0, 0.0, 0.2]],
+            array![0.0, 0.0],
+            RELU.clone(),
+        ));
         net.activation_diagram(array![1.0, 1.0].view(), &DiagramOptions::default())
             .unwrap()
     }
@@ -153,13 +150,7 @@ mod tests {
     #[test]
     fn to_console_flags_a_sampled_layer_in_its_heading() {
         let weights = Array2::from_shape_fn((50, 2), |(r, _)| r as f32);
-        let net = NeuralNetwork {
-            layers: vec![NeuronLayer {
-                weights,
-                biases: Array1::zeros(50),
-                activation: RELU.clone(),
-            }],
-        };
+        let net = NeuralNetwork::single(Dense::new(weights, Array1::zeros(50), RELU.clone()));
         let options = DiagramOptions {
             max_units: 8,
             ..DiagramOptions::default()

--- a/core/src/plot/image/diagram.rs
+++ b/core/src/plot/image/diagram.rs
@@ -365,7 +365,8 @@ fn spread(i: usize, count: usize, start: i32, end: i32) -> i32 {
 mod tests {
     use super::*;
     use crate::activations::RELU;
-    use crate::model::{NeuralNetwork, NeuronLayer};
+    use crate::layers::Dense;
+    use crate::model::NeuralNetwork;
     use crate::plot::activations::DiagramOptions;
     use ndarray::array;
 
@@ -374,13 +375,11 @@ mod tests {
     }
 
     fn diagram() -> ActivationDiagram {
-        let net = NeuralNetwork {
-            layers: vec![NeuronLayer {
-                weights: array![[1.0, 0.0], [-1.0, 0.0], [2.0, 0.0]],
-                biases: array![0.0, 0.0, 0.0],
-                activation: RELU.clone(),
-            }],
-        };
+        let net = NeuralNetwork::single(Dense::new(
+            array![[1.0, 0.0], [-1.0, 0.0], [2.0, 0.0]],
+            array![0.0, 0.0, 0.0],
+            RELU.clone(),
+        ));
         net.activation_diagram(array![1.0, 1.0].view(), &DiagramOptions::default())
             .unwrap()
     }


### PR DESCRIPTION
## Summary

Extract a `Layer` trait (object-safe, `DynClone`) as the single abstraction behind a
network stage, with `Dense` — the former `NeuronLayer`, moved to `nn::layers` — as its only
implementation. `NeuralNetwork` now holds `Vec<Box<dyn Layer>>` and gains validated
constructors (`new` / `single` / `with_layer`). Backprop, the optimizers and I/O all drive
layers through the trait. The dense layer stays **iso-functional**: same math, same
convergence, existing numerical tests unchanged.

Groundwork for later layer types; nothing user-facing changes.

## Notes

- **Public API**: `NeuralNetwork` and `Dense` fields are now private, with an inspection API
  (`layers()`, `Dense::weights()/biases()/activation()`). `LayerGradients` replaces the old
  `Gradients{dw,db}`; optimizers step through `ParameterUpdates` (parameter paired with its
  gradient, so a mismatch is unrepresentable) plus a default `Optimizer::update_layer`.
- **AdamW** decay stays weights-only via a per-`Parameter` `decays` flag.
- **Backward-compat break (deliberate, no migration)**: model files now carry a required
  `layer{i}.kind` tag and Adam state is serialized per parameter (`layer{L}.param{J}.{m|v}`).
  Artifacts saved before this branch will not load. New artifacts round-trip.
- **`compute_input_gradient` flag** on `Layer::backward`: the input layer (`i == 0`) skips the
  discarded `Wᵀ·dz` matmul it used to compute every batch (mirrors Caffe `propagate_down` /
  PyTorch `needs_input_grad`); the pass now returns a named `BackwardPass`.
- **Adam `restore` robustness**: a restored state whose parameter count/shape doesn't match
  the model now fails loudly in `update` instead of silently truncating the zip (which left a
  parameter un-updated). The now-unproducible `WrongRank` error variant is removed. Regression
  test added.
- **Iso-performance on small batches**: genericizing parameters to `ArrayD` made Adam's
  update run its arithmetic in dynamic dimensions, adding per-op overhead that dominated on
  tiny layers (mini-batch/small regressed ~+29%). The update is now a single fused in-place
  `Zip` pass (no per-sub-expression temporaries), recovering it (mini-batch/small −26.5%,
  full-batch −5.4%); MNIST was matmul-bound and unaffected throughout.

## Verification

`task checks` green: 505 workspace tests + 7 doctests, clippy `-D warnings` with and without
features, rustfmt clean. End-to-end CLI (train → save → load → predict/plot) confirmed.
