### PR TITLE
feat(nn): N-dimensional layers and end-to-end 2D CNN support

### DIFF
--- a/cli/tests/predict.rs
+++ b/cli/tests/predict.rs
@@ -131,7 +131,7 @@ fn errors_when_instance_dimension_mismatches_model() {
         .args(["predict", "model", "--instance", "sample"])
         .assert()
         .failure()
-        .stderr(contains("expects 2"));
+        .stderr(contains("expects [2]"));
 }
 
 #[test]

--- a/core/benches/training.rs
+++ b/core/benches/training.rs
@@ -1,19 +1,24 @@
-//! Performance benchmarks for the MLP hot paths: inference (`forward`/`predict`)
+//! Performance benchmarks for the network hot paths: inference (`forward`/`predict`)
 //! and a single training epoch (full-batch and mini-batch SGD).
 //!
-//! Two workloads bracket the realistic range:
-//! - `small`: a 2-feature binary problem (the synthetic-dataset CLI demos).
-//! - `mnist`: a 784-feature, 10-class problem with two hidden layers.
+//! Three workloads bracket the realistic range:
+//! - `small`: a 2-feature binary MLP (the synthetic-dataset CLI demos).
+//! - `mnist`: a 784-feature, 10-class MLP with two hidden layers.
+//! - `cnn`: a 1×28×28, 10-class convolutional net (Conv2d → Flatten → Dense),
+//!   exercising the spatial `im2col`/`col2im` paths on a rank-4 batch.
 //!
 //! Each epoch benchmark clones the model in `iter_batched`'s setup so the clone
 //! is excluded from the measured region and every iteration starts from the same
 //! weights (training mutates them in place).
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use ndarray::Array2;
+use ndarray::{Array2, Array4};
+use ndarray_rand::rand::SeedableRng;
+use ndarray_rand::rand::rngs::StdRng;
 use nrn::activations::{RELU, SIGMOID, SOFTMAX};
 use nrn::data::ModelDataset;
 use nrn::gradients::GradientClipping;
+use nrn::layers::{Conv2d, Dense, Flatten};
 use nrn::learning_rate::LearningRate;
 use nrn::loss_functions::{CROSS_ENTROPY_LOSS, LossFunction};
 use nrn::model::{NeuralNetwork, NeuronLayerSpec};
@@ -40,11 +45,11 @@ fn pseudo_random(shape: (usize, usize), mix: u64) -> Array2<f32> {
     })
 }
 
-/// Builds a `(features, samples)` input matrix and a one-hot / binary target matrix.
-fn make_dataset(n_features: usize, n_classes: usize, n_samples: usize) -> ModelDataset {
-    let inputs = pseudo_random((n_features, n_samples), 0);
+/// A one-hot (multi-class) or binary `(target_rows, samples)` target matrix whose labels
+/// cycle through the classes, so every class is represented.
+fn make_targets(n_classes: usize, n_samples: usize) -> Array2<f32> {
     let target_rows = if n_classes == 2 { 1 } else { n_classes };
-    let targets = Array2::from_shape_fn((target_rows, n_samples), |(r, c)| {
+    Array2::from_shape_fn((target_rows, n_samples), |(r, c)| {
         let label = c % n_classes;
         if n_classes == 2 {
             label as f32
@@ -53,8 +58,32 @@ fn make_dataset(n_features: usize, n_classes: usize, n_samples: usize) -> ModelD
         } else {
             0.0
         }
+    })
+}
+
+/// Builds a `(features, samples)` input matrix paired with matching targets.
+fn make_dataset(n_features: usize, n_classes: usize, n_samples: usize) -> ModelDataset {
+    let inputs = pseudo_random((n_features, n_samples), 0);
+    ModelDataset::new(inputs, make_targets(n_classes, n_samples))
+}
+
+/// Builds a `(channels, height, width, samples)` spatial batch (samples-last, the
+/// convention a leading `Conv2d` consumes) paired with matching targets.
+fn make_spatial_dataset(
+    channels: usize,
+    height: usize,
+    width: usize,
+    n_classes: usize,
+    n_samples: usize,
+) -> ModelDataset {
+    let inputs = Array4::from_shape_fn((channels, height, width, n_samples), |(ch, h, w, s)| {
+        let n = (ch as u64).wrapping_mul(73_856_093)
+            ^ (h as u64).wrapping_mul(19_349_663)
+            ^ (w as u64).wrapping_mul(83_492_791)
+            ^ (s as u64);
+        ((n % 2000) as f32) / 1000.0 - 1.0
     });
-    ModelDataset::new(inputs, targets)
+    ModelDataset::new(inputs, make_targets(n_classes, n_samples))
 }
 
 fn small_workload() -> Workload {
@@ -97,6 +126,32 @@ fn mnist_workload() -> Workload {
     }
 }
 
+fn cnn_workload() -> Workload {
+    // 1×28×28 → Conv2d(16 filters, 3×3, stride 1) → 16×26×26 → Flatten → Dense(10, softmax).
+    let conv = Conv2d::initialization(
+        (1, 28, 28),
+        16,
+        (3, 3),
+        1,
+        0,
+        RELU.clone(),
+        &mut StdRng::seed_from_u64(42),
+    );
+    let head = Dense::initialization(
+        16 * 26 * 26,
+        &NeuronLayerSpec::output_for(10),
+        &mut StdRng::seed_from_u64(43),
+    );
+    let model = NeuralNetwork::single(conv)
+        .with_layer(Flatten::new(vec![16, 26, 26]))
+        .with_layer(head);
+    Workload {
+        model,
+        dataset: make_spatial_dataset(1, 28, 28, 10, 1_000),
+        batch_size: 64,
+    }
+}
+
 fn loss() -> Arc<dyn LossFunction> {
     CROSS_ENTROPY_LOSS.clone()
 }
@@ -119,7 +174,11 @@ fn run_epoch(model: &mut NeuralNetwork, w: &Workload, mini_batch: Option<MiniBat
 
 fn bench_inference(c: &mut Criterion) {
     let mut group = c.benchmark_group("inference");
-    for (name, w) in [("small", small_workload()), ("mnist", mnist_workload())] {
+    for (name, w) in [
+        ("small", small_workload()),
+        ("mnist", mnist_workload()),
+        ("cnn", cnn_workload()),
+    ] {
         group.bench_function(name, |b| {
             b.iter(|| black_box(w.model.predict(w.dataset.inputs().view())));
         });
@@ -129,7 +188,11 @@ fn bench_inference(c: &mut Criterion) {
 
 fn bench_epoch_full_batch(c: &mut Criterion) {
     let mut group = c.benchmark_group("epoch_full_batch");
-    for (name, w) in [("small", small_workload()), ("mnist", mnist_workload())] {
+    for (name, w) in [
+        ("small", small_workload()),
+        ("mnist", mnist_workload()),
+        ("cnn", cnn_workload()),
+    ] {
         group.bench_function(name, |b| {
             b.iter_batched(
                 || w.model.clone(),
@@ -143,7 +206,11 @@ fn bench_epoch_full_batch(c: &mut Criterion) {
 
 fn bench_epoch_mini_batch(c: &mut Criterion) {
     let mut group = c.benchmark_group("epoch_mini_batch");
-    for (name, w) in [("small", small_workload()), ("mnist", mnist_workload())] {
+    for (name, w) in [
+        ("small", small_workload()),
+        ("mnist", mnist_workload()),
+        ("cnn", cnn_workload()),
+    ] {
         group.bench_function(name, |b| {
             b.iter_batched(
                 || w.model.clone(),

--- a/core/src/analysis/boundary.rs
+++ b/core/src/analysis/boundary.rs
@@ -317,9 +317,9 @@ mod tests {
             array![-0.5],
             SIGMOID.clone(),
         ));
-        // MinMax fitted on raw x0 ∈ [0, 2]: scaled 0.5 maps back to raw 1.0.
+        // MinMax fitted on raw x0 ∈ [0, 2] (features on rows): scaled 0.5 maps back to raw 1.0.
         let scaler = ScalerMethod::MinMax(
-            MinMaxScaler::default().fit(array![[0.0, 0.0], [2.0, 2.0]].view()),
+            MinMaxScaler::default().fit(array![[0.0, 2.0], [0.0, 2.0]].view()),
         );
         let predictor = Predictor::new(network, Some(scaler));
 

--- a/core/src/analysis/boundary.rs
+++ b/core/src/analysis/boundary.rs
@@ -162,7 +162,7 @@ fn make_grid_and_inputs(
     // Generate all grid points using recursive backtracking
     let total_points = resolution
         .checked_pow(n_dims as u32)
-        .expect("Grid too large: resolution^n_dims overflows usize");
+        .expect("grid too large: resolution^n_dims overflows usize");
     let mut nested_points = Vec::with_capacity(total_points);
 
     generate_points_recursive(
@@ -251,7 +251,7 @@ mod tests {
     use ndarray::array;
 
     #[test]
-    #[should_panic(expected = "Grid too large")]
+    #[should_panic(expected = "grid too large")]
     #[cfg(target_pointer_width = "64")]
     fn overflow_panics_with_clear_message() {
         // 2^65 > usize::MAX on 64-bit — without checked_pow this silently wraps to 0

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -1,6 +1,6 @@
 use crate::data::origin::DatasetOrigin;
 use crate::data::scalers::{Scaler, ScalerFeatureMismatch, ScalerKind, ScalerMethod};
-use ndarray::{Array1, Array2, Axis};
+use ndarray::{Array, Array1, Array2, ArrayD, Axis, Dimension, Ix2};
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::prelude::{SliceRandom, StdRng};
@@ -26,8 +26,10 @@ pub struct Dataset {
 }
 
 pub struct ModelDataset {
-    /// A 2D array where each column is a sample and each row is a feature
-    inputs: Array2<f32>,
+    /// A samples-last array: the leading axes are the per-sample features and the
+    /// trailing axis indexes samples. Rank-2 `(features, samples)` for tabular data,
+    /// higher rank for spatial data.
+    inputs: ArrayD<f32>,
     /// A 2D array where each column is a sample and each row is a target (one-hot encoded for multi-class)
     targets: Array2<f32>,
 }
@@ -339,9 +341,10 @@ impl Dataset {
         indices.shuffle(&mut StdRng::seed_from_u64(seed));
 
         let size = |ratio: f32| (n_samples as f32 * ratio).round() as usize;
+        let sample_axis = Axis(model.inputs.ndim() - 1);
         let select = |idx: &[usize]| {
             ModelDataset::new(
-                model.inputs.select(Axis(1), idx),
+                model.inputs.select(sample_axis, idx),
                 model.targets.select(Axis(1), idx),
             )
         };
@@ -363,23 +366,31 @@ impl Dataset {
 }
 
 impl ModelDataset {
-    /// Pairs column-major `inputs` `(features, samples)` with their `targets`
-    /// `(targets, samples)`.
+    /// Pairs samples-last `inputs` (trailing axis indexes samples) with their
+    /// `targets` `(targets, samples)`. `inputs` may be any rank: rank-2
+    /// `(features, samples)` for tabular data, higher rank for spatial data.
     ///
     /// # Panics
-    /// - When `inputs` and `targets` disagree on the sample count (columns).
-    pub fn new(inputs: Array2<f32>, targets: Array2<f32>) -> Self {
+    /// - When `inputs` and `targets` disagree on the sample count (`inputs`'
+    ///   trailing axis versus `targets`' columns).
+    pub fn new<D: Dimension>(inputs: Array<f32, D>, targets: Array2<f32>) -> Self {
+        let inputs = inputs.into_dyn();
         assert_eq!(
-            inputs.ncols(),
+            inputs.shape()[inputs.ndim() - 1],
             targets.ncols(),
             "Inputs and targets must have the same number of samples."
         );
         ModelDataset { inputs, targets }
     }
 
-    /// Returns the inputs, `(features, samples)`.
-    pub fn inputs(&self) -> &Array2<f32> {
+    /// Returns the inputs, samples-last (trailing axis indexes samples).
+    pub fn inputs(&self) -> &ArrayD<f32> {
         &self.inputs
+    }
+
+    /// The sample axis, the trailing axis of the samples-last inputs.
+    fn sample_axis(&self) -> Axis {
+        Axis(self.inputs.ndim() - 1)
     }
 
     /// Returns the targets, `(targets, samples)`.
@@ -395,7 +406,8 @@ impl ModelDataset {
         size: usize,
         rng: &mut R,
     ) -> impl Iterator<Item = ModelDataset> + '_ {
-        let mut indices: Vec<usize> = (0..self.inputs.ncols()).collect();
+        let sample_axis = self.sample_axis();
+        let mut indices: Vec<usize> = (0..self.targets.ncols()).collect();
         indices.shuffle(rng);
         let n = indices.len();
         let mut pos = 0;
@@ -407,45 +419,77 @@ impl ModelDataset {
             let chunk = &indices[pos..end];
             pos = end;
             Some(ModelDataset::new(
-                self.inputs.select(Axis(1), chunk),
+                self.inputs.select(sample_axis, chunk),
                 self.targets.select(Axis(1), chunk),
             ))
         })
     }
 
-    /// Fits a scaler of the given `kind` on these inputs. `inputs` is
-    /// `(features, samples)` whereas fitting expects `(samples, features)`, so the
-    /// view is transposed for the call.
-    pub fn fit_scaler(&self, kind: ScalerKind) -> ScalerMethod {
-        kind.fit(self.inputs.t())
+    /// The number of features per sample, the product of the leading axes.
+    fn n_features(&self) -> usize {
+        self.inputs.shape()[..self.inputs.ndim() - 1]
+            .iter()
+            .product()
     }
 
-    /// Applies a scaler to the inputs in-place. `inputs` is `(features, samples)`
-    /// whereas the scaler expects `(samples, features)`, so the view is transposed
-    /// for the call.
+    /// Fits a per-feature scaler of the given `kind` on these inputs. The leading
+    /// feature axes are merged into a single axis and the view transposed to the
+    /// `(samples, features)` layout fitting expects.
+    pub fn fit_scaler(&self, kind: ScalerKind) -> ScalerMethod {
+        let (n_features, n_samples) = (self.n_features(), self.targets.ncols());
+        let flat = self
+            .inputs
+            .to_shape((n_features, n_samples))
+            .expect("samples-last inputs reshape to (features, samples)");
+        kind.fit(flat.t())
+    }
+
+    /// Applies a per-feature scaler to the inputs in-place. The leading feature axes
+    /// are merged into a single axis and the mutable view transposed to the
+    /// `(samples, features)` layout the scaler expects.
     ///
     /// # Errors
     /// [`ScalerFeatureMismatch`] when the scaler's fitted feature count does not match
     /// these inputs.
     pub fn scale_inplace(&mut self, scaler: &dyn Scaler) -> Result<(), ScalerFeatureMismatch> {
-        scaler.apply_inplace(self.inputs.view_mut().reversed_axes())
+        // Rank-2 tabular inputs are already `(features, samples)`: transpose the view
+        // in place, no axis merge and no copy, whatever the underlying layout.
+        if let Ok(flat) = self.inputs.view_mut().into_dimensionality::<Ix2>() {
+            return scaler.apply_inplace(flat.reversed_axes());
+        }
+
+        // Higher-rank inputs merge their leading feature axes, which needs a
+        // contiguous buffer: scale a standard-layout copy and write it back.
+        let (n_features, n_samples) = (self.n_features(), self.targets.ncols());
+        let mut standard = self.inputs.as_standard_layout().into_owned();
+        {
+            let flat = standard
+                .view_mut()
+                .into_shape_with_order((n_features, n_samples))
+                .expect("standard-layout inputs merge their feature axes into (features, samples)");
+            scaler.apply_inplace(flat.reversed_axes())?;
+        }
+        self.inputs = standard;
+        Ok(())
     }
 }
 
 impl ModelSplit {
     /// Returns the number of training samples in the dataset.
     pub fn train_size(&self) -> usize {
-        self.train.inputs.ncols()
+        self.train.targets.ncols()
     }
 
     /// Returns the number of validation samples in the dataset.
     pub fn validation_size(&self) -> usize {
-        self.validation.as_ref().map_or(0, |val| val.inputs.ncols())
+        self.validation
+            .as_ref()
+            .map_or(0, |val| val.targets.ncols())
     }
 
     /// Returns the number of testing samples in the dataset.
     pub fn test_size(&self) -> usize {
-        self.test.inputs.ncols()
+        self.test.targets.ncols()
     }
 
     /// Applies `scaler` in-place to every split. The scaler is fitted on the
@@ -740,6 +784,51 @@ mod tests {
         {
             assert!(part.inputs.iter().all(|&v| v.is_finite()));
         }
+    }
+
+    #[test]
+    fn model_dataset_accepts_rank4_inputs_and_batches_on_the_sample_axis() {
+        use ndarray::Array4;
+
+        // (channels=1, height=2, width=2, samples=6): samples on the trailing axis.
+        let inputs = Array4::from_shape_fn((1, 2, 2, 6), |(_, h, w, s)| (h + w + s) as f32);
+        let targets = Array2::from_shape_fn((1, 6), |(_, s)| (s % 2) as f32);
+        let dataset = ModelDataset::new(inputs, targets);
+        assert_eq!(dataset.inputs().shape(), &[1, 2, 2, 6]);
+
+        let mut rng = StdRng::seed_from_u64(0);
+        let batches: Vec<_> = dataset.batches(4, &mut rng).collect();
+        // 6 samples in size-4 batches → a full batch of 4 and a remainder of 2, with
+        // only the trailing sample axis chunked and the feature axes preserved.
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].inputs().shape(), &[1, 2, 2, 4]);
+        assert_eq!(batches[0].targets().shape(), &[1, 4]);
+        assert_eq!(batches[1].inputs().shape(), &[1, 2, 2, 2]);
+    }
+
+    #[test]
+    fn fit_scaler_generalizes_to_rank_n_inputs() {
+        use ndarray::Array4;
+
+        // (channels=1, height=2, width=2, samples=3): the four spatial cells are the
+        // per-feature statistics, merged from the leading axes; each scales over its
+        // three samples.
+        let inputs = Array4::from_shape_fn((1, 2, 2, 3), |(_, h, w, s)| {
+            (h * 2 + w) as f32 * 10.0 + s as f32
+        });
+        let targets = Array2::from_shape_fn((1, 3), |(_, s)| (s % 2) as f32);
+        let mut model = ModelDataset::new(inputs, targets);
+
+        let scaler = model.fit_scaler(ScalerKind::MinMax);
+        model.scale_inplace(&scaler).unwrap();
+
+        assert_eq!(model.inputs().shape(), &[1, 2, 2, 3]);
+        assert!(
+            model
+                .inputs
+                .iter()
+                .all(|&v| (0.0..=1.0 + 1e-5).contains(&v))
+        );
     }
 
     #[test]

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -1,6 +1,6 @@
 use crate::data::origin::DatasetOrigin;
 use crate::data::scalers::{Scaler, ScalerFeatureMismatch, ScalerKind, ScalerMethod};
-use ndarray::{Array, Array1, Array2, ArrayD, Axis, Dimension};
+use ndarray::{Array, Array1, Array2, ArrayD, Axis, Dimension, Ix2};
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::prelude::{SliceRandom, StdRng};
@@ -341,10 +341,9 @@ impl Dataset {
         indices.shuffle(&mut StdRng::seed_from_u64(seed));
 
         let size = |ratio: f32| (n_samples as f32 * ratio).round() as usize;
-        let sample_axis = Axis(model.inputs.ndim() - 1);
         let select = |idx: &[usize]| {
             ModelDataset::new(
-                model.inputs.select(sample_axis, idx),
+                model.select_samples(idx),
                 model.targets.select(Axis(1), idx),
             )
         };
@@ -393,6 +392,16 @@ impl ModelDataset {
         Axis(self.inputs.ndim() - 1)
     }
 
+    /// Gathers the samples at `indices` along the sample axis into a fresh owned array.
+    /// Rank-2 inputs gather on the static `Ix2` type, which avoids the dynamic-rank
+    /// indexing overhead of [`ArrayD::select`] on the tabular hot path.
+    fn select_samples(&self, indices: &[usize]) -> ArrayD<f32> {
+        match self.inputs.view().into_dimensionality::<Ix2>() {
+            Ok(inputs) => inputs.select(Axis(1), indices).into_dyn(),
+            Err(_) => self.inputs.select(self.sample_axis(), indices),
+        }
+    }
+
     /// Returns the targets, `(targets, samples)`.
     pub fn targets(&self) -> &Array2<f32> {
         &self.targets
@@ -406,7 +415,6 @@ impl ModelDataset {
         size: usize,
         rng: &mut R,
     ) -> impl Iterator<Item = ModelDataset> + '_ {
-        let sample_axis = self.sample_axis();
         let mut indices: Vec<usize> = (0..self.targets.ncols()).collect();
         indices.shuffle(rng);
         let n = indices.len();
@@ -419,7 +427,7 @@ impl ModelDataset {
             let chunk = &indices[pos..end];
             pos = end;
             Some(ModelDataset::new(
-                self.inputs.select(sample_axis, chunk),
+                self.select_samples(chunk),
                 self.targets.select(Axis(1), chunk),
             ))
         })

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -1,6 +1,6 @@
 use crate::data::origin::DatasetOrigin;
 use crate::data::scalers::{Scaler, ScalerFeatureMismatch, ScalerKind, ScalerMethod};
-use ndarray::{Array, Array1, Array2, ArrayD, Axis, Dimension, Ix2};
+use ndarray::{Array, Array1, Array2, ArrayD, Axis, Dimension};
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::prelude::{SliceRandom, StdRng};
@@ -425,52 +425,21 @@ impl ModelDataset {
         })
     }
 
-    /// The number of features per sample, the product of the leading axes.
-    fn n_features(&self) -> usize {
-        self.inputs.shape()[..self.inputs.ndim() - 1]
-            .iter()
-            .product()
-    }
-
-    /// Fits a per-feature scaler of the given `kind` on these inputs. The leading
-    /// feature axes are merged into a single axis and the view transposed to the
-    /// `(samples, features)` layout fitting expects.
+    /// Fits a per-feature scaler of the given `kind` on these inputs. Features run
+    /// along the leading axis; each is fitted over the remaining spatial and sample
+    /// axes.
     pub fn fit_scaler(&self, kind: ScalerKind) -> ScalerMethod {
-        let (n_features, n_samples) = (self.n_features(), self.targets.ncols());
-        let flat = self
-            .inputs
-            .to_shape((n_features, n_samples))
-            .expect("samples-last inputs reshape to (features, samples)");
-        kind.fit(flat.t())
+        kind.fit(self.inputs.view())
     }
 
-    /// Applies a per-feature scaler to the inputs in-place. The leading feature axes
-    /// are merged into a single axis and the mutable view transposed to the
-    /// `(samples, features)` layout the scaler expects.
+    /// Applies a per-feature scaler to the inputs in place, scaling each leading-axis
+    /// feature over the remaining spatial and sample axes.
     ///
     /// # Errors
     /// [`ScalerFeatureMismatch`] when the scaler's fitted feature count does not match
     /// these inputs.
     pub fn scale_inplace(&mut self, scaler: &dyn Scaler) -> Result<(), ScalerFeatureMismatch> {
-        // Rank-2 tabular inputs are already `(features, samples)`: transpose the view
-        // in place, no axis merge and no copy, whatever the underlying layout.
-        if let Ok(flat) = self.inputs.view_mut().into_dimensionality::<Ix2>() {
-            return scaler.apply_inplace(flat.reversed_axes());
-        }
-
-        // Higher-rank inputs merge their leading feature axes, which needs a
-        // contiguous buffer: scale a standard-layout copy and write it back.
-        let (n_features, n_samples) = (self.n_features(), self.targets.ncols());
-        let mut standard = self.inputs.as_standard_layout().into_owned();
-        {
-            let flat = standard
-                .view_mut()
-                .into_shape_with_order((n_features, n_samples))
-                .expect("standard-layout inputs merge their feature axes into (features, samples)");
-            scaler.apply_inplace(flat.reversed_axes())?;
-        }
-        self.inputs = standard;
-        Ok(())
+        scaler.apply_inplace(self.inputs.view_mut())
     }
 }
 
@@ -807,14 +776,17 @@ mod tests {
     }
 
     #[test]
-    fn fit_scaler_generalizes_to_rank_n_inputs() {
+    fn fit_scaler_normalizes_rank_n_inputs_per_leading_feature() {
         use ndarray::Array4;
 
-        // (channels=1, height=2, width=2, samples=3): the four spatial cells are the
-        // per-feature statistics, merged from the leading axes; each scales over its
-        // three samples.
-        let inputs = Array4::from_shape_fn((1, 2, 2, 3), |(_, h, w, s)| {
-            (h * 2 + w) as f32 * 10.0 + s as f32
+        // (features=2, height=1, width=2, samples=3): feature 0 spans [0, 10] and
+        // feature 1 [0, 100] across all spatial cells and samples. Fitting and scaling
+        // through the dataset keeps the spatial shape and normalizes per feature, not
+        // per spatial cell.
+        let inputs = Array4::from_shape_fn((2, 1, 2, 3), |(f, _h, w, s)| {
+            let scale = if f == 0 { 1.0 } else { 10.0 };
+            let cell = if w == 0 { 0.0 } else { 8.0 };
+            (cell + s as f32) * scale
         });
         let targets = Array2::from_shape_fn((1, 3), |(_, s)| (s % 2) as f32);
         let mut model = ModelDataset::new(inputs, targets);
@@ -822,13 +794,17 @@ mod tests {
         let scaler = model.fit_scaler(ScalerKind::MinMax);
         model.scale_inplace(&scaler).unwrap();
 
-        assert_eq!(model.inputs().shape(), &[1, 2, 2, 3]);
+        assert_eq!(model.inputs().shape(), &[2, 1, 2, 3]);
         assert!(
             model
                 .inputs
                 .iter()
                 .all(|&v| (0.0..=1.0 + 1e-5).contains(&v))
         );
+        // An interior sample of feature 0 (value 1 in [0, 10]) lands at 0.1, not 0.5:
+        // the feature is normalized as a whole, not per spatial cell.
+        assert!((model.inputs[[0, 0, 0, 1]] - 0.1).abs() < 1e-5);
+        assert!((model.inputs[[0, 0, 1, 0]] - 0.8).abs() < 1e-5);
     }
 
     #[test]

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -425,15 +425,14 @@ impl ModelDataset {
         })
     }
 
-    /// Fits a per-feature scaler of the given `kind` on these inputs. Features run
-    /// along the leading axis; each is fitted over the remaining spatial and sample
-    /// axes.
+    /// Fits a scaler of the given `kind` on these inputs, laid out samples-last with
+    /// features along the leading axis.
     pub fn fit_scaler(&self, kind: ScalerKind) -> ScalerMethod {
         kind.fit(self.inputs.view())
     }
 
-    /// Applies a per-feature scaler to the inputs in place, scaling each leading-axis
-    /// feature over the remaining spatial and sample axes.
+    /// Applies `scaler` to the inputs in place. The inputs are laid out samples-last
+    /// with features along the leading axis.
     ///
     /// # Errors
     /// [`ScalerFeatureMismatch`] when the scaler's fitted feature count does not match

--- a/core/src/data/preprocessors/scalers/min_max.rs
+++ b/core/src/data/preprocessors/scalers/min_max.rs
@@ -9,14 +9,15 @@
 //! use nrn::data::scalers::{MinMaxScaler, Scaler};
 //! use ndarray::array;
 //!
+//! // Features on the leading axis: two features (rows), two samples (columns).
 //! let mut data = array![[0.0, 5.0], [10.0, 20.0]];
 //! let scaler = MinMaxScaler::default().fit(data.view());
-//! scaler.apply_inplace(data.view_mut()).unwrap();
+//! scaler.apply_inplace(data.view_mut().into_dyn()).unwrap();
 //! assert!(data.iter().all(|&v| v >= 0.0 && v <= 1.0 + 1e-5));
 //! ```
 
 use crate::data::scalers::{Scaler, ScalerFeatureMismatch};
-use ndarray::{Array1, ArrayView2, ArrayViewMut2, Axis};
+use ndarray::{Array1, ArrayView, ArrayViewMutD, Axis, RemoveAxis};
 
 /// Scaler that linearly rescales data feature-wise to a target range using the min-max method.
 /// See also the [`Scaler`] trait for interface details.
@@ -48,21 +49,28 @@ impl MinMaxScaler {
         }
     }
 
-    /// Calculates the minimum and maximum values per feature from the input data,
-    /// returning a new `MinMaxScaler` instance configured for scaling.
+    /// Calculates the minimum and maximum per feature from samples-last input of
+    /// any rank, returning a new `MinMaxScaler` instance configured for scaling.
     ///
-    /// This method consumes the current instance and returns a new one with
-    /// fitted parameters.
+    /// Features run along the leading axis; each is reduced over the remaining axes.
+    /// This method consumes the current instance and returns a new one with fitted
+    /// parameters.
     ///
     /// # Arguments
-    /// * `data` - 2D array view of training data.
+    /// * `data` - Array view of training data, features on the leading axis.
     ///
     /// # Returns
     /// A new `MinMaxScaler` configured with min/max per feature.
     ///
-    pub fn fit(mut self, data: ArrayView2<f32>) -> Self {
-        self.min = data.fold_axis(Axis(0), f32::INFINITY, |&a, &b| a.min(b));
-        self.max = data.fold_axis(Axis(0), f32::NEG_INFINITY, |&a, &b| a.max(b));
+    pub fn fit<D: RemoveAxis>(mut self, data: ArrayView<f32, D>) -> Self {
+        self.min = data
+            .axis_iter(Axis(0))
+            .map(|feature| feature.fold(f32::INFINITY, |a, &b| a.min(b)))
+            .collect();
+        self.max = data
+            .axis_iter(Axis(0))
+            .map(|feature| feature.fold(f32::NEG_INFINITY, |a, &b| a.max(b)))
+            .collect();
         self
     }
 }
@@ -91,27 +99,27 @@ impl Scaler for MinMaxScaler {
     ///
     /// # Errors
     ///
-    /// [`ScalerFeatureMismatch`] when the number of columns in `data` does not match the
+    /// [`ScalerFeatureMismatch`] when the leading axis of `inputs` does not match the
     /// number of features in the scaler (`min` and `max` length).
     ///
     /// # Arguments
     ///
-    /// * `data` - Mutable 2D array view of data to scale in-place.
+    /// * `inputs` - Mutable samples-last array to scale in-place, features on the leading axis.
     ///
-    fn apply_inplace(&self, mut data: ArrayViewMut2<f32>) -> Result<(), ScalerFeatureMismatch> {
-        let (expected, found) = (self.min.len(), data.shape()[1]);
+    fn apply_inplace(&self, mut inputs: ArrayViewMutD<f32>) -> Result<(), ScalerFeatureMismatch> {
+        let (expected, found) = (self.min.len(), inputs.shape()[0]);
         (found == expected)
             .then_some(())
             .ok_or(ScalerFeatureMismatch { expected, found })?;
 
         let (min_range, max_range) = self.range;
         let scale = max_range - min_range;
-        for (mut col, (&min, &max)) in data
-            .axis_iter_mut(Axis(1))
+        for (mut feature, (&min, &max)) in inputs
+            .axis_iter_mut(Axis(0))
             .zip(self.min.iter().zip(self.max.iter()))
         {
             let denom = max - min + f32::EPSILON;
-            for v in col.iter_mut() {
+            for v in feature.iter_mut() {
                 *v = ((*v - min) / denom) * scale + min_range;
             }
         }
@@ -126,7 +134,8 @@ mod tests {
 
     #[test]
     fn fit_computes_min_max_per_feature() {
-        let data = array![[1.0, 10.0], [3.0, 20.0], [2.0, 30.0]];
+        // Two features (rows), three samples each (columns).
+        let data = array![[1.0, 3.0, 2.0], [10.0, 20.0, 30.0]];
         let scaler = MinMaxScaler::default().fit(data.view());
         assert_eq!(scaler.min[0], 1.0);
         assert_eq!(scaler.min[1], 10.0);
@@ -136,22 +145,25 @@ mod tests {
 
     #[test]
     fn apply_rejects_feature_count_mismatch() {
-        // Fitted on 2 features, applied to 3-column data → error, not a panic.
+        // Fitted on 2 features, applied to inputs with 3 on the leading axis → error.
         let scaler = MinMaxScaler::default().fit(array![[0.0, 0.0], [1.0, 1.0]].view());
-        let mut wrong = array![[0.0, 0.0, 0.0]];
-        let error = scaler.apply_inplace(wrong.view_mut()).unwrap_err();
+        let mut wrong = array![[0.0], [0.0], [0.0]];
+        let error = scaler
+            .apply_inplace(wrong.view_mut().into_dyn())
+            .unwrap_err();
         assert_eq!((error.expected, error.found), (2, 3));
     }
 
     #[test]
     fn min_maps_to_zero_max_maps_to_one() {
-        let data = array![[0.0, 0.0], [10.0, 100.0]];
+        // Feature 0 spans [0, 10], feature 1 spans [0, 100] (one feature per row).
+        let data = array![[0.0, 10.0], [0.0, 100.0]];
         let scaler = MinMaxScaler::default().fit(data.view());
         let mut scaled = data.clone();
-        scaler.apply_inplace(scaled.view_mut()).unwrap();
+        scaler.apply_inplace(scaled.view_mut().into_dyn()).unwrap();
         assert!((scaled[[0, 0]] - 0.0).abs() < 1e-5);
-        assert!((scaled[[1, 0]] - 1.0).abs() < 1e-5);
-        assert!((scaled[[0, 1]] - 0.0).abs() < 1e-5);
+        assert!((scaled[[0, 1]] - 1.0).abs() < 1e-5);
+        assert!((scaled[[1, 0]] - 0.0).abs() < 1e-5);
         assert!((scaled[[1, 1]] - 1.0).abs() < 1e-5);
     }
 
@@ -160,7 +172,7 @@ mod tests {
         let data = array![[1.0, 5.0], [2.0, 15.0], [3.0, 25.0]];
         let scaler = MinMaxScaler::default().fit(data.view());
         let mut scaled = data.clone();
-        scaler.apply_inplace(scaled.view_mut()).unwrap();
+        scaler.apply_inplace(scaled.view_mut().into_dyn()).unwrap();
         for &v in scaled.iter() {
             assert!((0.0..=1.0 + 1e-5).contains(&v), "Value {} out of [0, 1]", v);
         }
@@ -168,27 +180,36 @@ mod tests {
 
     #[test]
     fn constant_feature_does_not_panic() {
-        // First feature is constant — denom would be zero without epsilon guard
-        let data = array![[5.0, 1.0], [5.0, 2.0], [5.0, 3.0]];
+        // First feature (row) is constant — denom would be zero without epsilon guard.
+        let data = array![[5.0, 5.0, 5.0], [1.0, 2.0, 3.0]];
         let scaler = MinMaxScaler::default().fit(data.view());
         let mut scaled = data.clone();
-        scaler.apply_inplace(scaled.view_mut()).unwrap();
+        scaler.apply_inplace(scaled.view_mut().into_dyn()).unwrap();
         // Constant feature maps to range lower bound (0.0)
         assert!((scaled[[0, 0]] - 0.0).abs() < 1e-3);
     }
 
     #[test]
-    fn apply_single_matches_batch_apply() {
-        let data = array![[1.0, 10.0], [3.0, 30.0]];
+    fn scales_rank_n_inputs_per_feature() {
+        use ndarray::Array4;
+
+        // (features=2, height=1, width=2, samples=3): feature 0 spans [0, 10] and
+        // feature 1 [0, 100] across all spatial cells and samples. Each feature is
+        // normalized over its whole slab, not per spatial cell.
+        let data = Array4::from_shape_fn((2, 1, 2, 3), |(f, _h, w, s)| {
+            let scale = if f == 0 { 1.0 } else { 10.0 };
+            let cell = if w == 0 { 0.0 } else { 8.0 };
+            (cell + s as f32) * scale
+        });
         let scaler = MinMaxScaler::default().fit(data.view());
+        let mut scaled = data.clone().into_dyn();
+        scaler.apply_inplace(scaled.view_mut()).unwrap();
 
-        let mut single = ndarray::array![2.0, 20.0];
-        scaler.apply_single_inplace(single.view_mut()).unwrap();
-
-        let mut batch = array![[2.0, 20.0]];
-        scaler.apply_inplace(batch.view_mut()).unwrap();
-
-        assert!((single[0] - batch[[0, 0]]).abs() < 1e-6);
-        assert!((single[1] - batch[[0, 1]]).abs() < 1e-6);
+        assert_eq!(scaler.min.len(), 2);
+        assert!(scaled.iter().all(|&v| (0.0..=1.0 + 1e-5).contains(&v)));
+        // An interior sample of feature 0 (value 1 in [0, 10]) lands at 0.1, not 0.5:
+        // the whole feature shares one min/max, it is not scaled per spatial cell.
+        assert!((scaled[[0, 0, 0, 1]] - 0.1).abs() < 1e-5);
+        assert!((scaled[[0, 0, 1, 0]] - 0.8).abs() < 1e-5);
     }
 }

--- a/core/src/data/preprocessors/scalers/mod.rs
+++ b/core/src/data/preprocessors/scalers/mod.rs
@@ -4,7 +4,7 @@ mod z_score;
 pub use min_max::MinMaxScaler;
 pub use z_score::ZScoreScaler;
 
-use ndarray::{ArrayView2, ArrayViewMut1, ArrayViewMut2, Axis};
+use ndarray::{ArrayView, ArrayViewMutD, RemoveAxis};
 
 /// An input's feature count did not match the scaler's fitted feature count.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,41 +35,25 @@ impl std::error::Error for ScalerFeatureMismatch {}
 /// - Z-score Normalization (Standardization): centers data around zero with unit variance.
 ///
 /// # Usage
-/// Implementors of this trait provide a scaling transformation applied feature-wise
-/// to a 2D array of floating-point values (e.g., features in a dataset).
+/// Implementors of this trait provide a scaling transformation applied per feature
+/// along the leading axis of a samples-last array (e.g., features in a dataset).
 pub trait Scaler: Send + Sync {
     /// Returns the canonical name of the scaler method.
     fn name(&self) -> &'static str;
 
-    /// Applies the scaling transformation in-place to the input 2D array.
+    /// Applies the scaling transformation in-place to samples-last inputs of any rank.
     ///
+    /// Features run along the leading axis; each is scaled over the remaining axes.
     /// The input array is modified directly; no new allocation occurs.
     ///
     /// # Parameters
     ///
-    /// * `input` - A mutable 2D array view representing dataset features.
+    /// * `inputs` - A mutable samples-last array view, features on the leading axis.
     ///
     /// # Errors
-    /// [`ScalerFeatureMismatch`] when the input's feature columns do not match the
-    /// scaler's fitted feature count.
-    fn apply_inplace(&self, input: ArrayViewMut2<f32>) -> Result<(), ScalerFeatureMismatch>;
-
-    /// Applies the scaling transformation to a single 1D array (vector) in-place.
-    ///
-    /// # Arguments
-    /// * `input` - A mutable 1D array (vector) of `f32` values representing a single data point.
-    ///
-    /// # Behavior
-    /// This method expands the 1D input into a 2D view, applies the transformation in-place,
-    /// and modifies the original vector without allocation.
-    ///
-    /// # Errors
-    /// [`ScalerFeatureMismatch`] when the input's length does not match the scaler's
+    /// [`ScalerFeatureMismatch`] when the leading axis does not match the scaler's
     /// fitted feature count.
-    fn apply_single_inplace(&self, input: ArrayViewMut1<f32>) -> Result<(), ScalerFeatureMismatch> {
-        let mut expanded = input.insert_axis(Axis(0));
-        self.apply_inplace(expanded.view_mut())
-    }
+    fn apply_inplace(&self, inputs: ArrayViewMutD<f32>) -> Result<(), ScalerFeatureMismatch>;
 }
 
 /// Defines the available built-in scaling methods.
@@ -83,9 +67,10 @@ pub trait Scaler: Send + Sync {
 /// use nrn::data::scalers::{ScalerMethod, MinMaxScaler, Scaler};
 /// use ndarray::array;
 ///
+/// // Features on the leading axis: two features (rows), two samples (columns).
 /// let mut data = array![[0.0, 5.0], [10.0, 20.0]];
 /// let scaler = ScalerMethod::MinMax(MinMaxScaler::default().fit(data.view()));
-/// scaler.apply_inplace(data.view_mut()).unwrap();
+/// scaler.apply_inplace(data.view_mut().into_dyn()).unwrap();
 /// assert!(data.iter().all(|&v| v >= 0.0 && v <= 1.0 + 1e-5));
 /// ```
 #[derive(Clone, Debug)]
@@ -106,9 +91,9 @@ pub enum ScalerKind {
 }
 
 impl ScalerKind {
-    /// Fits the chosen scaler on `data` (samples along rows, features along
-    /// columns), returning the fitted method.
-    pub fn fit(self, data: ArrayView2<f32>) -> ScalerMethod {
+    /// Fits the chosen scaler on samples-last `data` (features along the leading
+    /// axis), returning the fitted method.
+    pub fn fit<D: RemoveAxis>(self, data: ArrayView<f32, D>) -> ScalerMethod {
         match self {
             ScalerKind::MinMax => ScalerMethod::MinMax(MinMaxScaler::default().fit(data)),
             ScalerKind::ZScore => ScalerMethod::ZScore(ZScoreScaler::default().fit(data)),
@@ -134,10 +119,10 @@ impl Scaler for ScalerMethod {
         }
     }
 
-    fn apply_inplace(&self, input: ArrayViewMut2<f32>) -> Result<(), ScalerFeatureMismatch> {
+    fn apply_inplace(&self, inputs: ArrayViewMutD<f32>) -> Result<(), ScalerFeatureMismatch> {
         match self {
-            ScalerMethod::MinMax(s) => s.apply_inplace(input),
-            ScalerMethod::ZScore(s) => s.apply_inplace(input),
+            ScalerMethod::MinMax(s) => s.apply_inplace(inputs),
+            ScalerMethod::ZScore(s) => s.apply_inplace(inputs),
         }
     }
 }
@@ -148,21 +133,6 @@ mod tests {
     use ndarray::array;
 
     #[test]
-    fn apply_single_inplace_scales_a_lone_vector() {
-        // `apply_single_inplace` treats each element as its own feature (column),
-        // so fit on three features each spanning [0, 10].
-        let data = array![[0.0, 0.0, 0.0], [10.0, 10.0, 10.0]];
-        let scaler = MinMaxScaler::default().fit(data.view());
-
-        let mut vector = array![0.0, 5.0, 10.0];
-        scaler.apply_single_inplace(vector.view_mut()).unwrap();
-
-        assert!((vector[0] - 0.0).abs() < 1e-5);
-        assert!((vector[1] - 0.5).abs() < 1e-5);
-        assert!((vector[2] - 1.0).abs() < 1e-5);
-    }
-
-    #[test]
     fn method_min_max_delegates_name_and_transform() {
         let data = array![[0.0, 5.0], [10.0, 20.0]];
         let method = ScalerMethod::MinMax(MinMaxScaler::default().fit(data.view()));
@@ -170,7 +140,9 @@ mod tests {
         assert_eq!(method.name(), "min-max");
 
         let mut to_scale = data.clone();
-        method.apply_inplace(to_scale.view_mut()).unwrap();
+        method
+            .apply_inplace(to_scale.view_mut().into_dyn())
+            .unwrap();
         assert!(to_scale.iter().all(|&v| (0.0..=1.0 + 1e-5).contains(&v)));
     }
 
@@ -193,13 +165,15 @@ mod tests {
 
         assert_eq!(method.name(), "z-score");
 
-        // Features run along columns (fit averages over Axis(0)); each should be
-        // centred near zero mean after standardization.
+        // Features run along rows (the leading axis); each should be centred near
+        // zero mean over its samples after standardization.
         let mut to_scale = data.clone();
-        method.apply_inplace(to_scale.view_mut()).unwrap();
-        for col in to_scale.columns() {
-            let mean: f32 = col.sum() / col.len() as f32;
-            assert!(mean.abs() < 1e-5, "column mean was {}", mean);
+        method
+            .apply_inplace(to_scale.view_mut().into_dyn())
+            .unwrap();
+        for row in to_scale.rows() {
+            let mean: f32 = row.sum() / row.len() as f32;
+            assert!(mean.abs() < 1e-5, "row mean was {}", mean);
         }
     }
 }

--- a/core/src/data/preprocessors/scalers/z_score.rs
+++ b/core/src/data/preprocessors/scalers/z_score.rs
@@ -43,7 +43,7 @@ impl ZScoreScaler {
     /// This method panics if unable to compute mean (e.g., empty input).
     ///
     pub fn fit(mut self, data: ArrayView2<f32>) -> Self {
-        self.mean = data.mean_axis(Axis(0)).expect("Unable to compute mean");
+        self.mean = data.mean_axis(Axis(0)).expect("unable to compute mean");
         self.std_dev = data.std_axis(Axis(0), 0.0);
         // To avoid division by zero, replace any zero std_dev by epsilon
         self.std_dev

--- a/core/src/data/preprocessors/scalers/z_score.rs
+++ b/core/src/data/preprocessors/scalers/z_score.rs
@@ -12,17 +12,18 @@
 //! use nrn::data::scalers::{ZScoreScaler, Scaler};
 //! use ndarray::{array, Axis};
 //!
+//! // Features on the leading axis: two features (rows), three samples (columns).
 //! let mut data = array![[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]];
 //! let scaler = ZScoreScaler::default().fit(data.view());
-//! scaler.apply_inplace(data.view_mut()).unwrap();
-//! // Each feature now has approximately zero mean
-//! let mean = data.mean_axis(Axis(0)).unwrap();
+//! scaler.apply_inplace(data.view_mut().into_dyn()).unwrap();
+//! // Each feature now has approximately zero mean over its samples
+//! let mean = data.mean_axis(Axis(1)).unwrap();
 //! assert!(mean.iter().all(|&m| m.abs() < 1e-5));
 //! ```
 //!
 
 use crate::data::scalers::{Scaler, ScalerFeatureMismatch};
-use ndarray::{Array1, ArrayView2, ArrayViewMut2, Axis};
+use ndarray::{Array1, ArrayView, ArrayViewMutD, Axis, RemoveAxis};
 /// ZScoreScaler that normalizes each feature to zero mean and unit variance.
 ///
 /// This scaler fits the mean and standard deviation per feature (column),
@@ -36,15 +37,24 @@ pub struct ZScoreScaler {
 }
 
 impl ZScoreScaler {
-    /// Fits the scaler by computing mean and standard deviation per feature,
-    /// consuming the current scaler instance and returning a new fitted instance.
+    /// Fits the scaler by computing mean and standard deviation per feature from
+    /// samples-last input of any rank, consuming the current scaler instance and
+    /// returning a new fitted instance.
+    ///
+    /// Features run along the leading axis; each is reduced over the remaining axes.
     ///
     /// # Panics
     /// This method panics if unable to compute mean (e.g., empty input).
     ///
-    pub fn fit(mut self, data: ArrayView2<f32>) -> Self {
-        self.mean = data.mean_axis(Axis(0)).expect("unable to compute mean");
-        self.std_dev = data.std_axis(Axis(0), 0.0);
+    pub fn fit<D: RemoveAxis>(mut self, data: ArrayView<f32, D>) -> Self {
+        self.mean = data
+            .axis_iter(Axis(0))
+            .map(|feature| feature.mean().expect("unable to compute mean"))
+            .collect();
+        self.std_dev = data
+            .axis_iter(Axis(0))
+            .map(|feature| feature.std(0.0))
+            .collect();
         // To avoid division by zero, replace any zero std_dev by epsilon
         self.std_dev
             .mapv_inplace(|x| if x == 0.0 { f32::EPSILON } else { x });
@@ -71,22 +81,22 @@ impl Scaler for ZScoreScaler {
     ///
     /// # Arguments
     ///
-    /// * `data` - Mutable 2D array view whose features will be normalized.
+    /// * `inputs` - Mutable samples-last array to normalize, features on the leading axis.
     ///
     /// # Errors
     ///
-    /// [`ScalerFeatureMismatch`] when the input's feature columns do not match the scaler.
-    fn apply_inplace(&self, mut data: ArrayViewMut2<f32>) -> Result<(), ScalerFeatureMismatch> {
-        let (expected, found) = (self.mean.len(), data.shape()[1]);
+    /// [`ScalerFeatureMismatch`] when the leading axis of `inputs` does not match the scaler.
+    fn apply_inplace(&self, mut inputs: ArrayViewMutD<f32>) -> Result<(), ScalerFeatureMismatch> {
+        let (expected, found) = (self.mean.len(), inputs.shape()[0]);
         (found == expected)
             .then_some(())
             .ok_or(ScalerFeatureMismatch { expected, found })?;
 
-        for (mut col, (&mean, &std)) in data
-            .axis_iter_mut(Axis(1))
+        for (mut feature, (&mean, &std)) in inputs
+            .axis_iter_mut(Axis(0))
             .zip(self.mean.iter().zip(self.std_dev.iter()))
         {
-            for v in col.iter_mut() {
+            for v in feature.iter_mut() {
                 *v = (*v - mean) / std;
             }
         }
@@ -101,7 +111,8 @@ mod tests {
 
     #[test]
     fn fit_computes_mean_per_feature() {
-        let data = array![[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]];
+        // Two features (rows): [1, 3, 5] and [2, 4, 6].
+        let data = array![[1.0, 3.0, 5.0], [2.0, 4.0, 6.0]];
         let scaler = ZScoreScaler::default().fit(data.view());
         assert!((scaler.mean[0] - 3.0).abs() < 1e-5); // mean de [1, 3, 5]
         assert!((scaler.mean[1] - 4.0).abs() < 1e-5); // mean de [2, 4, 6]
@@ -109,32 +120,29 @@ mod tests {
 
     #[test]
     fn apply_rejects_feature_count_mismatch() {
-        // Fitted on 2 features, applied to 3-column data → error, not a panic.
+        // Fitted on 2 features, applied to inputs with 3 on the leading axis → error.
         let scaler = ZScoreScaler::default().fit(array![[1.0, 2.0], [3.0, 4.0]].view());
-        let mut wrong = array![[0.0, 0.0, 0.0]];
-        let error = scaler.apply_inplace(wrong.view_mut()).unwrap_err();
+        let mut wrong = array![[0.0], [0.0], [0.0]];
+        let error = scaler
+            .apply_inplace(wrong.view_mut().into_dyn())
+            .unwrap_err();
         assert_eq!((error.expected, error.found), (2, 3));
     }
 
     #[test]
     fn scaled_data_has_zero_mean_and_unit_variance() {
-        let data = array![
-            [1.0, 10.0],
-            [2.0, 20.0],
-            [3.0, 30.0],
-            [4.0, 40.0],
-            [5.0, 50.0]
-        ];
+        // Two features (rows), five samples each (columns).
+        let data = array![[1.0, 2.0, 3.0, 4.0, 5.0], [10.0, 20.0, 30.0, 40.0, 50.0]];
         let scaler = ZScoreScaler::default().fit(data.view());
         let mut scaled = data.clone();
-        scaler.apply_inplace(scaled.view_mut()).unwrap();
+        scaler.apply_inplace(scaled.view_mut().into_dyn()).unwrap();
 
-        let mean = scaled.mean_axis(Axis(0)).unwrap();
+        let mean = scaled.mean_axis(Axis(1)).unwrap();
         for &m in mean.iter() {
             assert!(m.abs() < 1e-5, "Mean {} not close to 0", m);
         }
 
-        let std = scaled.std_axis(Axis(0), 0.0);
+        let std = scaled.std_axis(Axis(1), 0.0);
         for &s in std.iter() {
             assert!((s - 1.0).abs() < 1e-5, "Std {} not close to 1", s);
         }
@@ -142,21 +150,21 @@ mod tests {
 
     #[test]
     fn known_values_transform_correctly() {
-        // [0, 2] → mean=1, std_population=1 → [-1, 1]
-        let data = array![[0.0], [2.0]];
+        // One feature [0, 2] → mean=1, std_population=1 → [-1, 1]
+        let data = array![[0.0, 2.0]];
         let scaler = ZScoreScaler::default().fit(data.view());
         let mut scaled = data.clone();
-        scaler.apply_inplace(scaled.view_mut()).unwrap();
+        scaler.apply_inplace(scaled.view_mut().into_dyn()).unwrap();
         assert!((scaled[[0, 0]] - (-1.0)).abs() < 1e-5);
-        assert!((scaled[[1, 0]] - 1.0).abs() < 1e-5);
+        assert!((scaled[[0, 1]] - 1.0).abs() < 1e-5);
     }
 
     #[test]
     fn constant_feature_does_not_panic() {
-        // First feature is constant — std would be zero without epsilon guard
-        let data = array![[5.0, 1.0], [5.0, 2.0], [5.0, 3.0]];
+        // First feature (row) is constant — std would be zero without epsilon guard.
+        let data = array![[5.0, 5.0, 5.0], [1.0, 2.0, 3.0]];
         let scaler = ZScoreScaler::default().fit(data.view());
         let mut scaled = data.clone();
-        scaler.apply_inplace(scaled.view_mut()).unwrap();
+        scaler.apply_inplace(scaled.view_mut().into_dyn()).unwrap();
     }
 }

--- a/core/src/data/synth/mod.rs
+++ b/core/src/data/synth/mod.rs
@@ -259,11 +259,11 @@ fn init_features_and_labels(
     n_clusters: usize,
     samples_per_cluster: usize,
 ) -> (Array2<f32>, Array1<f32>) {
-    assert!(n_features > 0, "n_features must be greater than zero");
-    assert!(n_clusters > 0, "n_clusters must be greater than zero");
+    assert!(n_features > 0, "n_features must be greater than zero.");
+    assert!(n_clusters > 0, "n_clusters must be greater than zero.");
     assert!(
         samples_per_cluster > 0,
-        "samples_per_cluster must be greater than zero"
+        "samples_per_cluster must be greater than zero."
     );
 
     let total_samples = samples_per_cluster * n_clusters;
@@ -275,11 +275,11 @@ fn init_features_and_labels(
 
 /// Calculates the maximum radius from a list of radius ranges.
 fn max_radius(radii: &[(f32, f32)]) -> f32 {
-    assert!(!radii.is_empty(), "radii must not be empty");
+    assert!(!radii.is_empty(), "radii must not be empty.");
 
     assert!(
         radii.iter().all(|&(min, max)| min >= 0.0 && max > min),
-        "Each radius must be a valid range with min >= 0 and max > min"
+        "Each radius must be a valid range with min >= 0 and max > min."
     );
 
     radii.iter().map(|&(_, max)| max).fold(0.0, f32::max)
@@ -289,7 +289,7 @@ fn max_radius(radii: &[(f32, f32)]) -> f32 {
 fn feature_bounds(feature_min: f32, feature_max: f32, radii: &[(f32, f32)]) -> (f32, f32) {
     assert!(
         feature_min < feature_max,
-        "feature_min must be less than feature_max"
+        "feature_min must be less than feature_max."
     );
 
     let max_radius = max_radius(radii);
@@ -298,7 +298,7 @@ fn feature_bounds(feature_min: f32, feature_max: f32, radii: &[(f32, f32)]) -> (
 
     assert!(
         feature_max_bound > feature_min_bound,
-        "feature_max_bound must be greater than feature_min_bound"
+        "feature_max_bound must be greater than feature_min_bound."
     );
 
     (feature_min_bound, feature_max_bound)
@@ -306,7 +306,7 @@ fn feature_bounds(feature_min: f32, feature_max: f32, radii: &[(f32, f32)]) -> (
 
 /// Calculates an optimal radius for clusters based on the feature range and number of clusters.
 fn calculate_radius(feature_min: f32, feature_max: f32, n_clusters: usize) -> f32 {
-    assert!(n_clusters > 0, "n_clusters must be greater than zero");
+    assert!(n_clusters > 0, "n_clusters must be greater than zero.");
     (feature_max - feature_min) / (2.5 * n_clusters as f32)
 }
 

--- a/core/src/io/model.rs
+++ b/core/src/io/model.rs
@@ -1,7 +1,7 @@
-use crate::activations::ActivationProvider;
 use crate::io::tensors::{self, F32Tensor};
-use crate::layers::{Dense, Layer};
+use crate::layers::{Layer, LayerKind};
 use crate::model::NeuralNetwork;
+use ndarray::ArrayD;
 use safetensors::SafeTensors;
 use std::collections::HashMap;
 use std::io::ErrorKind::InvalidData;
@@ -18,9 +18,9 @@ impl NeuralNetwork {
         metadata.insert("n_layers".to_string(), self.layers().len().to_string());
 
         for (i, layer) in self.layers().iter().enumerate() {
-            metadata.insert(format!("layer{i}.kind"), layer.kind().to_string());
-            if let Some(activation) = layer.activation_name() {
-                metadata.insert(format!("layer{i}.activation"), activation.to_string());
+            metadata.insert(format!("layer{i}.kind"), layer.kind().as_str().to_string());
+            for (key, value) in layer.config() {
+                metadata.insert(format!("layer{i}.{key}"), value);
             }
             for (name, tensor) in layer.named_tensors() {
                 entries.push((format!("layer{i}.{name}"), tensors::tensor(&tensor)));
@@ -41,16 +41,14 @@ impl NeuralNetwork {
         let mut layers: Vec<Box<dyn Layer>> = Vec::with_capacity(n_layers);
 
         for i in 0..n_layers {
-            let kind = tensors::meta(metadata, &format!("layer{i}.kind"))?;
-            let layer = match kind {
-                "dense" => dense_from_tensors(i, st, metadata)?,
-                other => {
-                    return Err(Error::new(
-                        InvalidData,
-                        format!("Unknown layer kind: {other}"),
-                    ));
-                }
-            };
+            let prefix = format!("layer{i}.");
+            let kind = LayerKind::try_from(tensors::meta(metadata, &format!("{prefix}kind"))?)
+                .map_err(|e| Error::new(InvalidData, e.to_string()))?;
+            let config = layer_config(metadata, &prefix);
+            let tensors = read_layer_tensors(st, &prefix)?;
+            let layer = kind
+                .instantiate(&config, tensors)
+                .map_err(|e| Error::new(InvalidData, e.to_string()))?;
             layers.push(layer);
         }
 
@@ -79,24 +77,30 @@ impl NeuralNetwork {
     }
 }
 
-/// Reconstructs a [`Dense`] layer at index `i` from its weights, biases, and activation name.
-fn dense_from_tensors(
-    i: usize,
-    st: &SafeTensors,
-    metadata: &HashMap<String, String>,
-) -> Result<Box<dyn Layer>> {
-    let weights = tensors::read_array2(&format!("layer{i}.weights"), st)?;
-    let biases = tensors::read_array1(&format!("layer{i}.biases"), st)?;
+/// Collects one layer's configuration from the metadata map, stripping the `layer{i}.`
+/// prefix from each key.
+fn layer_config(metadata: &HashMap<String, String>, prefix: &str) -> HashMap<String, String> {
+    metadata
+        .iter()
+        .filter_map(|(key, value)| {
+            key.strip_prefix(prefix)
+                .map(|k| (k.to_string(), value.clone()))
+        })
+        .collect()
+}
 
-    let activation_name = tensors::meta(metadata, &format!("layer{i}.activation"))?;
-    let activation = ActivationProvider::get_by_name(activation_name).ok_or_else(|| {
-        Error::new(
-            InvalidData,
-            format!("Unknown activation function: {activation_name}"),
-        )
-    })?;
-
-    Ok(Box::new(Dense::new(weights, biases, activation)))
+/// Reads one layer's tensors from the buffer, stripping the `layer{i}.` prefix from each name.
+fn read_layer_tensors(st: &SafeTensors, prefix: &str) -> Result<HashMap<String, ArrayD<f32>>> {
+    let mut tensors = HashMap::new();
+    for name in st.names() {
+        if let Some(key) = name.strip_prefix(prefix) {
+            let view = st
+                .tensor(name)
+                .map_err(|e| Error::new(InvalidData, e.to_string()))?;
+            tensors.insert(key.to_string(), tensors::read_arrayd(&view)?);
+        }
+    }
+    Ok(tensors)
 }
 
 #[cfg(test)]
@@ -123,6 +127,46 @@ mod tests {
         let predictions_before = model.predict(inputs.view());
 
         let path = temp_path("model");
+        model.save(&path).unwrap();
+
+        let loaded = NeuralNetwork::load(&path).unwrap();
+        let predictions_after = loaded.predict(inputs.view());
+
+        cleanup(&path);
+
+        assert_eq!(predictions_before, predictions_after);
+    }
+
+    #[test]
+    fn cnn_save_load_roundtrip_predictions_are_identical() {
+        use crate::activations::{RELU, SIGMOID};
+        use crate::layers::{Conv2d, Dense, Flatten, Layer};
+        use ndarray::{Array, IxDyn};
+        use ndarray_rand::rand::SeedableRng;
+        use ndarray_rand::rand::rngs::StdRng;
+
+        // A full CNN: Conv2d → Flatten → Dense, exercising every layer kind through io.
+        let mut rng = StdRng::seed_from_u64(3);
+        let conv = Conv2d::initialization((1, 4, 4), 2, (3, 3), 1, 0, RELU.clone(), &mut rng);
+        let flatten = Flatten::new(conv.output_shape());
+        let dense = Dense::initialization(
+            flatten.output_size(),
+            &NeuronLayerSpec {
+                neurons: 1,
+                activation: SIGMOID.clone(),
+            },
+            &mut rng,
+        );
+        let model = NeuralNetwork::single(conv)
+            .with_layer(flatten)
+            .with_layer(dense);
+
+        let inputs = Array::from_shape_fn(IxDyn(&[1, 4, 4, 5]), |d| {
+            (d[1] * 4 + d[2]) as f32 * 0.1 + d[3] as f32
+        });
+        let predictions_before = model.predict(inputs.view());
+
+        let path = temp_path("cnn_model");
         model.save(&path).unwrap();
 
         let loaded = NeuralNetwork::load(&path).unwrap();
@@ -164,7 +208,7 @@ mod tests {
         cleanup(&path);
 
         let message = result.err().map(|e| e.to_string()).unwrap_or_default();
-        assert!(message.contains("Unknown activation"), "got: {message}");
+        assert!(message.contains("unknown activation"), "got: {message}");
     }
 
     #[test]

--- a/core/src/nn/affine.rs
+++ b/core/src/nn/affine.rs
@@ -1,0 +1,101 @@
+use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Axis};
+
+/// The affine map `weights · input + bias` and its backward pass — the linear building block a
+/// layer wraps with an activation. [`Dense`](crate::layers::Dense) and
+/// [`Conv2d`](crate::layers::Conv2d) both build on it.
+#[derive(Clone, Debug)]
+pub struct Affine {
+    /// A `(outputs, inputs)` array, one row per output.
+    weights: Array2<f32>,
+    /// A `(outputs)` array, one bias per output.
+    biases: Array1<f32>,
+}
+
+impl Affine {
+    /// Assembles an `Affine` from explicit weights and biases.
+    /// # Panics
+    /// - When `weights` is empty.
+    /// - When the number of weight rows does not match the number of biases.
+    /// # Arguments
+    /// - `weights`: A `(outputs, inputs)` array, one row per output.
+    /// - `biases`: A `(outputs)` array, one bias per output.
+    pub fn new(weights: Array2<f32>, biases: Array1<f32>) -> Self {
+        assert!(
+            weights.nrows() > 0 && weights.ncols() > 0,
+            "Affine weights must be non-empty."
+        );
+        assert_eq!(
+            weights.nrows(),
+            biases.len(),
+            "Affine needs one bias per output."
+        );
+
+        Affine { weights, biases }
+    }
+
+    /// The pre-activation `weights · input + bias` for one batch.
+    /// # Arguments
+    /// - `input`: An `(inputs, samples)` array; the bias broadcasts across the samples.
+    /// # Returns
+    /// - An `(outputs, samples)` array.
+    pub fn forward(&self, input: ArrayView2<f32>) -> Array2<f32> {
+        let biases = self.biases.view().insert_axis(Axis(1)).to_owned();
+        self.weights.dot(&input) + &biases
+    }
+
+    /// The backward pass of the affine map for one batch.
+    /// # Arguments
+    /// - `dz`: The gradient of the loss with respect to the pre-activation, `(outputs, samples)`.
+    /// - `input`: The batch fed to [`forward`](Affine::forward), `(inputs, samples)`.
+    /// - `m`: The sample count the parameter gradients average over. Passed explicitly because
+    ///   it is not always `input.ncols()`: a convolution's affine input is the `im2col` matrix,
+    ///   whose columns span spatial positions as well as samples, yet its gradients must still
+    ///   average over samples alone.
+    /// - `compute_input_gradient`: Whether to also compute the gradient with respect to `input`.
+    /// # Returns
+    /// - `(dw, db, dinput)`: the weight gradient `(outputs, inputs)`, the bias gradient
+    ///   `(outputs)`, and — when requested — the input gradient `(inputs, samples)`.
+    pub fn backward(
+        &self,
+        dz: ArrayView2<f32>,
+        input: ArrayView2<f32>,
+        m: f32,
+        compute_input_gradient: bool,
+    ) -> (Array2<f32>, Array1<f32>, Option<Array2<f32>>) {
+        let dw = dz.dot(&input.t()) / m;
+        let db = dz.sum_axis(Axis(1)) / m;
+        let dinput = compute_input_gradient.then(|| self.weights.t().dot(&dz));
+        (dw, db, dinput)
+    }
+
+    /// This map's weight matrix `(outputs, inputs)`.
+    pub fn weights(&self) -> ArrayView2<'_, f32> {
+        self.weights.view()
+    }
+
+    /// This map's biases, one per output.
+    pub fn biases(&self) -> ArrayView1<'_, f32> {
+        self.biases.view()
+    }
+
+    /// Mutable access to the weight matrix, for an optimizer to update in place.
+    pub fn weights_mut(&mut self) -> &mut Array2<f32> {
+        &mut self.weights
+    }
+
+    /// Mutable access to the biases, for an optimizer to update in place.
+    pub fn biases_mut(&mut self) -> &mut Array1<f32> {
+        &mut self.biases
+    }
+
+    /// Mutable access to both parameters at once — weights then biases — so a layer can hand
+    /// them to an optimizer together without borrowing `self` twice.
+    pub fn parameters_mut(&mut self) -> (&mut Array2<f32>, &mut Array1<f32>) {
+        (&mut self.weights, &mut self.biases)
+    }
+
+    /// Whether every weight and bias is finite (no NaN or Inf).
+    pub fn is_finite(&self) -> bool {
+        self.weights.iter().all(|v| v.is_finite()) && self.biases.iter().all(|v| v.is_finite())
+    }
+}

--- a/core/src/nn/affine.rs
+++ b/core/src/nn/affine.rs
@@ -78,13 +78,15 @@ impl Affine {
         self.biases.view()
     }
 
-    /// Mutable access to the weight matrix, for an optimizer to update in place.
-    pub fn weights_mut(&mut self) -> &mut Array2<f32> {
+    /// Mutable access to the weight matrix.
+    #[cfg(test)]
+    pub(crate) fn weights_mut(&mut self) -> &mut Array2<f32> {
         &mut self.weights
     }
 
-    /// Mutable access to the biases, for an optimizer to update in place.
-    pub fn biases_mut(&mut self) -> &mut Array1<f32> {
+    /// Mutable access to the biases.
+    #[cfg(test)]
+    pub(crate) fn biases_mut(&mut self) -> &mut Array1<f32> {
         &mut self.biases
     }
 

--- a/core/src/nn/affine.rs
+++ b/core/src/nn/affine.rs
@@ -47,10 +47,9 @@ impl Affine {
     /// # Arguments
     /// - `dz`: The gradient of the loss with respect to the pre-activation, `(outputs, samples)`.
     /// - `input`: The batch fed to [`forward`](Affine::forward), `(inputs, samples)`.
-    /// - `m`: The sample count the parameter gradients average over. Passed explicitly because
-    ///   it is not always `input.ncols()`: a convolution's affine input is the `im2col` matrix,
-    ///   whose columns span spatial positions as well as samples, yet its gradients must still
-    ///   average over samples alone.
+    /// - `m`: The number of samples the parameter gradients average over. For a convolution
+    ///   this differs from `input.ncols()`, whose columns span spatial positions as well as
+    ///   samples.
     /// - `compute_input_gradient`: Whether to also compute the gradient with respect to `input`.
     /// # Returns
     /// - `(dw, db, dinput)`: the weight gradient `(outputs, inputs)`, the bias gradient

--- a/core/src/nn/classification.rs
+++ b/core/src/nn/classification.rs
@@ -63,7 +63,7 @@ mod tests {
     use super::Classification;
     use crate::activations::RELU;
     use crate::model::{
-        FeatureCountMismatch, LayerPlan, NeuralNetwork, NeuronLayerSpec, PredictionError, Predictor,
+        InputShapeMismatch, LayerPlan, NeuralNetwork, NeuronLayerSpec, PredictionError, Predictor,
     };
     use ndarray::array;
 
@@ -95,9 +95,9 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             error,
-            PredictionError::Network(FeatureCountMismatch {
-                expected: 2,
-                found: 3
+            PredictionError::Network(InputShapeMismatch {
+                expected: vec![2],
+                found: vec![3]
             })
         );
     }

--- a/core/src/nn/classification.rs
+++ b/core/src/nn/classification.rs
@@ -2,7 +2,7 @@
 //! probabilities, ranked most likely first.
 
 use crate::model::{PredictionError, Predictor};
-use ndarray::ArrayView1;
+use ndarray::{ArrayView, ArrayView1, Dimension};
 use std::cmp::Ordering::Equal;
 
 /// Class probabilities for one instance, ordered by descending probability.
@@ -42,15 +42,15 @@ impl Classification {
 }
 
 impl Predictor {
-    /// Classifies a single raw input vector, returning the class probabilities
+    /// Classifies a single raw instance of any rank, returning the class probabilities
     /// ranked most likely first. The scaler is applied first when present.
     ///
     /// # Errors
-    /// [`PredictionError`](crate::model::PredictionError) when the input's length does not
-    /// match the scaler's fitted feature count or the network's input size.
-    pub fn classify_single(
+    /// [`PredictionError`](crate::model::PredictionError) when the instance does not match
+    /// the scaler's fitted feature count or the network's input shape.
+    pub fn classify_single<D: Dimension>(
         &self,
-        input: ArrayView1<f32>,
+        input: ArrayView<f32, D>,
     ) -> Result<Classification, PredictionError> {
         Ok(Classification::from_outputs(
             self.predict_single(input)?.view(),

--- a/core/src/nn/layers/conv2d.rs
+++ b/core/src/nn/layers/conv2d.rs
@@ -1,10 +1,11 @@
 use crate::activations::Activation;
 use crate::affine::Affine;
 use crate::gradients::LayerGradients;
-use crate::layers::{BackwardPass, Layer, Parameter};
-use ndarray::{Array1, Array2, Array4, ArrayD, ArrayView2, ArrayView4, ArrayViewD, Ix4};
+use crate::layers::{BackwardPass, Layer, LayerConfigError, LayerKind, Parameter};
+use ndarray::{Array1, Array2, Array4, ArrayD, ArrayView2, ArrayView4, ArrayViewD, Ix1, Ix4};
 use ndarray_rand::rand::RngCore;
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// A 2D convolution layer. It slides a set of small kernels across the height and width of
@@ -155,6 +156,39 @@ impl Conv2d {
     pub fn activation(&self) -> &Arc<dyn Activation> {
         &self.activation
     }
+
+    /// Builds a `Conv2d` layer from its configuration and tensors.
+    /// # Arguments
+    /// - `config`: Carries the `"activation"` name, the `"input_shape"` `(channels, height,
+    ///   width)`, the `"stride"`, and the `"padding"`.
+    /// - `tensors`: Carries the `"kernels"` (rank-4) and `"biases"` (rank-1) tensors.
+    pub(super) fn from_config(
+        config: &HashMap<String, String>,
+        mut tensors: HashMap<String, ArrayD<f32>>,
+    ) -> Result<Self, LayerConfigError> {
+        let kernels = super::take_tensor::<Ix4>(&mut tensors, "kernels")?;
+        let biases = super::take_tensor::<Ix1>(&mut tensors, "biases")?;
+
+        let dims = super::config_dims(config, "input_shape")?;
+        let [channels, height, width] = dims[..] else {
+            return Err(LayerConfigError::InvalidConfig {
+                key: "input_shape".to_string(),
+                reason: format!("expected 3 dimensions, got {}", dims.len()),
+            });
+        };
+        let stride = super::config_usize(config, "stride")?;
+        let padding = super::config_usize(config, "padding")?;
+        let activation = super::config_activation(config)?;
+
+        Ok(Conv2d::new(
+            kernels,
+            biases,
+            (channels, height, width),
+            stride,
+            padding,
+            activation,
+        ))
+    }
 }
 
 impl Layer for Conv2d {
@@ -280,8 +314,21 @@ impl Layer for Conv2d {
         self.affine.is_finite()
     }
 
-    fn kind(&self) -> &'static str {
-        "conv2d"
+    fn kind(&self) -> LayerKind {
+        LayerKind::Conv2d
+    }
+
+    fn config(&self) -> Vec<(String, String)> {
+        let (channels, height, width) = self.input_shape;
+        vec![
+            ("activation".to_string(), self.activation.name().to_string()),
+            (
+                "input_shape".to_string(),
+                format!("{channels},{height},{width}"),
+            ),
+            ("stride".to_string(), self.stride.to_string()),
+            ("padding".to_string(), self.padding.to_string()),
+        ]
     }
 
     fn named_tensors(&self) -> Vec<(String, ArrayD<f32>)> {
@@ -431,7 +478,7 @@ mod tests {
         assert_eq!(layer.output_shape(), vec![3, 3, 3]);
         assert_eq!(layer.input_size(), 2 * 5 * 5);
         assert_eq!(layer.output_size(), 3 * 3 * 3);
-        assert_eq!(layer.kind(), "conv2d");
+        assert_eq!(layer.kind(), LayerKind::Conv2d);
         assert_eq!(layer.activation_name(), Some("relu"));
         assert!(layer.weight_matrix().is_none());
         assert!(layer.is_finite());
@@ -625,6 +672,42 @@ mod tests {
             1,
             0,
             RELU.clone(),
+        );
+    }
+
+    #[test]
+    fn config_and_tensors_round_trip_through_from_config() {
+        // 3 filters over a 2-channel 5×5 input, 3×3 kernel, stride 2, padding 1.
+        let mut rng = StdRng::seed_from_u64(7);
+        let layer = Conv2d::initialization((2, 5, 5), 3, (3, 3), 2, 1, RELU.clone(), &mut rng);
+
+        let config: HashMap<String, String> = layer.config().into_iter().collect();
+        let tensors: HashMap<String, ArrayD<f32>> = layer.named_tensors().into_iter().collect();
+        let rebuilt = Conv2d::from_config(&config, tensors).unwrap();
+
+        // Same geometry and parameters: forward on an arbitrary batch matches bit-for-bit.
+        let input = Array::from_shape_fn(IxDyn(&[2, 5, 5, 4]), |d| {
+            (d[0] + d[1] + d[2] + d[3]) as f32 * 0.1
+        });
+        assert_eq!(layer.forward(input.view()), rebuilt.forward(input.view()));
+        assert_eq!(layer.config(), rebuilt.config());
+    }
+
+    #[test]
+    fn from_config_rejects_missing_input_shape() {
+        let mut rng = StdRng::seed_from_u64(1);
+        let layer = Conv2d::initialization((1, 4, 4), 2, (3, 3), 1, 0, RELU.clone(), &mut rng);
+        let tensors: HashMap<String, ArrayD<f32>> = layer.named_tensors().into_iter().collect();
+        // Drop "input_shape" from an otherwise valid config.
+        let config: HashMap<String, String> = layer
+            .config()
+            .into_iter()
+            .filter(|(key, _)| key != "input_shape")
+            .collect();
+
+        assert_eq!(
+            Conv2d::from_config(&config, tensors).unwrap_err(),
+            LayerConfigError::MissingConfig("input_shape".to_string())
         );
     }
 }

--- a/core/src/nn/layers/conv2d.rs
+++ b/core/src/nn/layers/conv2d.rs
@@ -710,4 +710,22 @@ mod tests {
             LayerConfigError::MissingConfig("input_shape".to_string())
         );
     }
+
+    #[test]
+    fn from_config_rejects_input_shape_without_three_dimensions() {
+        let mut rng = StdRng::seed_from_u64(2);
+        let layer = Conv2d::initialization((1, 4, 4), 2, (3, 3), 1, 0, RELU.clone(), &mut rng);
+        let tensors: HashMap<String, ArrayD<f32>> = layer.named_tensors().into_iter().collect();
+        // A 2-dimension input_shape where a convolution needs (channels, height, width).
+        let mut config: HashMap<String, String> = layer.config().into_iter().collect();
+        config.insert("input_shape".to_string(), "4,4".to_string());
+
+        assert_eq!(
+            Conv2d::from_config(&config, tensors).unwrap_err(),
+            LayerConfigError::InvalidConfig {
+                key: "input_shape".to_string(),
+                reason: "expected 3 dimensions, got 2".to_string(),
+            }
+        );
+    }
 }

--- a/core/src/nn/layers/conv2d.rs
+++ b/core/src/nn/layers/conv2d.rs
@@ -155,17 +155,6 @@ impl Conv2d {
     pub fn activation(&self) -> &Arc<dyn Activation> {
         &self.activation
     }
-
-    /// The output's per-sample spatial shape `(out_channels, out_height, out_width)`.
-    fn output_shape(&self) -> (usize, usize, usize) {
-        let (out_channels, _, kh, kw) = self.kernels_shape;
-        let (_, height, width) = self.input_shape;
-        (
-            out_channels,
-            conv_output_dim(height, kh, self.stride, self.padding),
-            conv_output_dim(width, kw, self.stride, self.padding),
-        )
-    }
 }
 
 impl Layer for Conv2d {
@@ -187,7 +176,8 @@ impl Layer for Conv2d {
         let cols = im2col(input, kh, kw, self.stride, self.padding);
         let pre_activation = self.affine.forward(cols.view());
 
-        let (_, out_h, out_w) = self.output_shape();
+        let out_h = conv_output_dim(height, kh, self.stride, self.padding);
+        let out_w = conv_output_dim(width, kw, self.stride, self.padding);
         self.activation
             .apply(pre_activation.view())
             .to_shape((out_channels, out_h, out_w, samples))
@@ -215,7 +205,8 @@ impl Layer for Conv2d {
 
         let (in_channels, height, width, samples) = input.dim();
         let (out_channels, _, kh, kw) = self.kernels_shape;
-        let (_, out_h, out_w) = self.output_shape();
+        let out_h = conv_output_dim(height, kh, self.stride, self.padding);
+        let out_w = conv_output_dim(width, kw, self.stride, self.padding);
         let positions = out_h * out_w * samples;
 
         // Collapse the spatial output to the 2D (out_channels, positions) the activation VJP
@@ -270,14 +261,19 @@ impl Layer for Conv2d {
         ]
     }
 
-    fn input_size(&self) -> usize {
+    fn input_shape(&self) -> Vec<usize> {
         let (channels, height, width) = self.input_shape;
-        channels * height * width
+        vec![channels, height, width]
     }
 
-    fn output_size(&self) -> usize {
-        let (channels, height, width) = self.output_shape();
-        channels * height * width
+    fn output_shape(&self) -> Vec<usize> {
+        let (out_channels, _, kh, kw) = self.kernels_shape;
+        let (_, height, width) = self.input_shape;
+        vec![
+            out_channels,
+            conv_output_dim(height, kh, self.stride, self.padding),
+            conv_output_dim(width, kw, self.stride, self.padding),
+        ]
     }
 
     fn is_finite(&self) -> bool {
@@ -431,9 +427,10 @@ mod tests {
             1,
             RELU.clone(),
         );
+        assert_eq!(layer.input_shape(), vec![2, 5, 5]);
+        assert_eq!(layer.output_shape(), vec![3, 3, 3]);
         assert_eq!(layer.input_size(), 2 * 5 * 5);
         assert_eq!(layer.output_size(), 3 * 3 * 3);
-        assert_eq!(layer.output_shape(), (3, 3, 3));
         assert_eq!(layer.kind(), "conv2d");
         assert_eq!(layer.activation_name(), Some("relu"));
         assert!(layer.weight_matrix().is_none());

--- a/core/src/nn/layers/conv2d.rs
+++ b/core/src/nn/layers/conv2d.rs
@@ -1,0 +1,635 @@
+use crate::activations::Activation;
+use crate::gradients::LayerGradients;
+use crate::layers::{BackwardPass, Layer, Parameter};
+use ndarray::{Array1, Array2, Array4, ArrayD, ArrayView2, ArrayView4, ArrayViewD, Axis, Ix4};
+use ndarray_rand::rand::RngCore;
+use std::any::Any;
+use std::sync::Arc;
+
+/// A 2D convolution layer. It slides a bank of small kernels across the height and width of
+/// each sample; at every position it takes the weighted sum of the patch the kernel covers,
+/// so each kernel sweeps out one feature map. An activation is then applied to the result.
+///
+/// Arrays are `(channels, height, width, samples)` — the sample axis stays last, the layout
+/// [`Flatten`](crate::layers::Flatten) collapses.
+///
+/// The whole batch is convolved with a single matrix multiplication: `im2col` lays every
+/// kernel-sized patch out as a column, the kernels form a `(out_channels, in_channels·kh·kw)`
+/// matrix, and one matmul produces all feature maps at once — the same affine math as
+/// [`Dense`](crate::layers::Dense), with `col2im` folding the gradient back on the way down.
+#[derive(Clone, Debug)]
+pub struct Conv2d {
+    /// Kernels `(out_channels, in_channels, kernel_height, kernel_width)`, one filter per row.
+    kernels: Array4<f32>,
+    /// One bias per output channel.
+    biases: Array1<f32>,
+    /// The per-sample input shape `(in_channels, height, width)`, sample axis excluded.
+    input_shape: (usize, usize, usize),
+    /// The stride applied on both spatial axes.
+    stride: usize,
+    /// The zero-padding added on both spatial axes before convolving.
+    padding: usize,
+    /// The activation applied to this layer's output.
+    activation: Arc<dyn Activation>,
+}
+
+impl Conv2d {
+    /// Assembles a `Conv2d` from explicit kernels, biases, input shape, and activation.
+    /// # Panics
+    /// - When any kernel dimension is zero.
+    /// - When the number of biases does not match the number of output channels.
+    /// - When the kernel's input channels do not match `input_shape`'s channels.
+    /// - When `stride` is zero or the kernel does not fit the padded input.
+    /// # Arguments
+    /// - `kernels`: A `(out_channels, in_channels, kernel_height, kernel_width)` array.
+    /// - `biases`: A `(out_channels)` array, one bias per output channel.
+    /// - `input_shape`: The per-sample input shape `(in_channels, height, width)`.
+    /// - `stride`: The stride applied on both spatial axes.
+    /// - `padding`: The zero-padding added on both spatial axes.
+    /// - `activation`: The activation applied to this layer's output.
+    pub fn new(
+        kernels: Array4<f32>,
+        biases: Array1<f32>,
+        input_shape: (usize, usize, usize),
+        stride: usize,
+        padding: usize,
+        activation: Arc<dyn Activation>,
+    ) -> Self {
+        let (out_channels, in_channels, kh, kw) = kernels.dim();
+        assert!(
+            out_channels > 0 && in_channels > 0 && kh > 0 && kw > 0,
+            "Conv2d kernels must be non-empty."
+        );
+        assert_eq!(
+            out_channels,
+            biases.len(),
+            "Conv2d needs one bias per output channel."
+        );
+        assert_eq!(
+            in_channels, input_shape.0,
+            "Conv2d kernel input channels must match the input channels."
+        );
+        assert!(stride > 0, "Conv2d stride must be greater than zero.");
+        let (_, height, width) = input_shape;
+        assert!(
+            height + 2 * padding >= kh && width + 2 * padding >= kw,
+            "Conv2d kernel does not fit the padded input."
+        );
+
+        Conv2d {
+            kernels,
+            biases,
+            input_shape,
+            stride,
+            padding,
+            activation,
+        }
+    }
+
+    /// Initializes a `Conv2d` with kernels drawn from `rng` per the activation's scheme.
+    /// # Panics
+    /// - When any dimension is zero (see [`Conv2d::new`]).
+    /// # Arguments
+    /// - `input_shape`: The per-sample input shape `(in_channels, height, width)`.
+    /// - `out_channels`: The number of filters, i.e. output channels.
+    /// - `kernel`: The kernel's spatial size `(kernel_height, kernel_width)`.
+    /// - `stride`: The stride applied on both spatial axes.
+    /// - `padding`: The zero-padding added on both spatial axes.
+    /// - `activation`: The activation applied to this layer's output; it also picks the
+    ///   weight-initialization scheme.
+    /// - `rng`: The generator the kernels are drawn from. A seeded generator makes the
+    ///   initialization reproducible.
+    pub fn initialization(
+        input_shape: (usize, usize, usize),
+        out_channels: usize,
+        kernel: (usize, usize),
+        stride: usize,
+        padding: usize,
+        activation: Arc<dyn Activation>,
+        rng: &mut dyn RngCore,
+    ) -> Self {
+        let (in_channels, _, _) = input_shape;
+        let (kh, kw) = kernel;
+        assert!(
+            out_channels > 0 && in_channels > 0 && kh > 0 && kw > 0,
+            "Channels and kernel size must be greater than zero."
+        );
+
+        // A convolution's fan-in is one receptive field: in_channels · kh · kw. Initializing
+        // the flat (out_channels, fan_in) matrix reuses the dense initializers unchanged; the
+        // kernel bank is that same matrix folded to rank 4.
+        let fan_in = in_channels * kh * kw;
+        let (weights, biases) = activation
+            .initialization()
+            .apply((out_channels, fan_in), rng);
+        let kernels = weights
+            .into_shape_with_order((out_channels, in_channels, kh, kw))
+            .expect("(out, in·kh·kw) reshapes to (out, in, kh, kw): element counts match");
+
+        Self::new(kernels, biases, input_shape, stride, padding, activation)
+    }
+
+    /// This layer's kernels `(out_channels, in_channels, kernel_height, kernel_width)`.
+    pub fn kernels(&self) -> ArrayView4<'_, f32> {
+        self.kernels.view()
+    }
+
+    /// This layer's biases, one per output channel.
+    pub fn biases(&self) -> ndarray::ArrayView1<'_, f32> {
+        self.biases.view()
+    }
+
+    /// The activation applied to this layer's output.
+    pub fn activation(&self) -> &Arc<dyn Activation> {
+        &self.activation
+    }
+
+    /// The output's per-sample spatial shape `(out_channels, out_height, out_width)`.
+    fn output_shape(&self) -> (usize, usize, usize) {
+        let (out_channels, _, kh, kw) = self.kernels.dim();
+        let (_, height, width) = self.input_shape;
+        (
+            out_channels,
+            conv_output_dim(height, kh, self.stride, self.padding),
+            conv_output_dim(width, kw, self.stride, self.padding),
+        )
+    }
+}
+
+impl Layer for Conv2d {
+    fn forward(&self, input: ArrayViewD<f32>) -> ArrayD<f32> {
+        let input = input
+            .into_dimensionality::<Ix4>()
+            .expect("Conv2d expects a 4D (channels, height, width, samples) input");
+        let (in_channels, height, width, samples) = input.dim();
+        assert_eq!(
+            (in_channels, height, width),
+            self.input_shape,
+            "Conv2d input shape does not match its configured input shape."
+        );
+
+        let (out_channels, _, kh, kw) = self.kernels.dim();
+        let fan_in = in_channels * kh * kw;
+
+        // im2col → matmul → fold: the affine core is Dense's `weights · input + bias`.
+        let cols = im2col(input, kh, kw, self.stride, self.padding);
+        let weights = self
+            .kernels
+            .to_shape((out_channels, fan_in))
+            .expect("kernels are contiguous and reshape to (out_channels, in·kh·kw)");
+        let biases = self.biases.view().insert_axis(Axis(1)).to_owned();
+        let pre_activation = weights.dot(&cols) + &biases;
+
+        let (_, out_h, out_w) = self.output_shape();
+        self.activation
+            .apply(pre_activation.view())
+            .to_shape((out_channels, out_h, out_w, samples))
+            .expect("the matmul result folds back to (out_channels, out_h, out_w, samples)")
+            .into_owned()
+            .into_dyn()
+    }
+
+    fn backward(
+        &self,
+        da: ArrayViewD<f32>,
+        input: ArrayViewD<f32>,
+        output: ArrayViewD<f32>,
+        compute_input_gradient: bool,
+    ) -> BackwardPass {
+        let da = da
+            .into_dimensionality::<Ix4>()
+            .expect("Conv2d expects a 4D da");
+        let input = input
+            .into_dimensionality::<Ix4>()
+            .expect("Conv2d expects a 4D input");
+        let output = output
+            .into_dimensionality::<Ix4>()
+            .expect("Conv2d expects a 4D output");
+
+        let (in_channels, height, width, samples) = input.dim();
+        let (out_channels, _, kh, kw) = self.kernels.dim();
+        let fan_in = in_channels * kh * kw;
+        let (_, out_h, out_w) = self.output_shape();
+        let positions = out_h * out_w * samples;
+
+        // Collapse the spatial output to the 2D (out_channels, positions) the activation VJP
+        // and the matmul math operate on, mirroring Dense.
+        let da = da
+            .to_shape((out_channels, positions))
+            .expect("da folds to (out_channels, positions)");
+        let output = output
+            .to_shape((out_channels, positions))
+            .expect("output folds to (out_channels, positions)");
+
+        // dz = dL/d(pre-activation); parameter gradients average over the batch (samples),
+        // summing over the shared spatial positions, so they divide by the sample count only.
+        let dz = self.activation.vjp(da.view(), output.view());
+        let m = samples as f32;
+
+        let cols = im2col(input, kh, kw, self.stride, self.padding);
+        let dw = dz.dot(&cols.t()) / m;
+        let dk = dw
+            .into_shape_with_order((out_channels, in_channels, kh, kw))
+            .expect("(out, in·kh·kw) reshapes to the kernel shape");
+        let db = dz.sum_axis(Axis(1)) / m;
+
+        let input_gradient = compute_input_gradient.then(|| {
+            let weights = self
+                .kernels
+                .to_shape((out_channels, fan_in))
+                .expect("kernels reshape to (out_channels, in·kh·kw)");
+            let dcols = weights.t().dot(&dz);
+            col2im(
+                dcols.view(),
+                (in_channels, height, width, samples),
+                kh,
+                kw,
+                self.stride,
+                self.padding,
+            )
+            .into_dyn()
+        });
+
+        BackwardPass {
+            gradients: LayerGradients(vec![dk.into_dyn(), db.into_dyn()]),
+            input_gradient,
+        }
+    }
+
+    fn parameters_mut(&mut self) -> Vec<Parameter<'_>> {
+        vec![
+            Parameter {
+                value: self.kernels.view_mut().into_dyn(),
+                decays: true,
+            },
+            Parameter {
+                value: self.biases.view_mut().into_dyn(),
+                decays: false,
+            },
+        ]
+    }
+
+    fn input_size(&self) -> usize {
+        let (channels, height, width) = self.input_shape;
+        channels * height * width
+    }
+
+    fn output_size(&self) -> usize {
+        let (channels, height, width) = self.output_shape();
+        channels * height * width
+    }
+
+    fn is_finite(&self) -> bool {
+        self.kernels.iter().all(|v| v.is_finite()) && self.biases.iter().all(|v| v.is_finite())
+    }
+
+    fn kind(&self) -> &'static str {
+        "conv2d"
+    }
+
+    fn named_tensors(&self) -> Vec<(String, ArrayD<f32>)> {
+        vec![
+            ("kernels".to_string(), self.kernels.clone().into_dyn()),
+            ("biases".to_string(), self.biases.clone().into_dyn()),
+        ]
+    }
+
+    fn activation_name(&self) -> Option<&str> {
+        Some(self.activation.name())
+    }
+
+    fn weight_matrix(&self) -> Option<ArrayView2<'_, f32>> {
+        // The kernels are a rank-4 bank, not a single affine weight matrix.
+        None
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// The output extent along one spatial axis for the given kernel, stride, and padding.
+fn conv_output_dim(input: usize, kernel: usize, stride: usize, padding: usize) -> usize {
+    (input + 2 * padding - kernel) / stride + 1
+}
+
+/// Unfolds a `(in_channels, height, width, samples)` batch into the column matrix
+/// `(in_channels·kh·kw, out_height·out_width·samples)` that turns a convolution into a matmul.
+///
+/// Each column is one receptive-field patch; row `(c·kh + u)·kw + v` is the tap at kernel
+/// offset `(u, v)` of channel `c`, and taps falling in the zero-padding stay zero. Columns are
+/// ordered `(out_height, out_width, samples)` in C-order, so reshaping a `(out_channels, cols)`
+/// product back to `(out_channels, out_height, out_width, samples)` is a plain reshape.
+fn im2col(
+    input: ArrayView4<f32>,
+    kh: usize,
+    kw: usize,
+    stride: usize,
+    padding: usize,
+) -> Array2<f32> {
+    let (in_channels, height, width, samples) = input.dim();
+    let out_h = conv_output_dim(height, kh, stride, padding);
+    let out_w = conv_output_dim(width, kw, stride, padding);
+    let mut cols = Array2::zeros((in_channels * kh * kw, out_h * out_w * samples));
+
+    for c in 0..in_channels {
+        for u in 0..kh {
+            for v in 0..kw {
+                let row = (c * kh + u) * kw + v;
+                for oh in 0..out_h {
+                    let ih = (oh * stride + u) as isize - padding as isize;
+                    if ih < 0 || ih >= height as isize {
+                        continue;
+                    }
+                    for ow in 0..out_w {
+                        let iw = (ow * stride + v) as isize - padding as isize;
+                        if iw < 0 || iw >= width as isize {
+                            continue;
+                        }
+                        for s in 0..samples {
+                            let col = (oh * out_w + ow) * samples + s;
+                            cols[[row, col]] = input[[c, ih as usize, iw as usize, s]];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    cols
+}
+
+/// Folds a column matrix `(in_channels·kh·kw, out_height·out_width·samples)` back into an input
+/// `(in_channels, height, width, samples)`, summing the contributions of taps that share an
+/// input position. The gradient counterpart of [`im2col`]: overlapping receptive fields
+/// accumulate, which is exactly the gradient of the shared reads in the forward pass.
+fn col2im(
+    cols: ArrayView2<f32>,
+    input_shape: (usize, usize, usize, usize),
+    kh: usize,
+    kw: usize,
+    stride: usize,
+    padding: usize,
+) -> Array4<f32> {
+    let (in_channels, height, width, samples) = input_shape;
+    let out_h = conv_output_dim(height, kh, stride, padding);
+    let out_w = conv_output_dim(width, kw, stride, padding);
+    let mut input = Array4::zeros((in_channels, height, width, samples));
+
+    for c in 0..in_channels {
+        for u in 0..kh {
+            for v in 0..kw {
+                let row = (c * kh + u) * kw + v;
+                for oh in 0..out_h {
+                    let ih = (oh * stride + u) as isize - padding as isize;
+                    if ih < 0 || ih >= height as isize {
+                        continue;
+                    }
+                    for ow in 0..out_w {
+                        let iw = (ow * stride + v) as isize - padding as isize;
+                        if iw < 0 || iw >= width as isize {
+                            continue;
+                        }
+                        for s in 0..samples {
+                            let col = (oh * out_w + ow) * samples + s;
+                            input[[c, ih as usize, iw as usize, s]] += cols[[row, col]];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    input
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::activations::{RELU, SIGMOID};
+    use ndarray::{Array, Array1, IxDyn, array};
+    use ndarray_rand::rand::SeedableRng;
+    use ndarray_rand::rand::rngs::StdRng;
+
+    #[test]
+    fn accessors_report_shapes_activation_and_parameters() {
+        // 3 filters over a 2-channel 5×5 input, 3×3 kernel, stride 2, padding 1.
+        // out_h = out_w = (5 + 2 - 3) / 2 + 1 = 3.
+        let mut layer = Conv2d::new(
+            Array4::zeros((3, 2, 3, 3)),
+            Array1::zeros(3),
+            (2, 5, 5),
+            2,
+            1,
+            RELU.clone(),
+        );
+        assert_eq!(layer.input_size(), 2 * 5 * 5);
+        assert_eq!(layer.output_size(), 3 * 3 * 3);
+        assert_eq!(layer.output_shape(), (3, 3, 3));
+        assert_eq!(layer.kind(), "conv2d");
+        assert_eq!(layer.activation_name(), Some("relu"));
+        assert!(layer.weight_matrix().is_none());
+        assert!(layer.is_finite());
+
+        let tensors = layer.named_tensors();
+        assert_eq!(tensors[0].0, "kernels");
+        assert_eq!(tensors[0].1.shape(), &[3, 2, 3, 3]);
+        assert_eq!(tensors[1].0, "biases");
+        assert_eq!(tensors[1].1.shape(), &[3]);
+
+        let params = layer.parameters_mut();
+        assert_eq!(params.len(), 2);
+        // Kernels decay, biases do not; order matches the gradient order [dk, db].
+        assert!(params[0].decays);
+        assert_eq!(params[0].value.shape(), &[3, 2, 3, 3]);
+        assert!(!params[1].decays);
+        assert_eq!(params[1].value.shape(), &[3]);
+    }
+
+    #[test]
+    fn forward_matches_hand_computed_convolution() {
+        // 1 channel, 3×3 input, a single all-ones 2×2 kernel, stride 1, no padding, zero
+        // bias. ReLU is the identity on the (positive) window sums, so each output is the
+        // sum of its 2×2 receptive field.
+        let input = Array::from_shape_vec(
+            IxDyn(&[1, 3, 3, 1]),
+            vec![1., 2., 3., 4., 5., 6., 7., 8., 9.],
+        )
+        .unwrap();
+        let layer = Conv2d::new(
+            Array4::ones((1, 1, 2, 2)),
+            array![0.0],
+            (1, 3, 3),
+            1,
+            0,
+            RELU.clone(),
+        );
+
+        let output = layer.forward(input.view());
+
+        assert_eq!(output.shape(), &[1, 2, 2, 1]);
+        // windows: [1,2,4,5]=12, [2,3,5,6]=16, [4,5,7,8]=24, [5,6,8,9]=28.
+        let expected =
+            Array::from_shape_vec(IxDyn(&[1, 2, 2, 1]), vec![12., 16., 24., 28.]).unwrap();
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn backward_gradients_match_numerical_approximation() {
+        // Isolated conv layer exercised with stride 2 and padding 1 over a 2-channel 4×4
+        // input — the configuration that stresses the im2col/col2im index arithmetic
+        // (out_h = out_w = (4 + 2 - 3) / 2 + 1 = 2). With an upstream gradient of all ones,
+        // the loss is L = sum(output); finite differences of that sum recover the analytical
+        // gradients. backward divides the parameter gradients by the sample count, so the
+        // numerical estimate (which does not) is compared against `grad * m`.
+        let mut rng = StdRng::seed_from_u64(7);
+        let layer = Conv2d::initialization((2, 4, 4), 3, (3, 3), 2, 1, SIGMOID.clone(), &mut rng);
+        let input = Array::from_shape_fn(IxDyn(&[2, 4, 4, 2]), |idx| {
+            // Deterministic spread of values in a sensible range.
+            let flat = idx[0] * 100 + idx[1] * 10 + idx[2] + idx[3];
+            ((flat % 13) as f32 - 6.0) * 0.1
+        });
+        let m = input.shape()[3] as f32;
+
+        let output = layer.forward(input.view());
+        let da = ArrayD::<f32>::ones(output.raw_dim());
+        let pass = layer.backward(da.view(), input.view(), output.view(), true);
+        let grads = pass.gradients;
+        let da_prev = pass.input_gradient.expect("input gradient requested");
+
+        let loss = |layer: &Conv2d| layer.forward(input.view()).sum();
+        // The summed loss is ~O(10), so a smaller step drowns the central difference in f32
+        // cancellation noise; 1e-2 keeps the signal well above it while truncation stays tiny.
+        let eps = 1e-2_f32;
+        let tolerance = 5e-2_f32;
+        let check = |analytical: f32, numerical: f32, label: String| {
+            let rel = (numerical - analytical).abs()
+                / (numerical.abs().max(analytical.abs()).max(1e-2) + 1e-8);
+            assert!(
+                rel < tolerance,
+                "{label}: analytical={analytical:.6}, numerical={numerical:.6}"
+            );
+        };
+
+        // Kernel gradients: perturb each kernel entry, central-difference the loss, compare
+        // to `grad * m`.
+        let (out_c, in_c, kh, kw) = layer.kernels.dim();
+        for o in 0..out_c {
+            for c in 0..in_c {
+                for u in 0..kh {
+                    for v in 0..kw {
+                        let mut plus = layer.clone();
+                        plus.kernels[[o, c, u, v]] += eps;
+                        let mut minus = layer.clone();
+                        minus.kernels[[o, c, u, v]] -= eps;
+                        let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
+                        check(
+                            grads[0][[o, c, u, v]] * m,
+                            numerical,
+                            format!("dk[{o},{c},{u},{v}]"),
+                        );
+                    }
+                }
+            }
+            let mut plus = layer.clone();
+            plus.biases[o] += eps;
+            let mut minus = layer.clone();
+            minus.biases[o] -= eps;
+            let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
+            check(grads[1][o] * m, numerical, format!("db[{o}]"));
+        }
+
+        // Input gradient: perturb each input entry (no `* m` — it chains straight upstream).
+        for idx in ndarray::indices(input.shape()) {
+            let idx = [idx[0], idx[1], idx[2], idx[3]];
+            let mut plus = input.clone();
+            plus[idx] += eps;
+            let mut minus = input.clone();
+            minus[idx] -= eps;
+            let numerical = (layer.forward(plus.view()).sum() - layer.forward(minus.view()).sum())
+                / (2.0 * eps);
+            check(da_prev[IxDyn(&idx)], numerical, format!("da_prev{idx:?}"));
+        }
+    }
+
+    #[test]
+    fn backward_skips_input_gradient_when_not_requested() {
+        let mut rng = StdRng::seed_from_u64(1);
+        let layer = Conv2d::initialization((1, 4, 4), 2, (2, 2), 1, 0, RELU.clone(), &mut rng);
+        let input = ArrayD::<f32>::ones(IxDyn(&[1, 4, 4, 3]));
+        let output = layer.forward(input.view());
+
+        let da = ArrayD::<f32>::ones(output.raw_dim());
+        let pass = layer.backward(da.view(), input.view(), output.view(), false);
+
+        assert!(pass.input_gradient.is_none());
+        // Kernels and biases both produce a gradient.
+        assert_eq!(pass.gradients.len(), 2);
+    }
+
+    #[test]
+    fn initialization_is_reproducible_and_correctly_shaped() {
+        let build = || {
+            let mut rng = StdRng::seed_from_u64(42);
+            Conv2d::initialization((3, 8, 8), 5, (3, 3), 1, 1, RELU.clone(), &mut rng)
+        };
+        let a = build();
+        let b = build();
+
+        assert_eq!(a.kernels.dim(), (5, 3, 3, 3));
+        assert_eq!(a.biases.len(), 5);
+        // Same seed and architecture yield identical kernels.
+        assert_eq!(a.kernels, b.kernels);
+        // He initialization leaves the biases at zero.
+        assert!(a.biases.iter().all(|&b| b == 0.0));
+    }
+
+    #[test]
+    #[should_panic(expected = "Conv2d expects a 4D")]
+    fn forward_rejects_non_4d_input() {
+        let layer = Conv2d::new(
+            Array4::ones((1, 1, 2, 2)),
+            array![0.0],
+            (1, 3, 3),
+            1,
+            0,
+            RELU.clone(),
+        );
+        let input = ArrayD::<f32>::zeros(IxDyn(&[1, 3, 3]));
+        layer.forward(input.view());
+    }
+
+    #[test]
+    #[should_panic(expected = "input shape does not match")]
+    fn forward_rejects_mismatched_input_shape() {
+        let layer = Conv2d::new(
+            Array4::ones((1, 1, 2, 2)),
+            array![0.0],
+            (1, 3, 3),
+            1,
+            0,
+            RELU.clone(),
+        );
+        // Height 4 where the layer was configured for 3.
+        let input = ArrayD::<f32>::zeros(IxDyn(&[1, 4, 3, 2]));
+        layer.forward(input.view());
+    }
+
+    #[test]
+    #[should_panic(expected = "does not fit the padded input")]
+    fn new_rejects_kernel_larger_than_padded_input() {
+        // 4×4 kernel over a 3×3 input with no padding does not fit.
+        Conv2d::new(
+            Array4::ones((1, 1, 4, 4)),
+            array![0.0],
+            (1, 3, 3),
+            1,
+            0,
+            RELU.clone(),
+        );
+    }
+}

--- a/core/src/nn/layers/conv2d.rs
+++ b/core/src/nn/layers/conv2d.rs
@@ -1,12 +1,13 @@
 use crate::activations::Activation;
+use crate::affine::Affine;
 use crate::gradients::LayerGradients;
 use crate::layers::{BackwardPass, Layer, Parameter};
-use ndarray::{Array1, Array2, Array4, ArrayD, ArrayView2, ArrayView4, ArrayViewD, Axis, Ix4};
+use ndarray::{Array1, Array2, Array4, ArrayD, ArrayView2, ArrayView4, ArrayViewD, Ix4};
 use ndarray_rand::rand::RngCore;
 use std::any::Any;
 use std::sync::Arc;
 
-/// A 2D convolution layer. It slides a bank of small kernels across the height and width of
+/// A 2D convolution layer. It slides a set of small kernels across the height and width of
 /// each sample; at every position it takes the weighted sum of the patch the kernel covers,
 /// so each kernel sweeps out one feature map. An activation is then applied to the result.
 ///
@@ -19,10 +20,10 @@ use std::sync::Arc;
 /// [`Dense`](crate::layers::Dense), with `col2im` folding the gradient back on the way down.
 #[derive(Clone, Debug)]
 pub struct Conv2d {
-    /// Kernels `(out_channels, in_channels, kernel_height, kernel_width)`, one filter per row.
-    kernels: Array4<f32>,
-    /// One bias per output channel.
-    biases: Array1<f32>,
+    /// The affine map, its weights the kernels flattened to `(out_channels, in_channels·kh·kw)`.
+    affine: Affine,
+    /// The kernels' shape `(out_channels, in_channels, kernel_height, kernel_width)`.
+    kernels_shape: (usize, usize, usize, usize),
     /// The per-sample input shape `(in_channels, height, width)`, sample axis excluded.
     input_shape: (usize, usize, usize),
     /// The stride applied on both spatial axes.
@@ -76,9 +77,16 @@ impl Conv2d {
             "Conv2d kernel does not fit the padded input."
         );
 
+        // Flatten the kernels to the affine matrix (out_channels, in·kh·kw); the fan-in axes are
+        // contiguous, so this is a reshape, not a copy.
+        let kernels_shape = (out_channels, in_channels, kh, kw);
+        let weights = kernels
+            .into_shape_with_order((out_channels, in_channels * kh * kw))
+            .expect("(out, in, kh, kw) reshapes to (out, in·kh·kw): element counts match");
+
         Conv2d {
-            kernels,
-            biases,
+            affine: Affine::new(weights, biases),
+            kernels_shape,
             input_shape,
             stride,
             padding,
@@ -117,7 +125,7 @@ impl Conv2d {
 
         // A convolution's fan-in is one receptive field: in_channels · kh · kw. Initializing
         // the flat (out_channels, fan_in) matrix reuses the dense initializers unchanged; the
-        // kernel bank is that same matrix folded to rank 4.
+        // kernels are that same matrix folded to rank 4.
         let fan_in = in_channels * kh * kw;
         let (weights, biases) = activation
             .initialization()
@@ -130,13 +138,17 @@ impl Conv2d {
     }
 
     /// This layer's kernels `(out_channels, in_channels, kernel_height, kernel_width)`.
-    pub fn kernels(&self) -> ArrayView4<'_, f32> {
-        self.kernels.view()
+    pub fn kernels(&self) -> Array4<f32> {
+        self.affine
+            .weights()
+            .to_owned()
+            .into_shape_with_order(self.kernels_shape)
+            .expect("the affine weights fold back to the kernel shape")
     }
 
     /// This layer's biases, one per output channel.
     pub fn biases(&self) -> ndarray::ArrayView1<'_, f32> {
-        self.biases.view()
+        self.affine.biases()
     }
 
     /// The activation applied to this layer's output.
@@ -146,7 +158,7 @@ impl Conv2d {
 
     /// The output's per-sample spatial shape `(out_channels, out_height, out_width)`.
     fn output_shape(&self) -> (usize, usize, usize) {
-        let (out_channels, _, kh, kw) = self.kernels.dim();
+        let (out_channels, _, kh, kw) = self.kernels_shape;
         let (_, height, width) = self.input_shape;
         (
             out_channels,
@@ -168,17 +180,12 @@ impl Layer for Conv2d {
             "Conv2d input shape does not match its configured input shape."
         );
 
-        let (out_channels, _, kh, kw) = self.kernels.dim();
-        let fan_in = in_channels * kh * kw;
+        let (out_channels, _, kh, kw) = self.kernels_shape;
 
-        // im2col → matmul → fold: the affine core is Dense's `weights · input + bias`.
+        // im2col → affine matmul → fold: unfold each patch into a column, then the shared
+        // affine map turns the whole batch into feature maps in one `weights · cols + bias`.
         let cols = im2col(input, kh, kw, self.stride, self.padding);
-        let weights = self
-            .kernels
-            .to_shape((out_channels, fan_in))
-            .expect("kernels are contiguous and reshape to (out_channels, in·kh·kw)");
-        let biases = self.biases.view().insert_axis(Axis(1)).to_owned();
-        let pre_activation = weights.dot(&cols) + &biases;
+        let pre_activation = self.affine.forward(cols.view());
 
         let (_, out_h, out_w) = self.output_shape();
         self.activation
@@ -207,13 +214,12 @@ impl Layer for Conv2d {
             .expect("Conv2d expects a 4D output");
 
         let (in_channels, height, width, samples) = input.dim();
-        let (out_channels, _, kh, kw) = self.kernels.dim();
-        let fan_in = in_channels * kh * kw;
+        let (out_channels, _, kh, kw) = self.kernels_shape;
         let (_, out_h, out_w) = self.output_shape();
         let positions = out_h * out_w * samples;
 
         // Collapse the spatial output to the 2D (out_channels, positions) the activation VJP
-        // and the matmul math operate on, mirroring Dense.
+        // and the affine math operate on, mirroring Dense.
         let da = da
             .to_shape((out_channels, positions))
             .expect("da folds to (out_channels, positions)");
@@ -221,24 +227,18 @@ impl Layer for Conv2d {
             .to_shape((out_channels, positions))
             .expect("output folds to (out_channels, positions)");
 
-        // dz = dL/d(pre-activation); parameter gradients average over the batch (samples),
-        // summing over the shared spatial positions, so they divide by the sample count only.
+        // The columns span spatial positions as well as samples, so the affine backward is told
+        // to average over the sample count alone; col2im then folds the input gradient back.
         let dz = self.activation.vjp(da.view(), output.view());
-        let m = samples as f32;
-
         let cols = im2col(input, kh, kw, self.stride, self.padding);
-        let dw = dz.dot(&cols.t()) / m;
-        let dk = dw
-            .into_shape_with_order((out_channels, in_channels, kh, kw))
-            .expect("(out, in·kh·kw) reshapes to the kernel shape");
-        let db = dz.sum_axis(Axis(1)) / m;
+        let (dw, db, dcols) = self.affine.backward(
+            dz.view(),
+            cols.view(),
+            samples as f32,
+            compute_input_gradient,
+        );
 
-        let input_gradient = compute_input_gradient.then(|| {
-            let weights = self
-                .kernels
-                .to_shape((out_channels, fan_in))
-                .expect("kernels reshape to (out_channels, in·kh·kw)");
-            let dcols = weights.t().dot(&dz);
+        let input_gradient = dcols.map(|dcols| {
             col2im(
                 dcols.view(),
                 (in_channels, height, width, samples),
@@ -251,19 +251,20 @@ impl Layer for Conv2d {
         });
 
         BackwardPass {
-            gradients: LayerGradients(vec![dk.into_dyn(), db.into_dyn()]),
+            gradients: LayerGradients(vec![dw.into_dyn(), db.into_dyn()]),
             input_gradient,
         }
     }
 
     fn parameters_mut(&mut self) -> Vec<Parameter<'_>> {
+        let (weights, biases) = self.affine.parameters_mut();
         vec![
             Parameter {
-                value: self.kernels.view_mut().into_dyn(),
+                value: weights.view_mut().into_dyn(),
                 decays: true,
             },
             Parameter {
-                value: self.biases.view_mut().into_dyn(),
+                value: biases.view_mut().into_dyn(),
                 decays: false,
             },
         ]
@@ -280,7 +281,7 @@ impl Layer for Conv2d {
     }
 
     fn is_finite(&self) -> bool {
-        self.kernels.iter().all(|v| v.is_finite()) && self.biases.iter().all(|v| v.is_finite())
+        self.affine.is_finite()
     }
 
     fn kind(&self) -> &'static str {
@@ -289,8 +290,11 @@ impl Layer for Conv2d {
 
     fn named_tensors(&self) -> Vec<(String, ArrayD<f32>)> {
         vec![
-            ("kernels".to_string(), self.kernels.clone().into_dyn()),
-            ("biases".to_string(), self.biases.clone().into_dyn()),
+            ("kernels".to_string(), self.kernels().into_dyn()),
+            (
+                "biases".to_string(),
+                self.affine.biases().to_owned().into_dyn(),
+            ),
         ]
     }
 
@@ -299,7 +303,7 @@ impl Layer for Conv2d {
     }
 
     fn weight_matrix(&self) -> Option<ArrayView2<'_, f32>> {
-        // The kernels are a rank-4 bank, not a single affine weight matrix.
+        // A convolution has no single (output_size, input_size) weight matrix.
         None
     }
 
@@ -443,9 +447,11 @@ mod tests {
 
         let params = layer.parameters_mut();
         assert_eq!(params.len(), 2);
-        // Kernels decay, biases do not; order matches the gradient order [dk, db].
+        // Weights decay, biases do not; order matches the gradient order [dw, db]. The weight
+        // parameter is the flat affine matrix (out_channels, in·kh·kw) = (3, 18), not the rank-4
+        // kernels the named tensor exposes.
         assert!(params[0].decays);
-        assert_eq!(params[0].value.shape(), &[3, 2, 3, 3]);
+        assert_eq!(params[0].value.shape(), &[3, 2 * 3 * 3]);
         assert!(!params[1].decays);
         assert_eq!(params[1].value.shape(), &[3]);
     }
@@ -515,30 +521,22 @@ mod tests {
             );
         };
 
-        // Kernel gradients: perturb each kernel entry, central-difference the loss, compare
-        // to `grad * m`.
-        let (out_c, in_c, kh, kw) = layer.kernels.dim();
+        // Weight gradients: perturb each entry of the flat affine matrix (out_channels, in·kh·kw),
+        // central-difference the loss, compare to `grad * m`.
+        let (out_c, fan_in) = layer.affine.weights().dim();
         for o in 0..out_c {
-            for c in 0..in_c {
-                for u in 0..kh {
-                    for v in 0..kw {
-                        let mut plus = layer.clone();
-                        plus.kernels[[o, c, u, v]] += eps;
-                        let mut minus = layer.clone();
-                        minus.kernels[[o, c, u, v]] -= eps;
-                        let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
-                        check(
-                            grads[0][[o, c, u, v]] * m,
-                            numerical,
-                            format!("dk[{o},{c},{u},{v}]"),
-                        );
-                    }
-                }
+            for j in 0..fan_in {
+                let mut plus = layer.clone();
+                plus.affine.weights_mut()[[o, j]] += eps;
+                let mut minus = layer.clone();
+                minus.affine.weights_mut()[[o, j]] -= eps;
+                let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
+                check(grads[0][[o, j]] * m, numerical, format!("dw[{o},{j}]"));
             }
             let mut plus = layer.clone();
-            plus.biases[o] += eps;
+            plus.affine.biases_mut()[o] += eps;
             let mut minus = layer.clone();
-            minus.biases[o] -= eps;
+            minus.affine.biases_mut()[o] -= eps;
             let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
             check(grads[1][o] * m, numerical, format!("db[{o}]"));
         }
@@ -580,12 +578,12 @@ mod tests {
         let a = build();
         let b = build();
 
-        assert_eq!(a.kernels.dim(), (5, 3, 3, 3));
-        assert_eq!(a.biases.len(), 5);
+        assert_eq!(a.kernels().dim(), (5, 3, 3, 3));
+        assert_eq!(a.biases().len(), 5);
         // Same seed and architecture yield identical kernels.
-        assert_eq!(a.kernels, b.kernels);
+        assert_eq!(a.kernels(), b.kernels());
         // He initialization leaves the biases at zero.
-        assert!(a.biases.iter().all(|&b| b == 0.0));
+        assert!(a.biases().iter().all(|&b| b == 0.0));
     }
 
     #[test]

--- a/core/src/nn/layers/dense.rs
+++ b/core/src/nn/layers/dense.rs
@@ -108,7 +108,7 @@ impl Layer for Dense {
     fn forward(&self, input: ArrayViewD<f32>) -> ArrayD<f32> {
         let input = input
             .into_dimensionality::<Ix2>()
-            .expect("Dense expects a 2D (features, samples) input.");
+            .expect("Dense expects a 2D (features, samples) input");
         assert_eq!(
             input.nrows(),
             self.weights.ncols(),
@@ -132,13 +132,13 @@ impl Layer for Dense {
     ) -> BackwardPass {
         let da = da
             .into_dimensionality::<Ix2>()
-            .expect("Dense expects a 2D da.");
+            .expect("Dense expects a 2D da");
         let input = input
             .into_dimensionality::<Ix2>()
-            .expect("Dense expects a 2D input.");
+            .expect("Dense expects a 2D input");
         let output = output
             .into_dimensionality::<Ix2>()
-            .expect("Dense expects a 2D output.");
+            .expect("Dense expects a 2D output");
 
         let m = input.ncols() as f32;
 

--- a/core/src/nn/layers/dense.rs
+++ b/core/src/nn/layers/dense.rs
@@ -149,12 +149,12 @@ impl Layer for Dense {
         ]
     }
 
-    fn input_size(&self) -> usize {
-        self.affine.weights().ncols()
+    fn input_shape(&self) -> Vec<usize> {
+        vec![self.affine.weights().ncols()]
     }
 
-    fn output_size(&self) -> usize {
-        self.affine.weights().nrows()
+    fn output_shape(&self) -> Vec<usize> {
+        vec![self.affine.weights().nrows()]
     }
 
     fn is_finite(&self) -> bool {

--- a/core/src/nn/layers/dense.rs
+++ b/core/src/nn/layers/dense.rs
@@ -2,7 +2,7 @@ use crate::activations::Activation;
 use crate::gradients::LayerGradients;
 use crate::layers::{BackwardPass, Layer, Parameter};
 use crate::model::NeuronLayerSpec;
-use ndarray::{Array1, Array2, ArrayD, ArrayView1, ArrayView2, Axis};
+use ndarray::{Array1, Array2, ArrayD, ArrayView1, ArrayView2, ArrayViewD, Axis, Ix2};
 use ndarray_rand::rand::RngCore;
 use std::any::Any;
 use std::sync::Arc;
@@ -105,7 +105,10 @@ impl Dense {
 }
 
 impl Layer for Dense {
-    fn forward(&self, input: ArrayView2<f32>) -> Array2<f32> {
+    fn forward(&self, input: ArrayViewD<f32>) -> ArrayD<f32> {
+        let input = input
+            .into_dimensionality::<Ix2>()
+            .expect("Dense expects a 2D (features, samples) input.");
         assert_eq!(
             input.nrows(),
             self.weights.ncols(),
@@ -117,15 +120,26 @@ impl Layer for Dense {
 
         self.activation
             .apply((self.weights.dot(&input) + &broadcasted_biases).view())
+            .into_dyn()
     }
 
     fn backward(
         &self,
-        da: ArrayView2<f32>,
-        input: ArrayView2<f32>,
-        output: ArrayView2<f32>,
+        da: ArrayViewD<f32>,
+        input: ArrayViewD<f32>,
+        output: ArrayViewD<f32>,
         compute_input_gradient: bool,
     ) -> BackwardPass {
+        let da = da
+            .into_dimensionality::<Ix2>()
+            .expect("Dense expects a 2D da.");
+        let input = input
+            .into_dimensionality::<Ix2>()
+            .expect("Dense expects a 2D input.");
+        let output = output
+            .into_dimensionality::<Ix2>()
+            .expect("Dense expects a 2D output.");
+
         let m = input.ncols() as f32;
 
         // dz = dL/d(pre-activation); the activation's VJP turns dL/d(output) into it.
@@ -133,7 +147,7 @@ impl Layer for Dense {
         let dw = dz.dot(&input.t()) / m;
         let db = dz.sum_axis(Axis(1)) / m;
         // dL/d(input), the gradient handed back to the upstream layer.
-        let input_gradient = compute_input_gradient.then(|| self.weights.t().dot(&dz));
+        let input_gradient = compute_input_gradient.then(|| self.weights.t().dot(&dz).into_dyn());
 
         BackwardPass {
             gradients: LayerGradients(vec![dw.into_dyn(), db.into_dyn()]),
@@ -267,13 +281,13 @@ mod tests {
         ];
         let m = input.ncols() as f32;
 
-        let output = layer.forward(input.view());
-        let da = Array2::<f32>::ones(output.dim());
-        let pass = layer.backward(da.view(), input.view(), output.view(), true);
+        let output = layer.forward(input.view().into_dyn());
+        let da = ArrayD::<f32>::ones(output.raw_dim());
+        let pass = layer.backward(da.view(), input.view().into_dyn(), output.view(), true);
         let grads = pass.gradients;
         let da_prev = pass.input_gradient.expect("input gradient requested");
 
-        let loss = |layer: &Dense| layer.forward(input.view()).sum();
+        let loss = |layer: &Dense| layer.forward(input.view().into_dyn()).sum();
         let eps = 1e-3_f32;
         let tolerance = 5e-2_f32;
         let check = |analytical: f32, numerical: f32, label: &str| {
@@ -311,11 +325,56 @@ mod tests {
                 plus[[k, s]] += eps;
                 let mut minus = input.clone();
                 minus[[k, s]] -= eps;
-                let numerical = (layer.forward(plus.view()).sum()
-                    - layer.forward(minus.view()).sum())
+                let numerical = (layer.forward(plus.view().into_dyn()).sum()
+                    - layer.forward(minus.view().into_dyn()).sum())
                     / (2.0 * eps);
                 check(da_prev[[k, s]], numerical, &format!("da_prev[{k},{s}]"));
             }
         }
+    }
+
+    #[test]
+    fn forward_matches_the_2d_math_and_keeps_rank_two() {
+        let layer = Dense {
+            weights: array![[0.2, -0.4, 0.1], [0.5, 0.3, -0.2]],
+            biases: array![0.05, -0.1],
+            activation: SIGMOID.clone(),
+        };
+        let input = array![
+            [0.5, -0.3, 0.8, 0.1],
+            [0.2, 0.7, -0.5, 0.4],
+            [-0.1, 0.6, 0.3, -0.4]
+        ];
+
+        // Reference computed with the column-major math the layer used before the N-D switch.
+        let biases = layer.biases.view().insert_axis(Axis(1)).to_owned();
+        let reference = layer
+            .activation
+            .apply((layer.weights.dot(&input) + &biases).view());
+
+        let output = layer.forward(input.view().into_dyn());
+        assert_eq!(output.ndim(), 2);
+        assert_eq!(output.shape(), &[layer.output_size(), input.ncols()]);
+        // Bit-exact: the N-D pipe only reinterprets the dimension type, it does not touch values.
+        assert_eq!(output, reference.into_dyn());
+
+        // The input gradient round-trips back to rank 2 with the expected shape.
+        let da = ArrayD::<f32>::ones(output.raw_dim());
+        let pass = layer.backward(da.view(), input.view().into_dyn(), output.view(), true);
+        let input_gradient = pass.input_gradient.expect("input gradient requested");
+        assert_eq!(input_gradient.ndim(), 2);
+        assert_eq!(input_gradient.shape(), &[layer.input_size(), input.ncols()]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Dense expects a 2D")]
+    fn forward_rejects_non_2d_input() {
+        let layer = Dense {
+            weights: array![[0.2, -0.4], [0.5, 0.3]],
+            biases: array![0.0, 0.0],
+            activation: SIGMOID.clone(),
+        };
+        let input = ArrayD::<f32>::zeros(vec![2, 3, 4]);
+        layer.forward(input.view());
     }
 }

--- a/core/src/nn/layers/dense.rs
+++ b/core/src/nn/layers/dense.rs
@@ -1,11 +1,12 @@
 use crate::activations::Activation;
 use crate::affine::Affine;
 use crate::gradients::LayerGradients;
-use crate::layers::{BackwardPass, Layer, Parameter};
+use crate::layers::{BackwardPass, Layer, LayerConfigError, LayerKind, Parameter};
 use crate::model::NeuronLayerSpec;
-use ndarray::{Array1, Array2, ArrayD, ArrayView1, ArrayView2, ArrayViewD, Ix2};
+use ndarray::{Array1, Array2, ArrayD, ArrayView1, ArrayView2, ArrayViewD, Ix1, Ix2};
 use ndarray_rand::rand::RngCore;
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// A fully connected layer: an affine map `weights · input + bias` followed by an
@@ -77,6 +78,20 @@ impl Dense {
     /// The activation applied to this layer's output.
     pub fn activation(&self) -> &Arc<dyn Activation> {
         &self.activation
+    }
+
+    /// Builds a `Dense` layer from its configuration and tensors.
+    /// # Arguments
+    /// - `config`: Carries the `"activation"` name.
+    /// - `tensors`: Carries the `"weights"` (rank-2) and `"biases"` (rank-1) tensors.
+    pub(super) fn from_config(
+        config: &HashMap<String, String>,
+        mut tensors: HashMap<String, ArrayD<f32>>,
+    ) -> Result<Self, LayerConfigError> {
+        let weights = super::take_tensor::<Ix2>(&mut tensors, "weights")?;
+        let biases = super::take_tensor::<Ix1>(&mut tensors, "biases")?;
+        let activation = super::config_activation(config)?;
+        Ok(Dense::new(weights, biases, activation))
     }
 
     /// Mutable access to this layer's affine map.
@@ -161,8 +176,12 @@ impl Layer for Dense {
         self.affine.is_finite()
     }
 
-    fn kind(&self) -> &'static str {
-        "dense"
+    fn kind(&self) -> LayerKind {
+        LayerKind::Dense
+    }
+
+    fn config(&self) -> Vec<(String, String)> {
+        vec![("activation".to_string(), self.activation.name().to_string())]
     }
 
     fn named_tensors(&self) -> Vec<(String, ArrayD<f32>)> {
@@ -207,7 +226,7 @@ mod tests {
         let layer = Dense::new(Array2::zeros((2, 3)), Array1::zeros(2), RELU.clone());
         assert_eq!(layer.output_size(), 2);
         assert_eq!(layer.input_size(), 3);
-        assert_eq!(layer.kind(), "dense");
+        assert_eq!(layer.kind(), LayerKind::Dense);
         assert_eq!(layer.activation_name(), Some("relu"));
         assert_eq!(layer.weight_matrix().unwrap().dim(), (2, 3));
 

--- a/core/src/nn/layers/dense.rs
+++ b/core/src/nn/layers/dense.rs
@@ -79,16 +79,10 @@ impl Dense {
         &self.activation
     }
 
-    /// Mutable access to this layer's weight matrix.
+    /// Mutable access to this layer's affine map.
     #[cfg(test)]
-    pub(crate) fn weights_mut(&mut self) -> &mut Array2<f32> {
-        self.affine.weights_mut()
-    }
-
-    /// Mutable access to this layer's biases.
-    #[cfg(test)]
-    pub(crate) fn biases_mut(&mut self) -> &mut Array1<f32> {
-        self.affine.biases_mut()
+    pub(crate) fn affine_mut(&mut self) -> &mut Affine {
+        &mut self.affine
     }
 }
 
@@ -289,16 +283,16 @@ mod tests {
         for i in 0..layer.output_size() {
             for j in 0..layer.input_size() {
                 let mut plus = layer.clone();
-                plus.weights_mut()[[i, j]] += eps;
+                plus.affine.weights_mut()[[i, j]] += eps;
                 let mut minus = layer.clone();
-                minus.weights_mut()[[i, j]] -= eps;
+                minus.affine.weights_mut()[[i, j]] -= eps;
                 let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
                 check(grads[0][[i, j]] * m, numerical, &format!("dw[{i},{j}]"));
             }
             let mut plus = layer.clone();
-            plus.biases_mut()[i] += eps;
+            plus.affine.biases_mut()[i] += eps;
             let mut minus = layer.clone();
-            minus.biases_mut()[i] -= eps;
+            minus.affine.biases_mut()[i] -= eps;
             let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
             check(grads[1][i] * m, numerical, &format!("db[{i}]"));
         }

--- a/core/src/nn/layers/dense.rs
+++ b/core/src/nn/layers/dense.rs
@@ -1,8 +1,9 @@
 use crate::activations::Activation;
+use crate::affine::Affine;
 use crate::gradients::LayerGradients;
 use crate::layers::{BackwardPass, Layer, Parameter};
 use crate::model::NeuronLayerSpec;
-use ndarray::{Array1, Array2, ArrayD, ArrayView1, ArrayView2, ArrayViewD, Axis, Ix2};
+use ndarray::{Array1, Array2, ArrayD, ArrayView1, ArrayView2, ArrayViewD, Ix2};
 use ndarray_rand::rand::RngCore;
 use std::any::Any;
 use std::sync::Arc;
@@ -11,10 +12,8 @@ use std::sync::Arc;
 /// activation, applied to every sample in the batch.
 #[derive(Clone, Debug)]
 pub struct Dense {
-    /// A 2D array where each row corresponds to a neuron and each column corresponds to an input feature.
-    weights: Array2<f32>,
-    /// A 1D array where each element is the bias for the corresponding neuron.
-    biases: Array1<f32>,
+    /// The affine map: one row of weights per neuron, one bias per neuron.
+    affine: Affine,
     /// The activation function applied to the output of this layer.
     activation: Arc<dyn Activation>,
 }
@@ -29,19 +28,8 @@ impl Dense {
     /// - `biases`: A `(neurons)` array, one bias per neuron.
     /// - `activation`: The activation applied to this layer's output.
     pub fn new(weights: Array2<f32>, biases: Array1<f32>, activation: Arc<dyn Activation>) -> Self {
-        assert!(
-            weights.nrows() > 0 && weights.ncols() > 0,
-            "Dense layer weights must be non-empty."
-        );
-        assert_eq!(
-            weights.nrows(),
-            biases.len(),
-            "Dense layer needs one bias per neuron."
-        );
-
         Dense {
-            weights,
-            biases,
+            affine: Affine::new(weights, biases),
             activation,
         }
     }
@@ -71,19 +59,19 @@ impl Dense {
     /// Returns the specifications of this layer.
     pub fn spec(&self) -> NeuronLayerSpec {
         NeuronLayerSpec {
-            neurons: self.weights.nrows(),
+            neurons: self.affine.weights().nrows(),
             activation: self.activation.clone(),
         }
     }
 
     /// This layer's weight matrix `(neurons, inputs)`.
     pub fn weights(&self) -> ArrayView2<'_, f32> {
-        self.weights.view()
+        self.affine.weights()
     }
 
     /// This layer's biases, one per neuron.
     pub fn biases(&self) -> ArrayView1<'_, f32> {
-        self.biases.view()
+        self.affine.biases()
     }
 
     /// The activation applied to this layer's output.
@@ -94,13 +82,13 @@ impl Dense {
     /// Mutable access to this layer's weight matrix.
     #[cfg(test)]
     pub(crate) fn weights_mut(&mut self) -> &mut Array2<f32> {
-        &mut self.weights
+        self.affine.weights_mut()
     }
 
     /// Mutable access to this layer's biases.
     #[cfg(test)]
     pub(crate) fn biases_mut(&mut self) -> &mut Array1<f32> {
-        &mut self.biases
+        self.affine.biases_mut()
     }
 }
 
@@ -111,15 +99,12 @@ impl Layer for Dense {
             .expect("Dense expects a 2D (features, samples) input");
         assert_eq!(
             input.nrows(),
-            self.weights.ncols(),
+            self.affine.weights().ncols(),
             "Input shape does not match weights shape."
         );
 
-        // Broadcasting bias to match the shape of the output
-        let broadcasted_biases: Array2<f32> = self.biases.view().insert_axis(Axis(1)).to_owned();
-
         self.activation
-            .apply((self.weights.dot(&input) + &broadcasted_biases).view())
+            .apply(self.affine.forward(input).view())
             .into_dyn()
     }
 
@@ -140,44 +125,46 @@ impl Layer for Dense {
             .into_dimensionality::<Ix2>()
             .expect("Dense expects a 2D output");
 
-        let m = input.ncols() as f32;
-
         // dz = dL/d(pre-activation); the activation's VJP turns dL/d(output) into it.
+        // Dense's affine input is the batch itself, so it averages over its columns.
         let dz = self.activation.vjp(da, output);
-        let dw = dz.dot(&input.t()) / m;
-        let db = dz.sum_axis(Axis(1)) / m;
-        // dL/d(input), the gradient handed back to the upstream layer.
-        let input_gradient = compute_input_gradient.then(|| self.weights.t().dot(&dz).into_dyn());
+        let (dw, db, dinput) = self.affine.backward(
+            dz.view(),
+            input,
+            input.ncols() as f32,
+            compute_input_gradient,
+        );
 
         BackwardPass {
             gradients: LayerGradients(vec![dw.into_dyn(), db.into_dyn()]),
-            input_gradient,
+            input_gradient: dinput.map(|d| d.into_dyn()),
         }
     }
 
     fn parameters_mut(&mut self) -> Vec<Parameter<'_>> {
+        let (weights, biases) = self.affine.parameters_mut();
         vec![
             Parameter {
-                value: self.weights.view_mut().into_dyn(),
+                value: weights.view_mut().into_dyn(),
                 decays: true,
             },
             Parameter {
-                value: self.biases.view_mut().into_dyn(),
+                value: biases.view_mut().into_dyn(),
                 decays: false,
             },
         ]
     }
 
     fn input_size(&self) -> usize {
-        self.weights.ncols()
+        self.affine.weights().ncols()
     }
 
     fn output_size(&self) -> usize {
-        self.weights.nrows()
+        self.affine.weights().nrows()
     }
 
     fn is_finite(&self) -> bool {
-        self.weights.iter().all(|v| v.is_finite()) && self.biases.iter().all(|v| v.is_finite())
+        self.affine.is_finite()
     }
 
     fn kind(&self) -> &'static str {
@@ -186,8 +173,14 @@ impl Layer for Dense {
 
     fn named_tensors(&self) -> Vec<(String, ArrayD<f32>)> {
         vec![
-            ("weights".to_string(), self.weights.clone().into_dyn()),
-            ("biases".to_string(), self.biases.clone().into_dyn()),
+            (
+                "weights".to_string(),
+                self.affine.weights().to_owned().into_dyn(),
+            ),
+            (
+                "biases".to_string(),
+                self.affine.biases().to_owned().into_dyn(),
+            ),
         ]
     }
 
@@ -196,7 +189,7 @@ impl Layer for Dense {
     }
 
     fn weight_matrix(&self) -> Option<ArrayView2<'_, f32>> {
-        Some(self.weights.view())
+        Some(self.affine.weights())
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -212,16 +205,12 @@ impl Layer for Dense {
 mod tests {
     use super::*;
     use crate::activations::{RELU, SIGMOID};
-    use ndarray::array;
+    use ndarray::{Axis, array};
 
     #[test]
     fn accessors_report_dimensions_and_activation() {
         // 2 neurons, each taking 3 inputs.
-        let layer = Dense {
-            weights: Array2::zeros((2, 3)),
-            biases: Array1::zeros(2),
-            activation: RELU.clone(),
-        };
+        let layer = Dense::new(Array2::zeros((2, 3)), Array1::zeros(2), RELU.clone());
         assert_eq!(layer.output_size(), 2);
         assert_eq!(layer.input_size(), 3);
         assert_eq!(layer.kind(), "dense");
@@ -235,11 +224,11 @@ mod tests {
 
     #[test]
     fn parameters_are_weights_then_bias_with_decay_flags() {
-        let mut layer = Dense {
-            weights: array![[1.0, 2.0], [3.0, 4.0]],
-            biases: array![5.0, 6.0],
-            activation: RELU.clone(),
-        };
+        let mut layer = Dense::new(
+            array![[1.0, 2.0], [3.0, 4.0]],
+            array![5.0, 6.0],
+            RELU.clone(),
+        );
         let params = layer.parameters_mut();
         assert_eq!(params.len(), 2);
         // Weights decay, the bias does not.
@@ -251,11 +240,7 @@ mod tests {
 
     #[test]
     fn named_tensors_are_weights_and_biases() {
-        let layer = Dense {
-            weights: array![[1.0, 2.0]],
-            biases: array![3.0],
-            activation: RELU.clone(),
-        };
+        let layer = Dense::new(array![[1.0, 2.0]], array![3.0], RELU.clone());
         let tensors = layer.named_tensors();
         assert_eq!(tensors[0].0, "weights");
         assert_eq!(tensors[0].1, array![[1.0, 2.0]].into_dyn());
@@ -269,11 +254,11 @@ mod tests {
         // is L = sum(output), so finite differences of that sum recover the analytical
         // gradients. backward divides the parameter gradients by the sample count, so
         // the numerical estimate (which does not) is compared against `grad * m`.
-        let layer = Dense {
-            weights: array![[0.2, -0.4, 0.1], [0.5, 0.3, -0.2]],
-            biases: array![0.05, -0.1],
-            activation: SIGMOID.clone(),
-        };
+        let layer = Dense::new(
+            array![[0.2, -0.4, 0.1], [0.5, 0.3, -0.2]],
+            array![0.05, -0.1],
+            SIGMOID.clone(),
+        );
         let input = array![
             [0.5, -0.3, 0.8, 0.1],
             [0.2, 0.7, -0.5, 0.4],
@@ -304,16 +289,16 @@ mod tests {
         for i in 0..layer.output_size() {
             for j in 0..layer.input_size() {
                 let mut plus = layer.clone();
-                plus.weights[[i, j]] += eps;
+                plus.weights_mut()[[i, j]] += eps;
                 let mut minus = layer.clone();
-                minus.weights[[i, j]] -= eps;
+                minus.weights_mut()[[i, j]] -= eps;
                 let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
                 check(grads[0][[i, j]] * m, numerical, &format!("dw[{i},{j}]"));
             }
             let mut plus = layer.clone();
-            plus.biases[i] += eps;
+            plus.biases_mut()[i] += eps;
             let mut minus = layer.clone();
-            minus.biases[i] -= eps;
+            minus.biases_mut()[i] -= eps;
             let numerical = (loss(&plus) - loss(&minus)) / (2.0 * eps);
             check(grads[1][i] * m, numerical, &format!("db[{i}]"));
         }
@@ -335,11 +320,11 @@ mod tests {
 
     #[test]
     fn forward_matches_the_2d_math_and_keeps_rank_two() {
-        let layer = Dense {
-            weights: array![[0.2, -0.4, 0.1], [0.5, 0.3, -0.2]],
-            biases: array![0.05, -0.1],
-            activation: SIGMOID.clone(),
-        };
+        let layer = Dense::new(
+            array![[0.2, -0.4, 0.1], [0.5, 0.3, -0.2]],
+            array![0.05, -0.1],
+            SIGMOID.clone(),
+        );
         let input = array![
             [0.5, -0.3, 0.8, 0.1],
             [0.2, 0.7, -0.5, 0.4],
@@ -347,10 +332,10 @@ mod tests {
         ];
 
         // Reference computed with the column-major math the layer used before the N-D switch.
-        let biases = layer.biases.view().insert_axis(Axis(1)).to_owned();
+        let biases = layer.biases().insert_axis(Axis(1)).to_owned();
         let reference = layer
-            .activation
-            .apply((layer.weights.dot(&input) + &biases).view());
+            .activation()
+            .apply((layer.weights().dot(&input) + &biases).view());
 
         let output = layer.forward(input.view().into_dyn());
         assert_eq!(output.ndim(), 2);
@@ -369,11 +354,11 @@ mod tests {
     #[test]
     #[should_panic(expected = "Dense expects a 2D")]
     fn forward_rejects_non_2d_input() {
-        let layer = Dense {
-            weights: array![[0.2, -0.4], [0.5, 0.3]],
-            biases: array![0.0, 0.0],
-            activation: SIGMOID.clone(),
-        };
+        let layer = Dense::new(
+            array![[0.2, -0.4], [0.5, 0.3]],
+            array![0.0, 0.0],
+            SIGMOID.clone(),
+        );
         let input = ArrayD::<f32>::zeros(vec![2, 3, 4]);
         layer.forward(input.view());
     }

--- a/core/src/nn/layers/flatten.rs
+++ b/core/src/nn/layers/flatten.rs
@@ -1,0 +1,218 @@
+use crate::gradients::LayerGradients;
+use crate::layers::{BackwardPass, Layer, Parameter};
+use ndarray::{ArrayD, ArrayView2, ArrayViewD};
+use std::any::Any;
+
+/// A reshape layer collapsing each sample's feature dimensions into a single axis,
+/// mapping a spatial batch `(feature dims…, samples)` to the flat `(features, samples)`
+/// a [`Dense`](crate::layers::Dense) head consumes. It is the boundary between the
+/// spatial stages of a network and its dense classifier.
+///
+/// The sample axis stays last, so flattening is a pure reshape: no data moves and the
+/// layer holds no parameters. The backward pass reshapes the incoming gradient back to
+/// the input's spatial shape.
+#[derive(Clone, Debug)]
+pub struct Flatten {
+    /// The per-sample feature dimensions this layer flattens, sample axis excluded
+    /// (e.g. `[channels, height, width]`).
+    shape: Vec<usize>,
+}
+
+impl Flatten {
+    /// Builds a `Flatten` for inputs whose per-sample shape is `shape` (the sample axis
+    /// excluded).
+    /// # Panics
+    /// - When `shape` is empty or any dimension is zero.
+    /// # Arguments
+    /// - `shape`: The per-sample feature dimensions, such as `[channels, height, width]`.
+    pub fn new(shape: impl Into<Vec<usize>>) -> Self {
+        let shape = shape.into();
+        assert!(
+            !shape.is_empty(),
+            "Flatten needs at least one feature dimension."
+        );
+        assert!(
+            shape.iter().all(|&d| d > 0),
+            "Flatten dimensions must be greater than zero."
+        );
+
+        Flatten { shape }
+    }
+
+    /// The number of features produced by flattening one sample.
+    fn features(&self) -> usize {
+        self.shape.iter().product()
+    }
+}
+
+impl Layer for Flatten {
+    fn forward(&self, input: ArrayViewD<f32>) -> ArrayD<f32> {
+        let ndim = input.ndim();
+        assert_eq!(
+            ndim,
+            self.shape.len() + 1,
+            "Flatten expected a rank-{} input (feature dims + samples).",
+            self.shape.len() + 1
+        );
+        assert_eq!(
+            &input.shape()[..ndim - 1],
+            self.shape.as_slice(),
+            "Flatten input feature dimensions do not match its shape."
+        );
+
+        let samples = input.shape()[ndim - 1];
+        input
+            .to_shape((self.features(), samples))
+            .expect("collapsing the leading axes of a batch preserves its element count")
+            .into_owned()
+            .into_dyn()
+    }
+
+    fn backward(
+        &self,
+        da: ArrayViewD<f32>,
+        input: ArrayViewD<f32>,
+        _output: ArrayViewD<f32>,
+        compute_input_gradient: bool,
+    ) -> BackwardPass {
+        // Flatten carries no parameters; the incoming gradient only needs reshaping
+        // back to the input's spatial shape for the upstream layer.
+        let input_gradient = compute_input_gradient.then(|| {
+            da.to_shape(input.raw_dim())
+                .expect("the output gradient reshapes back to the input's spatial shape")
+                .into_owned()
+        });
+
+        BackwardPass {
+            gradients: LayerGradients(vec![]),
+            input_gradient,
+        }
+    }
+
+    fn parameters_mut(&mut self) -> Vec<Parameter<'_>> {
+        vec![]
+    }
+
+    fn input_size(&self) -> usize {
+        self.features()
+    }
+
+    fn output_size(&self) -> usize {
+        self.features()
+    }
+
+    fn is_finite(&self) -> bool {
+        true
+    }
+
+    fn kind(&self) -> &'static str {
+        "flatten"
+    }
+
+    fn named_tensors(&self) -> Vec<(String, ArrayD<f32>)> {
+        vec![]
+    }
+
+    fn activation_name(&self) -> Option<&str> {
+        None
+    }
+
+    fn weight_matrix(&self) -> Option<ArrayView2<'_, f32>> {
+        None
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::{Array, Array2, IxDyn};
+
+    #[test]
+    fn forward_collapses_feature_dims_keeping_samples_last() {
+        // (channels=2, height=2, width=1, samples=3) → (4, 3). Filling the input with
+        // 0..12 in C order makes the value at (feature, sample) equal feature*3 + sample,
+        // so the flattened result must equal 0..12 reshaped to (4, 3).
+        let input =
+            Array::from_shape_vec(IxDyn(&[2, 2, 1, 3]), (0..12).map(|v| v as f32).collect())
+                .unwrap();
+        let flatten = Flatten::new(vec![2, 2, 1]);
+
+        let output = flatten.forward(input.view());
+
+        assert_eq!(output.shape(), &[4, 3]);
+        let expected = Array2::from_shape_vec((4, 3), (0..12).map(|v| v as f32).collect()).unwrap();
+        assert_eq!(output, expected.into_dyn());
+    }
+
+    #[test]
+    fn accessors_report_flattened_size_and_no_parameters() {
+        let mut flatten = Flatten::new(vec![3, 4, 5]);
+        assert_eq!(flatten.input_size(), 60);
+        assert_eq!(flatten.output_size(), 60);
+        assert_eq!(flatten.kind(), "flatten");
+        assert_eq!(flatten.activation_name(), None);
+        assert!(flatten.weight_matrix().is_none());
+        assert!(flatten.named_tensors().is_empty());
+        assert!(flatten.parameters_mut().is_empty());
+        assert!(flatten.is_finite());
+    }
+
+    #[test]
+    fn backward_reshapes_gradient_back_to_input_shape() {
+        let input =
+            Array::from_shape_vec(IxDyn(&[2, 3, 4]), (0..24).map(|v| v as f32).collect()).unwrap();
+        let flatten = Flatten::new(vec![2, 3]);
+        let output = flatten.forward(input.view());
+
+        // Distinct gradient values so the reshape order is verifiable.
+        let da =
+            ArrayD::from_shape_vec(output.raw_dim(), (0..24).map(|v| v as f32 * 0.5).collect())
+                .unwrap();
+        let pass = flatten.backward(da.view(), input.view(), output.view(), true);
+
+        assert!(pass.gradients.is_empty(), "Flatten has no parameters");
+        let input_gradient = pass.input_gradient.expect("input gradient requested");
+        assert_eq!(input_gradient.shape(), input.shape());
+        // Flattening the reshaped gradient recovers `da`: the two reshapes are inverses.
+        assert_eq!(flatten.forward(input_gradient.view()), da);
+    }
+
+    #[test]
+    fn backward_skips_input_gradient_when_not_requested() {
+        let input = ArrayD::<f32>::zeros(IxDyn(&[2, 3, 5]));
+        let flatten = Flatten::new(vec![2, 3]);
+        let output = flatten.forward(input.view());
+
+        let da = ArrayD::<f32>::ones(output.raw_dim());
+        let pass = flatten.backward(da.view(), input.view(), output.view(), false);
+
+        assert!(pass.input_gradient.is_none());
+        assert!(pass.gradients.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "Flatten input feature dimensions")]
+    fn forward_rejects_mismatched_feature_dims() {
+        let flatten = Flatten::new(vec![2, 3]);
+        // Second feature dimension is 4, not the expected 3.
+        let input = ArrayD::<f32>::zeros(IxDyn(&[2, 4, 5]));
+        flatten.forward(input.view());
+    }
+
+    #[test]
+    #[should_panic(expected = "feature dims + samples")]
+    fn forward_rejects_wrong_rank() {
+        let flatten = Flatten::new(vec![2, 3]);
+        // Rank 2 where rank 3 (two feature dims + samples) is expected.
+        let input = ArrayD::<f32>::zeros(IxDyn(&[6, 5]));
+        flatten.forward(input.view());
+    }
+}

--- a/core/src/nn/layers/flatten.rs
+++ b/core/src/nn/layers/flatten.rs
@@ -1,7 +1,8 @@
 use crate::gradients::LayerGradients;
-use crate::layers::{BackwardPass, Layer, Parameter};
+use crate::layers::{BackwardPass, Layer, LayerConfigError, LayerKind, Parameter};
 use ndarray::{ArrayD, ArrayView2, ArrayViewD};
 use std::any::Any;
+use std::collections::HashMap;
 
 /// A reshape layer collapsing each sample's feature dimensions into a single axis,
 /// mapping a spatial batch `(feature dims…, samples)` to the flat `(features, samples)`
@@ -42,6 +43,17 @@ impl Flatten {
     /// The number of features produced by flattening one sample.
     fn features(&self) -> usize {
         self.shape.iter().product()
+    }
+
+    /// Builds a `Flatten` layer from its configuration.
+    /// # Arguments
+    /// - `config`: Carries the `"shape"`, the per-sample feature dimensions.
+    /// - `_tensors`: Unused — a `Flatten` holds no tensors.
+    pub(super) fn from_config(
+        config: &HashMap<String, String>,
+        _tensors: HashMap<String, ArrayD<f32>>,
+    ) -> Result<Self, LayerConfigError> {
+        Ok(Flatten::new(super::config_dims(config, "shape")?))
     }
 }
 
@@ -105,8 +117,18 @@ impl Layer for Flatten {
         true
     }
 
-    fn kind(&self) -> &'static str {
-        "flatten"
+    fn kind(&self) -> LayerKind {
+        LayerKind::Flatten
+    }
+
+    fn config(&self) -> Vec<(String, String)> {
+        let shape = self
+            .shape
+            .iter()
+            .map(usize::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        vec![("shape".to_string(), shape)]
     }
 
     fn named_tensors(&self) -> Vec<(String, ArrayD<f32>)> {
@@ -157,7 +179,7 @@ mod tests {
         let mut flatten = Flatten::new(vec![3, 4, 5]);
         assert_eq!(flatten.input_size(), 60);
         assert_eq!(flatten.output_size(), 60);
-        assert_eq!(flatten.kind(), "flatten");
+        assert_eq!(flatten.kind(), LayerKind::Flatten);
         assert_eq!(flatten.activation_name(), None);
         assert!(flatten.weight_matrix().is_none());
         assert!(flatten.named_tensors().is_empty());
@@ -214,5 +236,15 @@ mod tests {
         // Rank 2 where rank 3 (two feature dims + samples) is expected.
         let input = ArrayD::<f32>::zeros(IxDyn(&[6, 5]));
         flatten.forward(input.view());
+    }
+
+    #[test]
+    fn config_round_trips_through_from_config() {
+        let flatten = Flatten::new(vec![2, 3, 4]);
+        let config: HashMap<String, String> = flatten.config().into_iter().collect();
+        let rebuilt = Flatten::from_config(&config, HashMap::new()).unwrap();
+
+        assert_eq!(flatten.input_shape(), rebuilt.input_shape());
+        assert_eq!(flatten.config(), rebuilt.config());
     }
 }

--- a/core/src/nn/layers/flatten.rs
+++ b/core/src/nn/layers/flatten.rs
@@ -93,12 +93,12 @@ impl Layer for Flatten {
         vec![]
     }
 
-    fn input_size(&self) -> usize {
-        self.features()
+    fn input_shape(&self) -> Vec<usize> {
+        self.shape.clone()
     }
 
-    fn output_size(&self) -> usize {
-        self.features()
+    fn output_shape(&self) -> Vec<usize> {
+        vec![self.features()]
     }
 
     fn is_finite(&self) -> bool {

--- a/core/src/nn/layers/mod.rs
+++ b/core/src/nn/layers/mod.rs
@@ -12,7 +12,7 @@ pub use dense::Dense;
 
 use crate::gradients::LayerGradients;
 use dyn_clone::DynClone;
-use ndarray::{Array2, ArrayD, ArrayView2, ArrayViewMutD};
+use ndarray::{ArrayD, ArrayView2, ArrayViewD, ArrayViewMutD};
 use std::any::Any;
 use std::fmt::Debug;
 
@@ -30,7 +30,7 @@ pub struct BackwardPass {
     pub gradients: LayerGradients,
     /// The gradient of the loss with respect to the layer's input, or `None` when the
     /// caller did not request it.
-    pub input_gradient: Option<Array2<f32>>,
+    pub input_gradient: Option<ArrayD<f32>>,
 }
 
 /// One stage of a neural network, mapping a batch of inputs to a batch of outputs.
@@ -39,15 +39,15 @@ pub struct BackwardPass {
 pub trait Layer: DynClone + Debug {
     /// Computes the forward pass of this layer given the inputs.
     /// # Arguments
-    /// - `input`: A 2D array `(input_size, samples)` representing the inputs to this layer.
+    /// - `input`: An array `(input_size, samples)` representing the inputs to this layer.
     /// # Returns
-    /// - A 2D array `(output_size, samples)` representing the outputs of this layer.
-    fn forward(&self, input: ArrayView2<f32>) -> Array2<f32>;
+    /// - An array `(output_size, samples)` representing the outputs of this layer.
+    fn forward(&self, input: ArrayViewD<f32>) -> ArrayD<f32>;
 
     /// Computes the backward pass of this layer for one batch, propagating the gradient
     /// back one stage.
     /// # Arguments
-    /// - `da`: A 2D array, the gradient of the loss with respect to this layer's output.
+    /// - `da`: An array, the gradient of the loss with respect to this layer's output.
     /// - `input`: The batch that was fed to this layer in the forward pass.
     /// - `output`: This layer's output from the forward pass.
     /// - `compute_input_gradient`: Whether to also compute the gradient with respect to `input`.
@@ -57,9 +57,9 @@ pub trait Layer: DynClone + Debug {
     ///   the `da` the upstream layer receives.
     fn backward(
         &self,
-        da: ArrayView2<f32>,
-        input: ArrayView2<f32>,
-        output: ArrayView2<f32>,
+        da: ArrayViewD<f32>,
+        input: ArrayViewD<f32>,
+        output: ArrayViewD<f32>,
         compute_input_gradient: bool,
     ) -> BackwardPass;
 

--- a/core/src/nn/layers/mod.rs
+++ b/core/src/nn/layers/mod.rs
@@ -6,9 +6,11 @@
 //! respect to its input. Layers are stateless with respect to the forward activations —
 //! the network threads those between layers — so a layer holds only its parameters.
 
+mod conv2d;
 mod dense;
 mod flatten;
 
+pub use conv2d::Conv2d;
 pub use dense::Dense;
 pub use flatten::Flatten;
 

--- a/core/src/nn/layers/mod.rs
+++ b/core/src/nn/layers/mod.rs
@@ -14,11 +14,14 @@ pub use conv2d::Conv2d;
 pub use dense::Dense;
 pub use flatten::Flatten;
 
+use crate::activations::{Activation, ActivationProvider};
 use crate::gradients::LayerGradients;
 use dyn_clone::DynClone;
-use ndarray::{ArrayD, ArrayView2, ArrayViewD, ArrayViewMutD};
+use ndarray::{Array, ArrayD, ArrayView2, ArrayViewD, ArrayViewMutD, Dimension};
 use std::any::Any;
-use std::fmt::Debug;
+use std::collections::HashMap;
+use std::fmt::{self, Debug};
+use std::sync::Arc;
 
 /// One trainable parameter of a layer, exposed for an optimizer to update in place.
 pub struct Parameter<'a> {
@@ -92,8 +95,16 @@ pub trait Layer: DynClone + Debug {
     /// Whether every parameter value is finite (no NaN or Inf).
     fn is_finite(&self) -> bool;
 
-    /// A short identifier for the layer type, such as `"dense"`.
-    fn kind(&self) -> &'static str;
+    /// The concrete kind of this layer.
+    fn kind(&self) -> LayerKind;
+
+    /// The layer's non-tensor hyperparameters, as name/value pairs: the configuration that
+    /// describes this layer beyond its [`named_tensors`](Layer::named_tensors), such as a
+    /// convolution's stride and padding or its activation's name. Empty for a layer with no
+    /// such configuration.
+    fn config(&self) -> Vec<(String, String)> {
+        vec![]
+    }
 
     /// The layer's parameters as named tensors.
     fn named_tensors(&self) -> Vec<(String, ArrayD<f32>)>;
@@ -113,3 +124,176 @@ pub trait Layer: DynClone + Debug {
 }
 
 dyn_clone::clone_trait_object!(Layer);
+
+/// The concrete kind of a [`Layer`]. It names the layer type and rebuilds a layer of that
+/// kind from its [`config`](Layer::config) and [`named_tensors`](Layer::named_tensors) via
+/// [`instantiate`](LayerKind::instantiate).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LayerKind {
+    /// A fully connected [`Dense`] layer.
+    Dense,
+    /// A 2D convolution [`Conv2d`] layer.
+    Conv2d,
+    /// A reshaping [`Flatten`] layer.
+    Flatten,
+}
+
+impl LayerKind {
+    /// The stable string tag naming this kind.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LayerKind::Dense => "dense",
+            LayerKind::Conv2d => "conv2d",
+            LayerKind::Flatten => "flatten",
+        }
+    }
+
+    /// Builds a layer of this kind from its configuration and tensors.
+    /// # Arguments
+    /// - `config`: The layer's non-tensor hyperparameters, as produced by [`Layer::config`].
+    /// - `tensors`: The layer's named tensors, as produced by [`Layer::named_tensors`].
+    pub fn instantiate(
+        &self,
+        config: &HashMap<String, String>,
+        tensors: HashMap<String, ArrayD<f32>>,
+    ) -> Result<Box<dyn Layer>, LayerConfigError> {
+        Ok(match self {
+            LayerKind::Dense => Box::new(Dense::from_config(config, tensors)?),
+            LayerKind::Conv2d => Box::new(Conv2d::from_config(config, tensors)?),
+            LayerKind::Flatten => Box::new(Flatten::from_config(config, tensors)?),
+        })
+    }
+}
+
+impl TryFrom<&str> for LayerKind {
+    type Error = LayerConfigError;
+
+    fn try_from(tag: &str) -> Result<Self, LayerConfigError> {
+        match tag {
+            "dense" => Ok(LayerKind::Dense),
+            "conv2d" => Ok(LayerKind::Conv2d),
+            "flatten" => Ok(LayerKind::Flatten),
+            other => Err(LayerConfigError::UnknownKind(other.to_string())),
+        }
+    }
+}
+
+/// Error returned when a layer cannot be built from its configuration and tensors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LayerConfigError {
+    /// A required configuration key was absent.
+    MissingConfig(String),
+    /// A configuration value could not be parsed.
+    InvalidConfig {
+        /// The offending key.
+        key: String,
+        /// Why the value was rejected.
+        reason: String,
+    },
+    /// A required tensor was absent.
+    MissingTensor(String),
+    /// A tensor did not have the rank the layer requires.
+    WrongTensorRank {
+        /// The tensor's name.
+        name: String,
+        /// The rank the layer requires.
+        expected: usize,
+        /// The rank the tensor actually had.
+        got: usize,
+    },
+    /// The named activation is not registered.
+    UnknownActivation(String),
+    /// The kind tag does not name a known layer.
+    UnknownKind(String),
+}
+
+impl fmt::Display for LayerConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LayerConfigError::MissingConfig(key) => write!(f, "missing config key `{key}`"),
+            LayerConfigError::InvalidConfig { key, reason } => {
+                write!(f, "config key `{key}` is invalid: {reason}")
+            }
+            LayerConfigError::MissingTensor(name) => write!(f, "missing tensor `{name}`"),
+            LayerConfigError::WrongTensorRank {
+                name,
+                expected,
+                got,
+            } => write!(f, "tensor `{name}` has rank {got}, expected {expected}"),
+            LayerConfigError::UnknownActivation(name) => {
+                write!(f, "unknown activation function: {name}")
+            }
+            LayerConfigError::UnknownKind(tag) => write!(f, "unknown layer kind: {tag}"),
+        }
+    }
+}
+
+impl std::error::Error for LayerConfigError {}
+
+/// Reads a required string entry from a layer's configuration.
+fn config_str<'a>(
+    config: &'a HashMap<String, String>,
+    key: &str,
+) -> Result<&'a str, LayerConfigError> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .ok_or_else(|| LayerConfigError::MissingConfig(key.to_string()))
+}
+
+/// Reads a required unsigned integer entry from a layer's configuration.
+fn config_usize(config: &HashMap<String, String>, key: &str) -> Result<usize, LayerConfigError> {
+    config_str(config, key)?
+        .parse()
+        .map_err(
+            |e: std::num::ParseIntError| LayerConfigError::InvalidConfig {
+                key: key.to_string(),
+                reason: e.to_string(),
+            },
+        )
+}
+
+/// Reads a comma-separated dimension list (e.g. `"1,28,28"`) from a layer's configuration.
+fn config_dims(
+    config: &HashMap<String, String>,
+    key: &str,
+) -> Result<Vec<usize>, LayerConfigError> {
+    config_str(config, key)?
+        .split(',')
+        .map(|part| {
+            part.trim()
+                .parse::<usize>()
+                .map_err(|e| LayerConfigError::InvalidConfig {
+                    key: key.to_string(),
+                    reason: e.to_string(),
+                })
+        })
+        .collect()
+}
+
+/// Resolves the activation named under `"activation"` in a layer's configuration.
+fn config_activation(
+    config: &HashMap<String, String>,
+) -> Result<Arc<dyn Activation>, LayerConfigError> {
+    let name = config_str(config, "activation")?;
+    ActivationProvider::get_by_name(name)
+        .ok_or_else(|| LayerConfigError::UnknownActivation(name.to_string()))
+}
+
+/// Removes a required tensor and casts it to the rank `D` the layer expects.
+fn take_tensor<D: Dimension>(
+    tensors: &mut HashMap<String, ArrayD<f32>>,
+    name: &str,
+) -> Result<Array<f32, D>, LayerConfigError> {
+    let tensor = tensors
+        .remove(name)
+        .ok_or_else(|| LayerConfigError::MissingTensor(name.to_string()))?;
+    let got = tensor.ndim();
+    tensor
+        .into_dimensionality::<D>()
+        .map_err(|_| LayerConfigError::WrongTensorRank {
+            name: name.to_string(),
+            expected: D::NDIM.unwrap_or(got),
+            got,
+        })
+}

--- a/core/src/nn/layers/mod.rs
+++ b/core/src/nn/layers/mod.rs
@@ -74,9 +74,9 @@ pub trait Layer: DynClone + Debug {
     /// returned by [`backward`](Layer::backward).
     fn parameters_mut(&mut self) -> Vec<Parameter<'_>>;
 
-    /// The per-sample input shape this layer expects, the sample axis excluded — the
-    /// single source of truth for the layer's input geometry (e.g. `[features]` for a
-    /// dense layer, `[channels, height, width]` for a convolution).
+    /// The per-sample input shape this layer expects, the sample axis excluded
+    /// (e.g. `[features]` for a dense layer, `[channels, height, width]` for a
+    /// convolution).
     fn input_shape(&self) -> Vec<usize>;
 
     /// The per-sample output shape this layer produces, the sample axis excluded.

--- a/core/src/nn/layers/mod.rs
+++ b/core/src/nn/layers/mod.rs
@@ -125,9 +125,8 @@ pub trait Layer: DynClone + Debug {
 
 dyn_clone::clone_trait_object!(Layer);
 
-/// The concrete kind of a [`Layer`]. It names the layer type and rebuilds a layer of that
-/// kind from its [`config`](Layer::config) and [`named_tensors`](Layer::named_tensors) via
-/// [`instantiate`](LayerKind::instantiate).
+/// The concrete kind of a [`Layer`], used to build one from its
+/// [`config`](Layer::config) and [`named_tensors`](Layer::named_tensors).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LayerKind {
     /// A fully connected [`Dense`] layer.

--- a/core/src/nn/layers/mod.rs
+++ b/core/src/nn/layers/mod.rs
@@ -297,3 +297,57 @@ fn take_tensor<D: Dimension>(
             got,
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_tags_round_trip_and_reject_unknown() {
+        for kind in [LayerKind::Dense, LayerKind::Conv2d, LayerKind::Flatten] {
+            assert_eq!(LayerKind::try_from(kind.as_str()), Ok(kind));
+        }
+        assert_eq!(
+            LayerKind::try_from("mystery"),
+            Err(LayerConfigError::UnknownKind("mystery".to_string()))
+        );
+    }
+
+    #[test]
+    fn config_usize_reports_the_offending_key_on_a_non_integer_value() {
+        let config = HashMap::from([("stride".to_string(), "wide".to_string())]);
+        let error = config_usize(&config, "stride").unwrap_err();
+
+        assert!(
+            matches!(&error, LayerConfigError::InvalidConfig { key, .. } if key == "stride"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn config_dims_rejects_a_non_integer_dimension() {
+        let config = HashMap::from([("shape".to_string(), "2,x,4".to_string())]);
+        let error = config_dims(&config, "shape").unwrap_err();
+
+        assert!(
+            matches!(&error, LayerConfigError::InvalidConfig { key, .. } if key == "shape"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn errors_display_their_key_and_tag() {
+        let invalid = LayerConfigError::InvalidConfig {
+            key: "stride".to_string(),
+            reason: "not a number".to_string(),
+        };
+        assert_eq!(
+            invalid.to_string(),
+            "config key `stride` is invalid: not a number"
+        );
+        assert_eq!(
+            LayerConfigError::UnknownKind("mystery".to_string()).to_string(),
+            "unknown layer kind: mystery"
+        );
+    }
+}

--- a/core/src/nn/layers/mod.rs
+++ b/core/src/nn/layers/mod.rs
@@ -71,11 +71,23 @@ pub trait Layer: DynClone + Debug {
     /// returned by [`backward`](Layer::backward).
     fn parameters_mut(&mut self) -> Vec<Parameter<'_>>;
 
-    /// The number of input features this layer expects.
-    fn input_size(&self) -> usize;
+    /// The per-sample input shape this layer expects, the sample axis excluded — the
+    /// single source of truth for the layer's input geometry (e.g. `[features]` for a
+    /// dense layer, `[channels, height, width]` for a convolution).
+    fn input_shape(&self) -> Vec<usize>;
 
-    /// The number of output features this layer produces.
-    fn output_size(&self) -> usize;
+    /// The per-sample output shape this layer produces, the sample axis excluded.
+    fn output_shape(&self) -> Vec<usize>;
+
+    /// The number of input features this layer expects: the product of [`input_shape`](Layer::input_shape).
+    fn input_size(&self) -> usize {
+        self.input_shape().iter().product()
+    }
+
+    /// The number of output features this layer produces: the product of [`output_shape`](Layer::output_shape).
+    fn output_size(&self) -> usize {
+        self.output_shape().iter().product()
+    }
 
     /// Whether every parameter value is finite (no NaN or Inf).
     fn is_finite(&self) -> bool;

--- a/core/src/nn/layers/mod.rs
+++ b/core/src/nn/layers/mod.rs
@@ -7,8 +7,10 @@
 //! the network threads those between layers — so a layer holds only its parameters.
 
 mod dense;
+mod flatten;
 
 pub use dense::Dense;
+pub use flatten::Flatten;
 
 use crate::gradients::LayerGradients;
 use dyn_clone::DynClone;

--- a/core/src/nn/loss_functions/cross_entropy_loss.rs
+++ b/core/src/nn/loss_functions/cross_entropy_loss.rs
@@ -21,12 +21,6 @@ impl CrossEntropyLoss {
     /// and the upper clamp a no-op. A saturated sigmoid output of exactly `1.0` would
     /// then drive the binary-CE gradient's `p(1 − p)` denominator to zero — `NaN`/`inf`.
     pub(crate) const PROBABILITY_EPSILON: f32 = 1e-7;
-
-    /// Clips the predicted probabilities so that they lie within a safe numerical range
-    /// to prevent invalid logarithms during loss computation.
-    pub(crate) fn clip_probabilities(probabilities: &ArrayView2<f32>) -> Array2<f32> {
-        probabilities.mapv(|p| p.clamp(Self::PROBABILITY_EPSILON, 1.0 - Self::PROBABILITY_EPSILON))
-    }
 }
 
 impl LossFunction for CrossEntropyLoss {
@@ -43,7 +37,7 @@ impl LossFunction for CrossEntropyLoss {
     /// # Returns
     /// Average loss over the batch.
     fn compute(&self, predictions: ArrayView2<f32>, targets: ArrayView2<f32>) -> f32 {
-        let clipped = Self::clip_probabilities(&predictions);
+        let clipped = self.stabilize(predictions);
         let n_samples = predictions.ncols() as f32;
         let log_p = clipped.mapv(|p| p.ln());
 
@@ -59,9 +53,10 @@ impl LossFunction for CrossEntropyLoss {
 
     /// Computes ∂L/∂a — the gradient of the loss with respect to the predicted probabilities.
     ///
-    /// Expects `predictions` to be clipped to a safe interior of (0, 1) by the caller;
-    /// no clipping is applied here so that the caller can pass identical values to the
-    /// activation's `vjp`, ensuring exact compositional cancellation.
+    /// Expects `predictions` to be clipped to a safe interior of (0, 1) by the caller
+    /// (via [`stabilize`](LossFunction::stabilize)); no clipping is applied here so that
+    /// the caller can pass identical values to the activation's `vjp`, ensuring exact
+    /// compositional cancellation.
     ///
     /// # Arguments
     /// * `predictions` - Same as in `compute`.
@@ -80,6 +75,12 @@ impl LossFunction for CrossEntropyLoss {
             // Multi-class CE: ∂L/∂p_i = -y_i / p_i
             -targets.to_owned() / predictions.to_owned()
         }
+    }
+
+    /// Clips the predicted probabilities into the open interval `(0, 1)` so that `ln(p)`
+    /// stays finite and the binary gradient's `p(1 − p)` denominator never reaches zero.
+    fn stabilize(&self, predictions: ArrayView2<f32>) -> Array2<f32> {
+        predictions.mapv(|p| p.clamp(Self::PROBABILITY_EPSILON, 1.0 - Self::PROBABILITY_EPSILON))
     }
 }
 
@@ -101,7 +102,7 @@ mod tests {
     #[test]
     fn clip_keeps_saturated_probabilities_off_the_open_ends() {
         // Regression: a saturated 0.0/1.0 must land strictly inside (0, 1).
-        let clipped = CrossEntropyLoss::clip_probabilities(&array![[0.0, 1.0]].view());
+        let clipped = CrossEntropyLoss.stabilize(array![[0.0, 1.0]].view());
         assert!(clipped.iter().all(|&p| p > 0.0 && p < 1.0), "{clipped:?}");
     }
 
@@ -114,7 +115,7 @@ mod tests {
         assert!(loss.is_finite() && loss >= 0.0, "loss = {loss}");
 
         // gradient() expects pre-clipped inputs, mirroring the backward pass.
-        let safe = CrossEntropyLoss::clip_probabilities(&predictions.view());
+        let safe = CrossEntropyLoss.stabilize(predictions.view());
         let grad = CrossEntropyLoss.gradient(safe.view(), targets.view());
         assert!(grad.iter().all(|v| v.is_finite()), "grad = {grad:?}");
     }

--- a/core/src/nn/loss_functions/mod.rs
+++ b/core/src/nn/loss_functions/mod.rs
@@ -18,8 +18,20 @@ pub trait LossFunction: Send + Sync {
 
     /// Computes the gradient of the loss with respect to the predicted values.
     ///
+    /// Assumes `predictions` has already been passed through [`stabilize`](Self::stabilize).
+    ///
     /// # Arguments
     /// * `predictions` - A 2D array where each row represents a predicted output for a sample.
     /// * `targets` - A 2D array where each row represents the expected (true) output for a sample.
     fn gradient(&self, predictions: ArrayView2<f32>, targets: ArrayView2<f32>) -> Array2<f32>;
+
+    /// Projects `predictions` into the numerically safe domain that `compute` and
+    /// `gradient` assume. The default is the identity; a loss whose domain is singular
+    /// (e.g. cross-entropy's `ln` and `p(1 − p)` denominator) overrides it.
+    ///
+    /// Kept separate from `gradient` so the caller can feed the *same* stabilized values
+    /// to the output activation's `vjp`, making their product cancel exactly.
+    fn stabilize(&self, predictions: ArrayView2<f32>) -> Array2<f32> {
+        predictions.to_owned()
+    }
 }

--- a/core/src/nn/mod.rs
+++ b/core/src/nn/mod.rs
@@ -1,5 +1,6 @@
 pub mod accuracies;
 pub mod activations;
+pub mod affine;
 pub mod classification;
 pub mod evaluation;
 pub mod evaluation_history;

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -7,7 +7,7 @@
 use crate::activations::{Activation, SIGMOID, SOFTMAX};
 use crate::data::scalers::{Scaler, ScalerFeatureMismatch, ScalerMethod};
 use crate::layers::{Dense, Layer};
-use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Axis, Ix2};
+use ndarray::{Array1, Array2, ArrayD, ArrayView1, ArrayView2, Axis, Ix2};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::rngs::StdRng;
 use std::fmt;
@@ -66,7 +66,7 @@ impl std::error::Error for LayerPlanError {}
 /// Returns the last activation from a vector of activations.
 /// # Panics
 /// - When the `activations` vector is empty.
-pub fn last_activation(activations: &[Array2<f32>]) -> Array2<f32> {
+pub fn last_activation(activations: &[ArrayD<f32>]) -> ArrayD<f32> {
     activations
         .last()
         .expect("Ensure activations is not empty.")
@@ -186,19 +186,15 @@ impl NeuralNetwork {
     pub fn forward(
         &self,
         inputs: ArrayView2<f32>,
-    ) -> Result<Vec<Array2<f32>>, FeatureCountMismatch> {
+    ) -> Result<Vec<ArrayD<f32>>, FeatureCountMismatch> {
         self.validate_inputs(inputs)?;
 
         Ok(self
             .layers
             .iter()
-            .fold(vec![inputs.to_owned()], |mut acc, layer| {
-                let output = layer.forward(acc.last().unwrap().view().into_dyn());
-                acc.push(
-                    output
-                        .into_dimensionality::<Ix2>()
-                        .expect("The MLP threads rank-2 (features, samples) activations."),
-                );
+            .fold(vec![inputs.to_owned().into_dyn()], |mut acc, layer| {
+                let output = layer.forward(acc.last().unwrap().view());
+                acc.push(output);
                 acc
             }))
     }
@@ -226,7 +222,9 @@ impl NeuralNetwork {
     /// # Errors
     /// [`FeatureCountMismatch`] when the feature rows do not match [`Self::input_size`].
     pub fn predict(&self, inputs: ArrayView2<f32>) -> Result<Array2<f32>, FeatureCountMismatch> {
-        let output = last_activation(&self.forward(inputs)?);
+        let output = last_activation(&self.forward(inputs)?)
+            .into_dimensionality::<Ix2>()
+            .expect("the output layer produces rank-2 (classes, samples) activations");
         assert!(
             output.iter().all(|v| v.is_finite()),
             "non-finite predictions (NaN or inf): the model likely diverged during training"
@@ -595,7 +593,7 @@ mod tests {
         let activations = model.forward(inputs.view()).unwrap();
         let predicted = model.predict(inputs.view()).unwrap();
 
-        assert_eq!(predicted, *activations.last().unwrap());
+        assert_eq!(predicted.into_dyn(), *activations.last().unwrap());
     }
 
     #[test]

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -7,7 +7,7 @@
 use crate::activations::{Activation, SIGMOID, SOFTMAX};
 use crate::data::scalers::{Scaler, ScalerFeatureMismatch, ScalerMethod};
 use crate::layers::{Dense, Layer};
-use ndarray::{Array1, Array2, ArrayD, ArrayView, ArrayView1, ArrayView2, Axis, Dimension, Ix2};
+use ndarray::{Array1, Array2, ArrayD, ArrayView, Axis, Dimension, Ix2};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::rngs::StdRng;
 use std::fmt;
@@ -254,19 +254,6 @@ impl NeuralNetwork {
         );
         Ok(output)
     }
-
-    /// Predicts the output of the network given a single input vector, returning the final activation.
-    /// # Arguments
-    /// - `input`: A 1D array representing a single input vector to the network.
-    /// # Errors
-    /// [`InputShapeMismatch`] when `input`'s length does not match [`Self::input_size`].
-    pub fn predict_single(
-        &self,
-        input: ArrayView1<f32>,
-    ) -> Result<Array1<f32>, InputShapeMismatch> {
-        let inputs = input.insert_axis(Axis(1));
-        Ok(self.predict(inputs)?.column(0).to_owned())
-    }
 }
 
 /// A trained [`NeuralNetwork`] paired with the scaler fitted alongside it.
@@ -284,33 +271,41 @@ impl Predictor {
         Self { network, scaler }
     }
 
-    /// Predicts on a single raw input vector, applying the scaler first when present.
+    /// Predicts on a single raw instance of any rank (samples-last, minus the sample
+    /// axis), applying the scaler first when present.
     ///
     /// # Errors
-    /// [`PredictionError::Scaling`] when a scaler is present and the input does not match
-    /// its fitted feature count, or [`PredictionError::Network`] when it does not match the
-    /// network's input size.
-    pub fn predict_single(&self, input: ArrayView1<f32>) -> Result<Array1<f32>, PredictionError> {
-        let mut input = input.to_owned();
-        if let Some(scaler) = &self.scaler {
-            scaler.apply_single_inplace(input.view_mut())?;
-        }
-        Ok(self.network.predict_single(input.view())?)
+    /// [`PredictionError::Scaling`] when a scaler is present and the instance does not
+    /// match its fitted feature count, or [`PredictionError::Network`] when it does not
+    /// match the network's input shape.
+    pub fn predict_single<D: Dimension>(
+        &self,
+        input: ArrayView<f32, D>,
+    ) -> Result<Array1<f32>, PredictionError> {
+        let sample_axis = input.ndim();
+        let inputs = input.insert_axis(Axis(sample_axis));
+        Ok(self.predict(inputs)?.column(0).to_owned())
     }
 
-    /// Predicts on a batch of raw inputs `(features, samples)`, applying the scaler
-    /// first when present.
+    /// Predicts on a batch of raw inputs of any rank (samples on the trailing axis),
+    /// applying the scaler first when present.
     ///
     /// # Errors
     /// [`PredictionError::Scaling`] when a scaler is present and the inputs do not match
     /// its fitted feature count, or [`PredictionError::Network`] when they do not match the
-    /// network's input size.
-    pub fn predict(&self, inputs: ArrayView2<f32>) -> Result<Array2<f32>, PredictionError> {
-        let mut inputs = inputs.to_owned();
-        if let Some(scaler) = &self.scaler {
-            scaler.apply_inplace(inputs.view_mut().reversed_axes())?;
+    /// network's input shape.
+    pub fn predict<D: Dimension>(
+        &self,
+        inputs: ArrayView<f32, D>,
+    ) -> Result<Array2<f32>, PredictionError> {
+        match &self.scaler {
+            Some(scaler) => {
+                let mut owned = inputs.to_owned().into_dyn();
+                scaler.apply_inplace(owned.view_mut())?;
+                Ok(self.network.predict(owned.view())?)
+            }
+            None => Ok(self.network.predict(inputs)?),
         }
-        Ok(self.network.predict(inputs.view())?)
     }
 }
 
@@ -585,6 +580,45 @@ mod tests {
     }
 
     #[test]
+    fn predictor_applies_a_per_feature_scaler_to_a_spatial_batch() {
+        use crate::data::scalers::ScalerKind;
+        use crate::layers::Flatten;
+        use ndarray::{Array4, s};
+
+        // Flatten (2×2×2 → 8) → Dense (1 sigmoid, binary): a network that accepts a
+        // rank-4 spatial batch. Two identical builds (same seed) let one go into the
+        // predictor and the other check the bare network on manually scaled inputs.
+        let network = |seed| {
+            NeuralNetwork::single(Flatten::new(vec![2, 2, 2])).with_layer(Dense::initialization(
+                8,
+                &NeuronLayerSpec::output_for(2),
+                &mut StdRng::seed_from_u64(seed),
+            ))
+        };
+
+        // (features=2, height=2, width=2, samples=4), the two features on different scales.
+        let inputs = Array4::from_shape_fn((2, 2, 2, 4), |(f, h, w, s)| {
+            (f as f32 + 1.0) * 10.0 * (h + w + s) as f32
+        });
+        let scaler = ScalerKind::MinMax.fit(inputs.view());
+        let predictor = Predictor::new(network(1), Some(scaler.clone()));
+
+        // The predictor scales the rank-4 batch per feature before the network: its
+        // output matches the bare network run on the manually scaled inputs.
+        let via_predictor = predictor.predict(inputs.view()).unwrap();
+        let mut scaled = inputs.clone().into_dyn();
+        scaler.apply_inplace(scaled.view_mut()).unwrap();
+        let via_network = network(1).predict(scaled.view()).unwrap();
+        assert_eq!(via_predictor, via_network);
+
+        // A single rank-3 instance is scaled with the same parameters, so it matches
+        // the corresponding column of the batch prediction.
+        let instance = inputs.slice(s![.., .., .., 0]).to_owned();
+        let single = predictor.predict_single(instance.view()).unwrap();
+        assert_eq!(single, via_predictor.column(0).to_owned());
+    }
+
+    #[test]
     fn validate_inputs_rejects_a_matching_count_but_wrong_arrangement() {
         use crate::layers::Conv2d;
 
@@ -747,25 +781,6 @@ mod tests {
         let multi =
             NeuralNetwork::initialization(3, &NeuronLayerSpec::network_for(vec![4], &*RELU, 5), 0);
         assert_eq!(multi.n_classes(), 5);
-    }
-
-    #[test]
-    fn predict_single_matches_predict_on_one_sample() {
-        let specs = NeuronLayerSpec::network_for(vec![4], &*RELU, 2);
-        let model = NeuralNetwork::initialization(3, &specs, 0);
-
-        let sample = array![1.0, 2.0, 3.0];
-        let single = model.predict_single(sample.view()).unwrap();
-
-        let batch = array![[1.0], [2.0], [3.0]]; // (features, 1 sample)
-        let batch_output = model.predict(batch.view()).unwrap();
-
-        assert!(
-            (single - batch_output.column(0))
-                .mapv(f32::abs)
-                .iter()
-                .all(|&v| v < 1e-6)
-        );
     }
 
     // infer_from branches — complexity score = ln(n_features * n_classes / n_samples)

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -69,7 +69,7 @@ impl std::error::Error for LayerPlanError {}
 pub fn last_activation(activations: &[ArrayD<f32>]) -> ArrayD<f32> {
     activations
         .last()
-        .expect("Ensure activations is not empty.")
+        .expect("forward always yields at least the input activation")
         .to_owned()
 }
 
@@ -78,7 +78,10 @@ impl NeuralNetwork {
     /// # Panics
     /// When `layers` is empty.
     pub fn new(layers: Vec<Box<dyn Layer>>) -> Self {
-        assert!(!layers.is_empty(), "a network must have at least one layer");
+        assert!(
+            !layers.is_empty(),
+            "A network must have at least one layer."
+        );
         NeuralNetwork { layers }
     }
 
@@ -95,7 +98,7 @@ impl NeuralNetwork {
             assert_eq!(
                 layer.input_size(),
                 last.output_size(),
-                "layer input size must match the previous layer's output size"
+                "Layer input size must match the previous layer's output size."
             );
         }
         self.layers.push(Box::new(layer));

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -643,6 +643,34 @@ mod tests {
     }
 
     #[test]
+    fn predict_surfaces_a_scaler_feature_mismatch_as_a_scaling_error() {
+        use crate::data::scalers::ScalerKind;
+        use crate::layers::Flatten;
+
+        // A scaler fitted on 2 leading-axis features, then applied to a batch with 3:
+        // the scaler's mismatch surfaces through `?` as PredictionError::Scaling.
+        let network =
+            NeuralNetwork::single(Flatten::new(vec![2, 2, 2])).with_layer(Dense::initialization(
+                8,
+                &NeuronLayerSpec::output_for(2),
+                &mut StdRng::seed_from_u64(0),
+            ));
+        let fit_batch = Array::from_shape_fn(IxDyn(&[2, 4]), |d| (d[0] + d[1]) as f32);
+        let scaler = ScalerKind::MinMax.fit(fit_batch.view());
+        let predictor = Predictor::new(network, Some(scaler));
+
+        let wrong = ArrayD::<f32>::ones(IxDyn(&[3, 2, 2, 5]));
+        let error = predictor.predict(wrong.view()).unwrap_err();
+
+        assert!(
+            matches!(error, PredictionError::Scaling(_)),
+            "unexpected error: {error}"
+        );
+        // The Scaling arm delegates its Display to the underlying scaler error.
+        assert!(error.to_string().contains("features"));
+    }
+
+    #[test]
     fn validate_inputs_rejects_a_matching_count_but_wrong_arrangement() {
         use crate::layers::Conv2d;
 

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -603,7 +603,7 @@ mod tests {
     #[should_panic(expected = "non-finite predictions")]
     fn predict_panics_when_model_has_diverged() {
         let mut model = make_network(Array2::zeros((1, 2)), Array1::zeros(1), SIGMOID.clone());
-        *dense_mut(&mut model, 0).weights_mut() = array![[f32::NAN, 0.0]];
+        *dense_mut(&mut model, 0).affine_mut().weights_mut() = array![[f32::NAN, 0.0]];
         let inputs = array![[1.0], [1.0]];
         let _ = model.predict(inputs.view());
     }
@@ -617,14 +617,14 @@ mod tests {
     #[test]
     fn is_finite_detects_nan_in_weights() {
         let mut model = make_network(Array2::zeros((1, 2)), Array1::zeros(1), SIGMOID.clone());
-        dense_mut(&mut model, 0).weights_mut()[[0, 0]] = f32::NAN;
+        dense_mut(&mut model, 0).affine_mut().weights_mut()[[0, 0]] = f32::NAN;
         assert!(!model.is_finite());
     }
 
     #[test]
     fn is_finite_detects_inf_in_biases() {
         let mut model = make_network(Array2::zeros((1, 2)), Array1::zeros(1), SIGMOID.clone());
-        dense_mut(&mut model, 0).biases_mut()[0] = f32::INFINITY;
+        dense_mut(&mut model, 0).affine_mut().biases_mut()[0] = f32::INFINITY;
         assert!(!model.is_finite());
     }
 

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -7,7 +7,7 @@
 use crate::activations::{Activation, SIGMOID, SOFTMAX};
 use crate::data::scalers::{Scaler, ScalerFeatureMismatch, ScalerMethod};
 use crate::layers::{Dense, Layer};
-use ndarray::{Array1, Array2, ArrayD, ArrayView1, ArrayView2, Axis, Ix2};
+use ndarray::{Array1, Array2, ArrayD, ArrayView, ArrayView1, ArrayView2, Axis, Dimension, Ix2};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::rngs::StdRng;
 use std::fmt;
@@ -182,20 +182,27 @@ impl NeuralNetwork {
     }
 
     /// Computes the forward pass through the network, returning the activations of each layer.
+    ///
+    /// The input is rank-agnostic: its last axis is the sample axis and its leading axes are the
+    /// per-sample features, so a dense network takes a rank-2 `(features, samples)` batch while a
+    /// spatial one (e.g. a leading `Conv2d`) takes a higher-rank `(channels, height, width, samples)`
+    /// batch. Each layer reshapes its input as it needs.
     /// # Errors
-    /// [`FeatureCountMismatch`] when the feature rows of `inputs` do not match [`Self::input_size`].
+    /// [`FeatureCountMismatch`] when the product of `inputs`' leading (feature) axes differs from
+    /// [`Self::input_size`].
     /// # Arguments
-    /// - `inputs`: A 2D array representing the inputs to the network.
-    pub fn forward(
+    /// - `inputs`: An array whose last axis is samples and whose leading axes are the features.
+    pub fn forward<D: Dimension>(
         &self,
-        inputs: ArrayView2<f32>,
+        inputs: ArrayView<f32, D>,
     ) -> Result<Vec<ArrayD<f32>>, FeatureCountMismatch> {
-        self.validate_inputs(inputs)?;
+        let inputs = inputs.into_dyn();
+        self.validate_inputs(inputs.view())?;
 
         Ok(self
             .layers
             .iter()
-            .fold(vec![inputs.to_owned().into_dyn()], |mut acc, layer| {
+            .fold(vec![inputs.to_owned()], |mut acc, layer| {
                 let output = layer.forward(acc.last().unwrap().view());
                 acc.push(output);
                 acc
@@ -207,13 +214,19 @@ impl NeuralNetwork {
         self.layers.iter().all(|layer| layer.is_finite())
     }
 
-    /// Validates that `inputs` `(features, samples)` carry the feature count this network expects.
+    /// Validates that `inputs` carry the feature count this network expects: the sample axis is
+    /// last, so the leading axes are the per-sample features and must multiply to
+    /// [`Self::input_size`].
     ///
     /// # Errors
-    /// [`FeatureCountMismatch`] when the feature rows differ from [`Self::input_size`].
-    pub fn validate_inputs(&self, inputs: ArrayView2<f32>) -> Result<(), FeatureCountMismatch> {
+    /// [`FeatureCountMismatch`] when the leading axes' product differs from [`Self::input_size`].
+    pub fn validate_inputs<D: Dimension>(
+        &self,
+        inputs: ArrayView<f32, D>,
+    ) -> Result<(), FeatureCountMismatch> {
         let expected = self.input_size();
-        let found = inputs.nrows();
+        let shape = inputs.shape();
+        let found: usize = shape[..shape.len().saturating_sub(1)].iter().product();
         (found == expected)
             .then_some(())
             .ok_or(FeatureCountMismatch { expected, found })
@@ -221,10 +234,15 @@ impl NeuralNetwork {
 
     /// Predicts the output of the network given the inputs, returning the final activations.
     /// # Arguments
-    /// - `inputs`: A 2D array `(features, samples)` representing the inputs to the network.
+    /// - `inputs`: An array whose last axis is samples and whose leading axes are the features
+    ///   (rank-2 `(features, samples)` for a dense network, higher-rank for a spatial one).
     /// # Errors
-    /// [`FeatureCountMismatch`] when the feature rows do not match [`Self::input_size`].
-    pub fn predict(&self, inputs: ArrayView2<f32>) -> Result<Array2<f32>, FeatureCountMismatch> {
+    /// [`FeatureCountMismatch`] when the product of the leading (feature) axes differs from
+    /// [`Self::input_size`].
+    pub fn predict<D: Dimension>(
+        &self,
+        inputs: ArrayView<f32, D>,
+    ) -> Result<Array2<f32>, FeatureCountMismatch> {
         let output = last_activation(&self.forward(inputs)?)
             .into_dimensionality::<Ix2>()
             .expect("the output layer produces rank-2 (classes, samples) activations");
@@ -497,7 +515,7 @@ impl NeuronLayerSpec {
 mod tests {
     use super::*;
     use crate::activations::{RELU, SIGMOID};
-    use ndarray::{Array1, Array2, array};
+    use ndarray::{Array, Array1, Array2, IxDyn, array};
 
     fn make_network(
         weights: Array2<f32>,
@@ -528,6 +546,40 @@ mod tests {
         assert_eq!(model.layers[1].output_size(), 3);
 
         assert_eq!(model.summary(), "[3] -> 4-relu -> 3-softmax");
+    }
+
+    #[test]
+    fn convolutional_network_predicts_end_to_end_on_a_spatial_batch() {
+        use crate::layers::{Conv2d, Flatten};
+
+        // Conv2d (1×4×4 → 2×2×2) → Flatten (8) → Dense (1 sigmoid, binary). The rank-4
+        // spatial batch threads through forward/predict unchanged; the Flatten collapses it
+        // to the rank-2 the Dense head consumes, and predict yields (classes, samples).
+        let conv = Conv2d::initialization(
+            (1, 4, 4),
+            2,
+            (3, 3),
+            1,
+            0,
+            RELU.clone(),
+            &mut StdRng::seed_from_u64(0),
+        );
+        let head = Dense::initialization(
+            8,
+            &NeuronLayerSpec::output_for(2),
+            &mut StdRng::seed_from_u64(1),
+        );
+        let model = NeuralNetwork::single(conv)
+            .with_layer(Flatten::new(vec![2, 2, 2]))
+            .with_layer(head);
+
+        // A spatial input the dense predict path could never accept: (channels, height, width, samples).
+        let inputs = Array::from_shape_fn(IxDyn(&[1, 4, 4, 3]), |idx| {
+            ((idx[1] + idx[2] + idx[3]) as f32).sin()
+        });
+        let output = model.predict(inputs.view()).unwrap();
+        assert_eq!(output.shape(), &[1, 3]); // (classes, samples)
+        assert!(output.iter().all(|&v| (0.0..=1.0).contains(&v)));
     }
 
     #[test]

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -92,13 +92,13 @@ impl NeuralNetwork {
 
     /// Appends a layer to the network, returning the network for chaining.
     /// # Panics
-    /// When the layer's input size does not match the current output size.
+    /// When the layer's input shape does not match the previous layer's output shape.
     pub fn with_layer(mut self, layer: impl Layer + 'static) -> Self {
         if let Some(last) = self.layers.last() {
             assert_eq!(
-                layer.input_size(),
-                last.output_size(),
-                "Layer input size must match the previous layer's output size."
+                layer.input_shape(),
+                last.output_shape(),
+                "Layer input shape must match the previous layer's output shape."
             );
         }
         self.layers.push(Box::new(layer));
@@ -188,14 +188,14 @@ impl NeuralNetwork {
     /// spatial one (e.g. a leading `Conv2d`) takes a higher-rank `(channels, height, width, samples)`
     /// batch. Each layer reshapes its input as it needs.
     /// # Errors
-    /// [`FeatureCountMismatch`] when the product of `inputs`' leading (feature) axes differs from
-    /// [`Self::input_size`].
+    /// [`InputShapeMismatch`] when `inputs`' leading (feature) axes differ from the network's
+    /// input shape.
     /// # Arguments
     /// - `inputs`: An array whose last axis is samples and whose leading axes are the features.
     pub fn forward<D: Dimension>(
         &self,
         inputs: ArrayView<f32, D>,
-    ) -> Result<Vec<ArrayD<f32>>, FeatureCountMismatch> {
+    ) -> Result<Vec<ArrayD<f32>>, InputShapeMismatch> {
         let inputs = inputs.into_dyn();
         self.validate_inputs(inputs.view())?;
 
@@ -214,22 +214,25 @@ impl NeuralNetwork {
         self.layers.iter().all(|layer| layer.is_finite())
     }
 
-    /// Validates that `inputs` carry the feature count this network expects: the sample axis is
-    /// last, so the leading axes are the per-sample features and must multiply to
-    /// [`Self::input_size`].
+    /// Validates that `inputs` carry the per-sample shape this network expects: the sample axis
+    /// is last, so the leading axes are the per-sample features and must equal the first layer's
+    /// [`input_shape`](crate::layers::Layer::input_shape).
     ///
     /// # Errors
-    /// [`FeatureCountMismatch`] when the leading axes' product differs from [`Self::input_size`].
+    /// [`InputShapeMismatch`] when the leading axes differ from the first layer's input shape.
     pub fn validate_inputs<D: Dimension>(
         &self,
         inputs: ArrayView<f32, D>,
-    ) -> Result<(), FeatureCountMismatch> {
-        let expected = self.input_size();
+    ) -> Result<(), InputShapeMismatch> {
+        let expected = self.layers[0].input_shape();
         let shape = inputs.shape();
-        let found: usize = shape[..shape.len().saturating_sub(1)].iter().product();
+        let found = &shape[..shape.len().saturating_sub(1)];
         (found == expected)
             .then_some(())
-            .ok_or(FeatureCountMismatch { expected, found })
+            .ok_or_else(|| InputShapeMismatch {
+                expected,
+                found: found.to_vec(),
+            })
     }
 
     /// Predicts the output of the network given the inputs, returning the final activations.
@@ -237,12 +240,11 @@ impl NeuralNetwork {
     /// - `inputs`: An array whose last axis is samples and whose leading axes are the features
     ///   (rank-2 `(features, samples)` for a dense network, higher-rank for a spatial one).
     /// # Errors
-    /// [`FeatureCountMismatch`] when the product of the leading (feature) axes differs from
-    /// [`Self::input_size`].
+    /// [`InputShapeMismatch`] when the leading (feature) axes differ from the network's input shape.
     pub fn predict<D: Dimension>(
         &self,
         inputs: ArrayView<f32, D>,
-    ) -> Result<Array2<f32>, FeatureCountMismatch> {
+    ) -> Result<Array2<f32>, InputShapeMismatch> {
         let output = last_activation(&self.forward(inputs)?)
             .into_dimensionality::<Ix2>()
             .expect("the output layer produces rank-2 (classes, samples) activations");
@@ -257,11 +259,11 @@ impl NeuralNetwork {
     /// # Arguments
     /// - `input`: A 1D array representing a single input vector to the network.
     /// # Errors
-    /// [`FeatureCountMismatch`] when `input`'s length does not match [`Self::input_size`].
+    /// [`InputShapeMismatch`] when `input`'s length does not match [`Self::input_size`].
     pub fn predict_single(
         &self,
         input: ArrayView1<f32>,
-    ) -> Result<Array1<f32>, FeatureCountMismatch> {
+    ) -> Result<Array1<f32>, InputShapeMismatch> {
         let inputs = input.insert_axis(Axis(1));
         Ok(self.predict(inputs)?.column(0).to_owned())
     }
@@ -312,35 +314,35 @@ impl Predictor {
     }
 }
 
-/// An instance's feature count did not match the network's input size.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FeatureCountMismatch {
-    /// The number of input features the network expects.
-    pub expected: usize,
-    /// The number of features the instance carries.
-    pub found: usize,
+/// An instance's per-sample shape did not match the network's input shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputShapeMismatch {
+    /// The per-sample input shape the network expects.
+    pub expected: Vec<usize>,
+    /// The per-sample shape the instance carries.
+    pub found: Vec<usize>,
 }
 
-impl fmt::Display for FeatureCountMismatch {
+impl fmt::Display for InputShapeMismatch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "instance has {} features but the model expects {}",
+            "instance has shape {:?} but the model expects {:?}",
             self.found, self.expected
         )
     }
 }
 
-impl std::error::Error for FeatureCountMismatch {}
+impl std::error::Error for InputShapeMismatch {}
 
 /// A [`Predictor`] rejected an instance: either its scaler or its network found the
 /// wrong number of features.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PredictionError {
     /// The scaler's fitted feature count did not match the input.
     Scaling(ScalerFeatureMismatch),
-    /// The network's input size did not match the input.
-    Network(FeatureCountMismatch),
+    /// The network's input shape did not match the input.
+    Network(InputShapeMismatch),
 }
 
 impl fmt::Display for PredictionError {
@@ -360,8 +362,8 @@ impl From<ScalerFeatureMismatch> for PredictionError {
     }
 }
 
-impl From<FeatureCountMismatch> for PredictionError {
-    fn from(error: FeatureCountMismatch) -> Self {
+impl From<InputShapeMismatch> for PredictionError {
+    fn from(error: InputShapeMismatch) -> Self {
         PredictionError::Network(error)
     }
 }
@@ -580,6 +582,60 @@ mod tests {
         let output = model.predict(inputs.view()).unwrap();
         assert_eq!(output.shape(), &[1, 3]); // (classes, samples)
         assert!(output.iter().all(|&v| (0.0..=1.0).contains(&v)));
+    }
+
+    #[test]
+    fn validate_inputs_rejects_a_matching_count_but_wrong_arrangement() {
+        use crate::layers::Conv2d;
+
+        // A Conv2d-first network expects a per-sample shape of (1, 4, 4) = 16 features. A
+        // rank-2 (16, samples) batch has the right feature count but the wrong arrangement:
+        // the product check accepted it, the shape check rejects it.
+        let conv = Conv2d::initialization(
+            (1, 4, 4),
+            2,
+            (3, 3),
+            1,
+            0,
+            RELU.clone(),
+            &mut StdRng::seed_from_u64(0),
+        );
+        let model = NeuralNetwork::single(conv);
+
+        let flat = Array2::<f32>::zeros((16, 5)); // 16 features, 5 samples — right count, flat.
+        let err = model.validate_inputs(flat.view()).unwrap_err();
+        assert_eq!(err.expected, vec![1, 4, 4]);
+        assert_eq!(err.found, vec![16]);
+
+        // The correctly-shaped rank-4 batch passes.
+        let spatial = ArrayD::<f32>::zeros(IxDyn(&[1, 4, 4, 5]));
+        assert!(model.validate_inputs(spatial.view()).is_ok());
+    }
+
+    #[test]
+    #[should_panic(expected = "Layer input shape must match the previous layer's output shape")]
+    fn with_layer_rejects_rank_mismatch_at_build_time() {
+        use crate::layers::Conv2d;
+
+        // Conv2d outputs a rank-3 (out_channels, out_h, out_w) per sample; feeding it straight
+        // into a Dense (rank-1 input) without a Flatten is a shape mismatch the build rejects,
+        // even though the feature counts could line up.
+        let conv = Conv2d::initialization(
+            (1, 4, 4),
+            2,
+            (3, 3),
+            1,
+            0,
+            RELU.clone(),
+            &mut StdRng::seed_from_u64(0),
+        );
+        // Conv2d output is (2, 2, 2) = 8 features; a Dense taking 8 inputs matches on count.
+        let head = Dense::initialization(
+            8,
+            &NeuronLayerSpec::output_for(2),
+            &mut StdRng::seed_from_u64(1),
+        );
+        let _ = NeuralNetwork::single(conv).with_layer(head);
     }
 
     #[test]

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -7,7 +7,7 @@
 use crate::activations::{Activation, SIGMOID, SOFTMAX};
 use crate::data::scalers::{Scaler, ScalerFeatureMismatch, ScalerMethod};
 use crate::layers::{Dense, Layer};
-use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Axis};
+use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Axis, Ix2};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::rngs::StdRng;
 use std::fmt;
@@ -193,7 +193,12 @@ impl NeuralNetwork {
             .layers
             .iter()
             .fold(vec![inputs.to_owned()], |mut acc, layer| {
-                acc.push(layer.forward(acc.last().unwrap().view()));
+                let output = layer.forward(acc.last().unwrap().view().into_dyn());
+                acc.push(
+                    output
+                        .into_dimensionality::<Ix2>()
+                        .expect("The MLP threads rank-2 (features, samples) activations."),
+                );
                 acc
             }))
     }

--- a/core/src/nn/model.rs
+++ b/core/src/nn/model.rs
@@ -165,16 +165,23 @@ impl NeuralNetwork {
         if out == 1 { 2 } else { out }
     }
 
-    /// Returns a summary of the network's architecture as a string,
-    /// showing the number of neurons in each layer, including the input layer.
+    /// Returns a summary of the network's architecture as a string, showing the per-sample
+    /// input shape and each layer's output shape (with its activation, when it has one).
     pub fn summary(&self) -> String {
-        once(format!("[{}]", self.input_size()))
+        fn shape(dims: &[usize]) -> String {
+            let dims = dims.iter().map(usize::to_string).collect::<Vec<_>>();
+            format!("[{}]", dims.join(", "))
+        }
+
+        once(shape(&self.layers[0].input_shape()))
             .chain(
                 self.layers
                     .iter()
                     .map(|layer| match layer.activation_name() {
-                        Some(activation) => format!("{}-{}", layer.output_size(), activation),
-                        None => layer.output_size().to_string(),
+                        Some(activation) => {
+                            format!("{}-{}", shape(&layer.output_shape()), activation)
+                        }
+                        None => shape(&layer.output_shape()),
                     }),
             )
             .collect::<Vec<String>>()
@@ -542,7 +549,24 @@ mod tests {
         assert_eq!(model.layers[0].output_size(), 4);
         assert_eq!(model.layers[1].output_size(), 3);
 
-        assert_eq!(model.summary(), "[3] -> 4-relu -> 3-softmax");
+        assert_eq!(model.summary(), "[3] -> [4]-relu -> [3]-softmax");
+    }
+
+    #[test]
+    fn summary_shows_per_sample_shapes_and_omits_the_suffix_for_a_layer_without_activation() {
+        use crate::layers::Flatten;
+
+        // Flatten (2×2×2 → 8) preserves the spatial input shape in the summary and carries
+        // no activation, so its segment is the bare output shape with no "-activation"
+        // suffix; the Dense head keeps its suffix.
+        let model =
+            NeuralNetwork::single(Flatten::new(vec![2, 2, 2])).with_layer(Dense::initialization(
+                8,
+                &NeuronLayerSpec::output_for(2),
+                &mut StdRng::seed_from_u64(0),
+            ));
+
+        assert_eq!(model.summary(), "[2, 2, 2] -> [8] -> [1]-sigmoid");
     }
 
     #[test]

--- a/core/src/nn/training/backprop.rs
+++ b/core/src/nn/training/backprop.rs
@@ -489,6 +489,64 @@ mod tests {
     }
 
     #[test]
+    fn training_a_convolutional_network_decreases_the_loss() {
+        use crate::activations::Activation;
+        use crate::layers::{Conv2d, Flatten};
+        use ndarray::Array4;
+
+        // Conv2d(1×4×4 → 2×2×2) → Flatten(8) → Dense(8 → 1, sigmoid binary): a spatial
+        // stack trained end-to-end from a rank-4 samples-last dataset.
+        let mut rng = StdRng::seed_from_u64(0);
+        let sigmoid: Arc<dyn Activation> = SIGMOID.clone();
+        let conv = Conv2d::initialization((1, 4, 4), 2, (3, 3), 1, 0, sigmoid, &mut rng);
+        let flatten = Flatten::new(vec![2, 2, 2]);
+        let head = Dense::initialization(8, &NeuronLayerSpec::output_for(2), &mut rng);
+        let mut model = NeuralNetwork::single(conv)
+            .with_layer(flatten)
+            .with_layer(head);
+
+        // Two linearly separable clusters: the first half bright (label 1), the rest
+        // dark (label 0), so the loss has a clear direction to fall in.
+        let n = 16;
+        let inputs = Array4::from_shape_fn((1, 4, 4, n), |(_, h, w, s)| {
+            let sign = if s < n / 2 { 1.0 } else { -1.0 };
+            sign * (0.5 + 0.1 * ((h + w) as f32).cos())
+        });
+        let targets = Array2::from_shape_fn((1, n), |(_, s)| if s < n / 2 { 1.0 } else { 0.0 });
+        let dataset = ModelDataset::new(inputs.clone(), targets.clone());
+
+        let loss: Arc<dyn LossFunction> = CROSS_ENTROPY_LOSS.clone();
+        let loss_now = |model: &NeuralNetwork| {
+            let pred = model.predict(inputs.view()).unwrap();
+            loss.compute(pred.view(), targets.view())
+        };
+
+        let initial = loss_now(&model);
+
+        let lr = LearningRate::new(0.5).unwrap();
+        let mut optimizer = StochasticGradientDescent::new(lr, WeightDecay::ZERO);
+        let mut scheduler = ConstantScheduler::new(lr);
+        for _ in 0..100 {
+            model
+                .train(
+                    &dataset,
+                    &loss,
+                    &mut optimizer as &mut dyn Optimizer,
+                    &mut scheduler as &mut dyn Scheduler,
+                    &GradientClipping::None,
+                    None,
+                )
+                .unwrap();
+        }
+
+        let final_loss = loss_now(&model);
+        assert!(
+            final_loss < initial,
+            "training a CNN should decrease the loss: initial={initial:.6}, final={final_loss:.6}"
+        );
+    }
+
+    #[test]
     fn training_is_deterministic_for_a_fixed_seed() {
         // Two runs with the same seed and data produce bit-identical weights.
         fn run() -> NeuralNetwork {

--- a/core/src/nn/training/backprop.rs
+++ b/core/src/nn/training/backprop.rs
@@ -213,10 +213,10 @@ mod tests {
         let mut model = NeuralNetwork::initialization(2, &specs, 0);
 
         // Fixed weights for reproducibility
-        *dense_mut(&mut model, 0).weights_mut() = array![[0.1, -0.2], [0.3, 0.1]];
-        *dense_mut(&mut model, 0).biases_mut() = Array1::from_vec(vec![0.05, -0.05]);
-        *dense_mut(&mut model, 1).weights_mut() = array![[0.4, -0.1]];
-        *dense_mut(&mut model, 1).biases_mut() = Array1::from_vec(vec![0.1]);
+        *dense_mut(&mut model, 0).affine_mut().weights_mut() = array![[0.1, -0.2], [0.3, 0.1]];
+        *dense_mut(&mut model, 0).affine_mut().biases_mut() = Array1::from_vec(vec![0.05, -0.05]);
+        *dense_mut(&mut model, 1).affine_mut().weights_mut() = array![[0.4, -0.1]];
+        *dense_mut(&mut model, 1).affine_mut().biases_mut() = Array1::from_vec(vec![0.1]);
 
         let inputs = array![[0.5, -0.3, 0.8], [0.2, 0.7, -0.5]]; // (2 features, 3 samples)
         let targets = array![[1.0, 0.0, 1.0]]; // (1 output, 3 samples)
@@ -246,9 +246,11 @@ mod tests {
             for i in 0..rows {
                 for j in 0..cols {
                     let mut m_plus = model.clone();
-                    dense_mut(&mut m_plus, layer_idx).weights_mut()[[i, j]] += eps;
+                    dense_mut(&mut m_plus, layer_idx).affine_mut().weights_mut()[[i, j]] += eps;
                     let mut m_minus = model.clone();
-                    dense_mut(&mut m_minus, layer_idx).weights_mut()[[i, j]] -= eps;
+                    dense_mut(&mut m_minus, layer_idx)
+                        .affine_mut()
+                        .weights_mut()[[i, j]] -= eps;
                     let numerical = (compute_loss(&m_plus, &inputs, &targets, &loss_fn)
                         - compute_loss(&m_minus, &inputs, &targets, &loss_fn))
                         / (2.0 * eps);
@@ -262,9 +264,9 @@ mod tests {
 
             for i in 0..dense(&model, layer_idx).biases().len() {
                 let mut m_plus = model.clone();
-                dense_mut(&mut m_plus, layer_idx).biases_mut()[i] += eps;
+                dense_mut(&mut m_plus, layer_idx).affine_mut().biases_mut()[i] += eps;
                 let mut m_minus = model.clone();
-                dense_mut(&mut m_minus, layer_idx).biases_mut()[i] -= eps;
+                dense_mut(&mut m_minus, layer_idx).affine_mut().biases_mut()[i] -= eps;
                 let numerical = (compute_loss(&m_plus, &inputs, &targets, &loss_fn)
                     - compute_loss(&m_minus, &inputs, &targets, &loss_fn))
                     / (2.0 * eps);
@@ -287,8 +289,10 @@ mod tests {
         let specs = NeuronLayerSpec::network_for(vec![], &*SIGMOID, 3);
         let mut model = NeuralNetwork::initialization(2, &specs, 0);
 
-        *dense_mut(&mut model, 0).weights_mut() = array![[0.5, -0.3], [0.2, 0.8], [-0.4, 0.1]];
-        *dense_mut(&mut model, 0).biases_mut() = Array1::from_vec(vec![0.1, -0.2, 0.1]);
+        *dense_mut(&mut model, 0).affine_mut().weights_mut() =
+            array![[0.5, -0.3], [0.2, 0.8], [-0.4, 0.1]];
+        *dense_mut(&mut model, 0).affine_mut().biases_mut() =
+            Array1::from_vec(vec![0.1, -0.2, 0.1]);
 
         // 4 samples across 3 classes
         let inputs = array![[1.0, -1.0, 0.5, -0.5], [0.5, 0.5, -0.5, -0.5]];
@@ -319,9 +323,11 @@ mod tests {
             for i in 0..rows {
                 for j in 0..cols {
                     let mut m_plus = model.clone();
-                    dense_mut(&mut m_plus, layer_idx).weights_mut()[[i, j]] += eps;
+                    dense_mut(&mut m_plus, layer_idx).affine_mut().weights_mut()[[i, j]] += eps;
                     let mut m_minus = model.clone();
-                    dense_mut(&mut m_minus, layer_idx).weights_mut()[[i, j]] -= eps;
+                    dense_mut(&mut m_minus, layer_idx)
+                        .affine_mut()
+                        .weights_mut()[[i, j]] -= eps;
                     let numerical = (compute_loss(&m_plus, &inputs, &targets, &loss_fn)
                         - compute_loss(&m_minus, &inputs, &targets, &loss_fn))
                         / (2.0 * eps);
@@ -334,9 +340,9 @@ mod tests {
             }
             for i in 0..dense(&model, layer_idx).biases().len() {
                 let mut m_plus = model.clone();
-                dense_mut(&mut m_plus, layer_idx).biases_mut()[i] += eps;
+                dense_mut(&mut m_plus, layer_idx).affine_mut().biases_mut()[i] += eps;
                 let mut m_minus = model.clone();
-                dense_mut(&mut m_minus, layer_idx).biases_mut()[i] -= eps;
+                dense_mut(&mut m_minus, layer_idx).affine_mut().biases_mut()[i] -= eps;
                 let numerical = (compute_loss(&m_plus, &inputs, &targets, &loss_fn)
                     - compute_loss(&m_minus, &inputs, &targets, &loss_fn))
                     / (2.0 * eps);
@@ -357,8 +363,8 @@ mod tests {
         let mut model = NeuralNetwork::initialization(2, &specs, 0);
 
         // Large weights so the single sample's logit saturates the sigmoid.
-        *dense_mut(&mut model, 0).weights_mut() = array![[100.0, 100.0]];
-        *dense_mut(&mut model, 0).biases_mut() = Array1::from_vec(vec![0.0]);
+        *dense_mut(&mut model, 0).affine_mut().weights_mut() = array![[100.0, 100.0]];
+        *dense_mut(&mut model, 0).affine_mut().biases_mut() = Array1::from_vec(vec![0.0]);
 
         let inputs = array![[1.0, -1.0], [1.0, -1.0]]; // logits +200 / -200 → 1.0 / 0.0
         let targets = array![[1.0, 0.0]];

--- a/core/src/nn/training/backprop.rs
+++ b/core/src/nn/training/backprop.rs
@@ -381,6 +381,49 @@ mod tests {
     }
 
     #[test]
+    fn flatten_layer_threads_through_training_without_parameters() {
+        use crate::layers::Flatten;
+
+        // A parameterless Flatten as the first layer (rank-2 in, rank-2 out here, so a
+        // no-op reshape) must thread through forward, backprop, and the optimizer: the
+        // optimizer skips its empty parameter list while the Dense head still learns.
+        let head = Dense::initialization(
+            4,
+            &NeuronLayerSpec::output_for(2),
+            &mut StdRng::seed_from_u64(1),
+        );
+        let mut model = NeuralNetwork::new(vec![Box::new(Flatten::new(vec![4])), Box::new(head)]);
+
+        let before = dense(&model, 1).weights().to_owned();
+
+        let inputs = Array2::from_shape_fn((4, 12), |(r, c)| ((r + c) as f32).cos());
+        let mut targets = Array2::zeros((1, 12));
+        for c in 0..12 {
+            targets[[0, c]] = (c % 2) as f32;
+        }
+        let dataset = ModelDataset::new(inputs, targets);
+
+        let loss: Arc<dyn LossFunction> = CROSS_ENTROPY_LOSS.clone();
+        let lr = LearningRate::new(0.1).unwrap();
+        let mut optimizer = StochasticGradientDescent::new(lr, WeightDecay::ZERO);
+        let mut scheduler = ConstantScheduler::new(lr);
+
+        model
+            .train(
+                &dataset,
+                &loss,
+                &mut optimizer as &mut dyn Optimizer,
+                &mut scheduler as &mut dyn Scheduler,
+                &GradientClipping::None,
+                None,
+            )
+            .unwrap();
+
+        let after = dense(&model, 1).weights().to_owned();
+        assert_ne!(before, after, "the Dense head should have learned");
+    }
+
+    #[test]
     fn training_is_deterministic_for_a_fixed_seed() {
         // Two runs with the same seed and data produce bit-identical weights.
         fn run() -> NeuralNetwork {

--- a/core/src/nn/training/backprop.rs
+++ b/core/src/nn/training/backprop.rs
@@ -1,7 +1,7 @@
 use crate::data::ModelDataset;
 use crate::gradients::{GradientClipping, LayerGradients};
 use crate::loss_functions::{CrossEntropyLoss, LossFunction};
-use crate::model::{FeatureCountMismatch, NeuralNetwork, last_activation};
+use crate::model::{InputShapeMismatch, NeuralNetwork, last_activation};
 use crate::optimizers::Optimizer;
 use crate::schedulers::Scheduler;
 use ndarray::{ArrayD, ArrayView2, Ix2};
@@ -38,7 +38,7 @@ impl MiniBatch {
 impl NeuralNetwork {
     /// Trains the network for one epoch using the provided dataset.
     /// # Errors
-    /// [`FeatureCountMismatch`] when the dataset's feature rows do not match [`Self::input_size`].
+    /// [`InputShapeMismatch`] when the dataset's feature rows do not match [`Self::input_size`].
     /// # Arguments
     /// - `dataset`: The dataset containing inputs and targets for training.
     /// - `loss_function`: The loss function to use for computing the loss and its gradient.
@@ -55,7 +55,7 @@ impl NeuralNetwork {
         scheduler: &mut dyn Scheduler,
         clipping: &GradientClipping,
         mini_batch: Option<MiniBatch>,
-    ) -> Result<(), FeatureCountMismatch> {
+    ) -> Result<(), InputShapeMismatch> {
         // Scheduler steps once per epoch regardless of batch size
         let lr = scheduler.step();
         optimizer.set_learning_rate(lr);

--- a/core/src/nn/training/backprop.rs
+++ b/core/src/nn/training/backprop.rs
@@ -1,6 +1,6 @@
 use crate::data::ModelDataset;
 use crate::gradients::{GradientClipping, LayerGradients};
-use crate::loss_functions::{CrossEntropyLoss, LossFunction};
+use crate::loss_functions::LossFunction;
 use crate::model::{InputShapeMismatch, NeuralNetwork, last_activation};
 use crate::optimizers::Optimizer;
 use crate::schedulers::Scheduler;
@@ -133,9 +133,9 @@ impl NeuralNetwork {
         let last_act = last_activation(activations)
             .into_dimensionality::<Ix2>()
             .expect("the output layer produces rank-2 (classes, samples) activations");
-        // Clip to (0, 1) interior so gradient() and vjp() see the same values;
+        // Project into the loss's safe domain so gradient() and vjp() see the same values;
         // their product then cancels exactly to p − y even near saturation.
-        let safe_act = CrossEntropyLoss::clip_probabilities(&last_act.view());
+        let safe_act = loss_function.stabilize(last_act.view());
         // dL/d(output) handed to the output layer.
         let mut da = loss_function.gradient(safe_act.view(), targets).into_dyn();
 
@@ -384,6 +384,65 @@ mod tests {
                 g.0
             );
         }
+    }
+
+    #[test]
+    fn backward_stabilizes_through_the_plugged_in_loss_not_cross_entropy() {
+        // Regression: backward() must project the output activation through the *plugged-in*
+        // loss's stabilize(), not a hardcoded cross-entropy clamp. A loss that keeps the
+        // default (identity) stabilize() must therefore see the raw activations — here the
+        // saturated 1.0/0.0 that cross-entropy would have clamped into (ε, 1 - ε).
+        use std::sync::Mutex;
+
+        struct RawSpyLoss {
+            seen: Mutex<Option<Array2<f32>>>,
+        }
+
+        impl LossFunction for RawSpyLoss {
+            fn name(&self) -> &'static str {
+                "RawSpy"
+            }
+            fn compute(&self, _predictions: ArrayView2<f32>, _targets: ArrayView2<f32>) -> f32 {
+                0.0
+            }
+            fn gradient(
+                &self,
+                predictions: ArrayView2<f32>,
+                _targets: ArrayView2<f32>,
+            ) -> Array2<f32> {
+                *self.seen.lock().unwrap() = Some(predictions.to_owned());
+                Array2::zeros(predictions.raw_dim())
+            }
+            // stabilize() left as the trait default (identity).
+        }
+
+        let specs = NeuronLayerSpec::network_for(vec![], &*SIGMOID, 2);
+        let mut model = NeuralNetwork::initialization(2, &specs, 0);
+        *dense_mut(&mut model, 0).affine_mut().weights_mut() = array![[100.0, 100.0]];
+        *dense_mut(&mut model, 0).affine_mut().biases_mut() = Array1::from_vec(vec![0.0]);
+        let inputs = array![[1.0, -1.0], [1.0, -1.0]]; // logits +200 / -200 → 1.0 / 0.0
+        let targets = array![[1.0, 0.0]];
+
+        let activations = model.forward(inputs.view()).unwrap();
+        assert_eq!(last_activation(&activations), array![[1.0, 0.0]].into_dyn());
+
+        let spy = Arc::new(RawSpyLoss {
+            seen: Mutex::new(None),
+        });
+        let loss_fn: Arc<dyn LossFunction> = spy.clone();
+        let _ = model.backward(&activations, targets.view(), &loss_fn);
+
+        let seen = spy
+            .seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("gradient was called");
+        assert_eq!(
+            seen,
+            array![[1.0, 0.0]],
+            "backward must feed the loss's own stabilize() output to gradient(), not a clamp"
+        );
     }
 
     #[test]

--- a/core/src/nn/training/backprop.rs
+++ b/core/src/nn/training/backprop.rs
@@ -135,18 +135,18 @@ impl NeuralNetwork {
         // their product then cancels exactly to p − y even near saturation.
         let safe_act = CrossEntropyLoss::clip_probabilities(&last_act.view());
         // dL/d(output) handed to the output layer.
-        let mut da = loss_function.gradient(safe_act.view(), targets);
+        let mut da = loss_function.gradient(safe_act.view(), targets).into_dyn();
 
         let layers = self.layers();
         let mut gradients = Vec::with_capacity(layers.len());
         let last = layers.len() - 1;
 
         for i in (0..layers.len()).rev() {
-            let input = activations[i].view();
+            let input = activations[i].view().into_dyn();
             let output = if i == last {
-                safe_act.view()
+                safe_act.view().into_dyn()
             } else {
-                activations[i + 1].view()
+                activations[i + 1].view().into_dyn()
             };
             // The input layer (i == 0) has no upstream layer to receive an input gradient.
             let pass = layers[i].backward(da.view(), input, output, i > 0);

--- a/core/src/nn/training/backprop.rs
+++ b/core/src/nn/training/backprop.rs
@@ -4,7 +4,7 @@ use crate::loss_functions::{CrossEntropyLoss, LossFunction};
 use crate::model::{FeatureCountMismatch, NeuralNetwork, last_activation};
 use crate::optimizers::Optimizer;
 use crate::schedulers::Scheduler;
-use ndarray::{Array2, ArrayView2};
+use ndarray::{ArrayD, ArrayView2, Ix2};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand::rngs::StdRng;
 use std::sync::Arc;
@@ -97,7 +97,7 @@ impl NeuralNetwork {
     /// - `clipping`: The gradient clipping strategy to apply during training.
     fn update_parameters(
         &mut self,
-        activations: &[Array2<f32>],
+        activations: &[ArrayD<f32>],
         targets: ArrayView2<f32>,
         loss_function: &Arc<dyn LossFunction>,
         optimizer: &mut dyn Optimizer,
@@ -126,11 +126,13 @@ impl NeuralNetwork {
     /// - `targets`: A 2D array representing the true labels for the inputs.
     fn backward(
         &self,
-        activations: &[Array2<f32>],
+        activations: &[ArrayD<f32>],
         targets: ArrayView2<f32>,
         loss_function: &Arc<dyn LossFunction>,
     ) -> Vec<LayerGradients> {
-        let last_act = last_activation(activations);
+        let last_act = last_activation(activations)
+            .into_dimensionality::<Ix2>()
+            .expect("the output layer produces rank-2 (classes, samples) activations");
         // Clip to (0, 1) interior so gradient() and vjp() see the same values;
         // their product then cancels exactly to p − y even near saturation.
         let safe_act = CrossEntropyLoss::clip_probabilities(&last_act.view());
@@ -142,11 +144,11 @@ impl NeuralNetwork {
         let last = layers.len() - 1;
 
         for i in (0..layers.len()).rev() {
-            let input = activations[i].view().into_dyn();
+            let input = activations[i].view();
             let output = if i == last {
                 safe_act.view().into_dyn()
             } else {
-                activations[i + 1].view().into_dyn()
+                activations[i + 1].view()
             };
             // The input layer (i == 0) has no upstream layer to receive an input gradient.
             let pass = layers[i].backward(da.view(), input, output, i > 0);
@@ -174,7 +176,7 @@ mod tests {
     use crate::optimizers::StochasticGradientDescent;
     use crate::schedulers::ConstantScheduler;
     use crate::weight_decay::WeightDecay;
-    use ndarray::{Array1, array};
+    use ndarray::{Array1, Array2, array};
 
     /// Downcasts a network's layer to the concrete [`Dense`] to read its weights and biases.
     fn dense(model: &NeuralNetwork, index: usize) -> &Dense {
@@ -364,7 +366,7 @@ mod tests {
         let loss_fn: Arc<dyn LossFunction> = CROSS_ENTROPY_LOSS.clone();
         let activations = model.forward(inputs.view()).unwrap();
         // The forward output is genuinely saturated, so this exercises the clamp.
-        assert_eq!(last_activation(&activations), array![[1.0, 0.0]]);
+        assert_eq!(last_activation(&activations), array![[1.0, 0.0]].into_dyn());
 
         let grads = model.backward(&activations, targets.view(), &loss_fn);
         for g in &grads {

--- a/core/src/nn/training/early_stopping.rs
+++ b/core/src/nn/training/early_stopping.rs
@@ -1,6 +1,6 @@
 use super::evaluator::Evaluator;
 use crate::data::ModelDataset;
-use crate::model::{FeatureCountMismatch, NeuralNetwork};
+use crate::model::{InputShapeMismatch, NeuralNetwork};
 use std::fmt;
 
 /// Declarative early-stopping settings, part of a [`crate::training::HyperParameters`] spec.
@@ -86,13 +86,13 @@ impl EarlyStopping {
     /// be stopped based on the resulting loss.
     ///
     /// # Errors
-    /// [`FeatureCountMismatch`] when `model`'s input size does not match `validation`.
+    /// [`InputShapeMismatch`] when `model`'s input size does not match `validation`.
     pub fn check(
         &mut self,
         validation: &ModelDataset,
         model: &NeuralNetwork,
         evaluator: &Evaluator,
-    ) -> Result<bool, FeatureCountMismatch> {
+    ) -> Result<bool, InputShapeMismatch> {
         let loss = evaluator.eval_dataset(model, validation)?.loss;
 
         Ok(self.observe(loss, model))

--- a/core/src/nn/training/early_stopping.rs
+++ b/core/src/nn/training/early_stopping.rs
@@ -149,7 +149,8 @@ mod tests {
 
         let mut model_at_best = model_initial.clone();
         // Give model_at_best a distinctive bias so we can tell it apart
-        *dense_mut(&mut model_at_best, 0).biases_mut() = Array1::from_vec(vec![42.0, 42.0]);
+        *dense_mut(&mut model_at_best, 0).affine_mut().biases_mut() =
+            Array1::from_vec(vec![42.0, 42.0]);
 
         assert!(!es.observe(1.0, &model_initial)); // improvement: saved
         assert!(!es.observe(0.5, &model_at_best)); // new best: overwrites saved

--- a/core/src/nn/training/evaluator.rs
+++ b/core/src/nn/training/evaluator.rs
@@ -2,7 +2,7 @@ use crate::accuracies::Accuracy;
 use crate::data::{ModelDataset, ModelSplit};
 use crate::evaluation::{Evaluation, EvaluationSet};
 use crate::loss_functions::LossFunction;
-use crate::model::{FeatureCountMismatch, NeuralNetwork};
+use crate::model::{InputShapeMismatch, NeuralNetwork};
 use ndarray::ArrayView2;
 use std::sync::Arc;
 
@@ -21,12 +21,12 @@ impl Evaluator {
     /// Evaluates the model on the training, validation (if available), and test datasets.
     ///
     /// # Errors
-    /// [`FeatureCountMismatch`] when `model`'s input size does not match the split's features.
+    /// [`InputShapeMismatch`] when `model`'s input size does not match the split's features.
     pub fn eval_set(
         &self,
         model: &NeuralNetwork,
         split: &ModelSplit,
-    ) -> Result<EvaluationSet, FeatureCountMismatch> {
+    ) -> Result<EvaluationSet, InputShapeMismatch> {
         Ok(EvaluationSet {
             train: self.eval_dataset(model, &split.train)?,
             validation: split
@@ -41,12 +41,12 @@ impl Evaluator {
     /// Evaluates the model on a single dataset.
     ///
     /// # Errors
-    /// [`FeatureCountMismatch`] when `model`'s input size does not match the dataset's features.
+    /// [`InputShapeMismatch`] when `model`'s input size does not match the dataset's features.
     pub fn eval_dataset(
         &self,
         model: &NeuralNetwork,
         dataset: &ModelDataset,
-    ) -> Result<Evaluation, FeatureCountMismatch> {
+    ) -> Result<Evaluation, InputShapeMismatch> {
         let predictions = model.predict(dataset.inputs().view())?;
         Ok(self.eval_predictions(predictions.view(), dataset.targets().view()))
     }

--- a/core/src/nn/training/hyperparams.rs
+++ b/core/src/nn/training/hyperparams.rs
@@ -782,10 +782,11 @@ mod tests {
         use crate::data::scalers::MinMaxScaler;
         use ndarray::array;
 
-        // A scaler fitted on a far wider range than the data; reused verbatim it
-        // keeps every input well below 0.5 (refitting on the train split would not).
+        // A scaler fitted on a far wider range than the data (features on rows); reused
+        // verbatim it keeps every input well below 0.5 (refitting on the train split
+        // would not).
         let supplied = ScalerMethod::MinMax(
-            MinMaxScaler::default().fit(array![[0.0, 0.0], [100.0, 100.0]].view()),
+            MinMaxScaler::default().fit(array![[0.0, 100.0], [0.0, 100.0]].view()),
         );
 
         let hp = spec_with_scaler(None);

--- a/core/src/nn/training/hyperparams.rs
+++ b/core/src/nn/training/hyperparams.rs
@@ -7,7 +7,7 @@ use crate::data::scalers::{ScalerFeatureMismatch, ScalerKind, ScalerMethod};
 use crate::gradients::{GradientClipping, GradientClippingError};
 use crate::learning_rate::{LearningRate, LearningRateError};
 use crate::loss_functions::{CROSS_ENTROPY_LOSS, LossFunction};
-use crate::model::{FeatureCountMismatch, NeuralNetwork};
+use crate::model::{InputShapeMismatch, NeuralNetwork};
 use crate::optimizers::{Adam, Optimizer, StochasticGradientDescent};
 use crate::schedulers::{
     ConstantScheduler, CosineAnnealing, CosineAnnealingError, Scheduler, StepDecay, StepDecayError,
@@ -441,7 +441,7 @@ impl HyperParameters {
     /// [`Trainer::restore`](crate::training::Trainer::restore) on the result.
     ///
     /// # Errors
-    /// [`FeatureCountMismatch`] when `model`'s input size does not match the dataset's
+    /// [`InputShapeMismatch`] when `model`'s input size does not match the dataset's
     /// feature count. The two are supplied separately (e.g. resuming a run with a fresh
     /// dataset), so this is the one place their compatibility is checked; once past it,
     /// every forward pass over the split is guaranteed to fit.
@@ -450,7 +450,7 @@ impl HyperParameters {
         model: NeuralNetwork,
         data: TrainingData,
         callbacks: Callbacks,
-    ) -> Result<Trainer, FeatureCountMismatch> {
+    ) -> Result<Trainer, InputShapeMismatch> {
         model.validate_inputs(data.split.train.inputs().view())?;
 
         let optimizer = self.optimizer.instantiate(self.lr, self.weight_decay);

--- a/core/src/plot/activations.rs
+++ b/core/src/plot/activations.rs
@@ -11,7 +11,7 @@ use crate::classification::Classification;
 use crate::data::scalers::Scaler;
 use crate::model::{FeatureCountMismatch, NeuralNetwork, PredictionError, Predictor};
 use crate::plot::scene::Color;
-use ndarray::{ArrayView1, ArrayView2, Axis};
+use ndarray::{Array2, ArrayView1, ArrayView2, Axis, Ix2};
 
 /// Activation magnitudes at or below this count as a silent neuron.
 const FIRING_EPSILON: f32 = 1e-6;
@@ -178,7 +178,15 @@ impl NeuralNetwork {
         input: ArrayView1<f32>,
         options: &DiagramOptions,
     ) -> Result<ActivationDiagram, FeatureCountMismatch> {
-        let activations = self.forward(input.insert_axis(Axis(1)))?;
+        let activations: Vec<Array2<f32>> = self
+            .forward(input.insert_axis(Axis(1)))?
+            .into_iter()
+            .map(|values| {
+                values
+                    .into_dimensionality::<Ix2>()
+                    .expect("the diagram visualizes rank-2 (features, samples) activations")
+            })
+            .collect();
         let last_stage = activations.len() - 1;
         let shown: Vec<Vec<usize>> = activations
             .iter()

--- a/core/src/plot/activations.rs
+++ b/core/src/plot/activations.rs
@@ -255,7 +255,9 @@ impl Predictor {
     ) -> Result<ActivationDiagram, PredictionError> {
         let mut input = input.to_owned();
         if let Some(scaler) = &self.scaler {
-            scaler.apply_single_inplace(input.view_mut())?;
+            // Scale the lone instance: features on the leading axis, a single sample.
+            let mut expanded = input.view_mut().insert_axis(Axis(1)).into_dyn();
+            scaler.apply_inplace(expanded.view_mut())?;
         }
         Ok(self.network.activation_diagram(input.view(), options)?)
     }

--- a/core/src/plot/activations.rs
+++ b/core/src/plot/activations.rs
@@ -9,7 +9,7 @@
 
 use crate::classification::Classification;
 use crate::data::scalers::Scaler;
-use crate::model::{FeatureCountMismatch, NeuralNetwork, PredictionError, Predictor};
+use crate::model::{InputShapeMismatch, NeuralNetwork, PredictionError, Predictor};
 use crate::plot::scene::Color;
 use ndarray::{Array2, ArrayView1, ArrayView2, Axis, Ix2};
 
@@ -172,12 +172,12 @@ impl NeuralNetwork {
     /// instance, capping and pruning per `options`.
     ///
     /// # Errors
-    /// [`FeatureCountMismatch`] when `input`'s length does not match the network's input size.
+    /// [`InputShapeMismatch`] when `input`'s length does not match the network's input size.
     pub fn activation_diagram(
         &self,
         input: ArrayView1<f32>,
         options: &DiagramOptions,
-    ) -> Result<ActivationDiagram, FeatureCountMismatch> {
+    ) -> Result<ActivationDiagram, InputShapeMismatch> {
         let activations: Vec<Array2<f32>> = self
             .forward(input.insert_axis(Axis(1)))?
             .into_iter()
@@ -690,9 +690,9 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             error,
-            PredictionError::Network(FeatureCountMismatch {
-                expected: 2,
-                found: 1
+            PredictionError::Network(InputShapeMismatch {
+                expected: vec![2],
+                found: vec![1]
             })
         );
     }

--- a/core/tests/io_roundtrip.rs
+++ b/core/tests/io_roundtrip.rs
@@ -65,8 +65,10 @@ fn full_pipeline_roundtrips_through_safetensors() {
     assert_eq!(dataset.labels(), loaded.labels());
 
     // --- Scaler (serialized as JSON, not safetensors) -------------------
-    let scaler = ScalerMethod::MinMax(MinMaxScaler::default().fit(dataset.features().view()));
-    let mut expected = dataset.features().clone();
+    // Scalers work on the model dataset's samples-last inputs (features leading).
+    let model_dataset = dataset.to_model_dataset();
+    let scaler = ScalerMethod::MinMax(MinMaxScaler::default().fit(model_dataset.inputs().view()));
+    let mut expected = model_dataset.inputs().clone();
     scaler.apply_inplace(expected.view_mut()).unwrap();
 
     let scaler_path = dir.join("scaler");
@@ -74,12 +76,11 @@ fn full_pipeline_roundtrips_through_safetensors() {
     record.save(&scaler_path).unwrap();
     let reloaded_scaler: ScalerMethod = ScalerRecord::load(&scaler_path).unwrap().into();
 
-    let mut actual = dataset.features().clone();
+    let mut actual = model_dataset.inputs().clone();
     reloaded_scaler.apply_inplace(actual.view_mut()).unwrap();
     assert_eq!(expected, actual);
 
     // --- Model + training run (incremental writer → directory load) --
-    let model_dataset = dataset.to_model_dataset();
     let specs = NeuronLayerSpec::plan(LayerPlan::Explicit(vec![4]), 2, &*RELU).unwrap();
     let mut model = NeuralNetwork::initialization(2, &specs, 0);
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,7 +9,7 @@ cargo bench -p nrn --bench training --features blas   # system BLAS (per-OS back
 ```
 
 The harness lives in [`core/benches/training.rs`](../core/benches/training.rs) and
-covers three operations on two workloads:
+covers three operations on three workloads:
 
 | Operation          | What it measures                                        |
 | ------------------ | ------------------------------------------------------- |
@@ -17,10 +17,14 @@ covers three operations on two workloads:
 | `epoch_full_batch` | one training epoch, full-batch gradient descent         |
 | `epoch_mini_batch` | one training epoch, mini-batch SGD (batch size 64)      |
 
-| Workload | Architecture                         | Samples |
-| -------- | ------------------------------------ | ------- |
-| `small`  | 2 → 16 (relu) → 1 (sigmoid)          | 1 000   |
-| `mnist`  | 784 → 128 → 64 (relu) → 10 (softmax) | 2 000   |
+| Workload | Architecture                                         | Samples |
+| -------- | ---------------------------------------------------- | ------- |
+| `small`  | 2 → 16 (relu) → 1 (sigmoid)                          | 1 000   |
+| `mnist`  | 784 → 128 → 64 (relu) → 10 (softmax)                 | 2 000   |
+| `cnn`    | 1×28×28 → conv2d(16, 3×3, relu) → flatten → 10 (softmax) | 1 000   |
+
+The `cnn` workload takes a rank-4 `(channels, height, width, samples)` batch, so it
+exercises the spatial `im2col`/`col2im` paths the MLP workloads never touch.
 
 Each epoch benchmark clones the model in criterion's `iter_batched` setup, so the
 clone is excluded from the measured region and every iteration starts from the
@@ -33,20 +37,16 @@ Times are the criterion median (point estimate). Lower is better. Re-measure on
 your own machine before drawing conclusions — these are a relative baseline, not
 an absolute spec.
 
-### Baseline — 2026-06-30
+### Baseline — 2026-07-05
 
 - **Machine:** Apple M4 (10 cores), `rustc 1.95.0`, `--release`
-- **Commit:** `perf/training-inference-buffers` @ baseline (criterion harness added,
-  no optimization applied yet)
+- **Commit:** `test(bench): add a CNN workload to the training benches` (`0371846`)
 
-| Operation          | small (pure) | small (BLAS) | mnist (pure) | mnist (BLAS) | mnist speedup |
-| ------------------ | ------------ | ------------ | ------------ | ------------ | ------------- |
-| `inference`        | 11.6 µs      | 11.2 µs      | 4.54 ms      | 0.52 ms      | **8.8×**      |
-| `epoch_full_batch` | 37.4 µs      | 26.1 µs      | 9.35 ms      | 1.17 ms      | **8.0×**      |
-| `epoch_mini_batch` | 78.7 µs      | 76.9 µs      | 14.1 ms      | 6.03 ms      | **2.3×**      |
-
-> Measured with a short run (`--warm-up-time 1 --measurement-time 3`) for a quick
-> baseline. The default (longer) settings give tighter confidence intervals.
+| Operation          | small (pure) | small (BLAS) | mnist (pure) | mnist (BLAS) | mnist × | cnn (pure) | cnn (BLAS) | cnn × |
+| ------------------ | ------------ | ------------ | ------------ | ------------ | ------- | ---------- | ---------- | ----- |
+| `inference`        | 12.5 µs      | 11.1 µs      | 4.22 ms      | 0.53 ms      | **8.0×** | 13.5 ms    | 10.5 ms    | **1.3×** |
+| `epoch_full_batch` | 29.8 µs      | 26.0 µs      | 8.85 ms      | 1.09 ms      | **8.1×** | 33.4 ms    | 21.4 ms    | **1.6×** |
+| `epoch_mini_batch` | 79.9 µs      | 80.6 µs      | 11.9 ms      | 4.15 ms      | **2.9×** | 35.0 ms    | 20.8 ms    | **1.7×** |
 
 ## The `blas` feature
 
@@ -55,9 +55,11 @@ By default `dot` runs on ndarray's pure-Rust
 backend routes matmul through a system BLAS (`sgemm`):
 
 - **~8×** on `inference` and `epoch_full_batch` for the MNIST-sized workload.
-- **2.3×** on `epoch_mini_batch`: that path is bound by the per-batch index gather
+- **~3×** on `epoch_mini_batch`: that path is bound by the per-batch index gather
   (`select`), not the matmul.
 - **No change** on `small`: 2-feature matmuls are dominated by per-call overhead.
+- **~1.3–1.7×** on `cnn`: each sample's `im2col` matmul is small `(16, 9)·(9, 676)`,
+  and the `im2col`/`col2im` reshaping around it is pure-Rust either way.
 
 The backend is picked per OS: Accelerate on macOS (no extra install), OpenBLAS
 elsewhere.


### PR DESCRIPTION
## Summary

Generalizes the network from a rank-2 (features, samples) MLP to arbitrary-rank
(samples-last) tensors, and delivers an end-to-end 2D CNN on top: a spatial stack
`Conv2d → Flatten → Dense` now trains, predicts, and round-trips through
save/load. Built as a series of small, iso-functional increments — the dense path
stays bit-for-bit unchanged at every step.

Highlights:

- **`Layer` in N-D.** `forward`/`backward` operate on `ArrayD`; `input_shape`/`output_shape`
  (per-sample `Vec<usize>`) are the source of truth for a layer's geometry, so
  `with_layer` and `validate_inputs` compare *shapes*, not just feature counts
  (a `Conv2d → Dense` without a `Flatten` is rejected at build time).
- **New layers.** `Conv2d` (forward/backward via im2col/col2im + matmul, mirroring
  `Dense`; He init) and a parameterless `Flatten` (pure reshape, samples-last).
- **Shared `Affine` core.** The `weights·x + b` map and its backward pass are extracted
  behind both `Dense` and `Conv2d` (`m` passed explicitly, since a conv's affine
  columns span spatial positions as well as samples).
- **Rank-N data & scaling.** `ModelDataset` inputs are samples-last `ArrayD`;
  `batches`/`split` chunk the trailing axis. The scaler convention flips to samples-last
  (features on the leading axis), which removes the transposes/copies the earlier
  increments needed — `fit`/`apply_inplace` are now rank-generic one-liners.
- **Loss stabilization moved onto the trait.** `LossFunction::stabilize` clips probabilities
  into `(0, 1)`; `backward` feeds the *plugged-in* loss's `stabilize` output to both
  `gradient` and the activation `vjp`, so their product cancels exactly to `p − y` even
  when a sigmoid saturates.
- **Layer I/O.** `LayerKind` + `Layer::config()`/`from_config` (a Keras-style
  `get_config`/`from_config` pair) let `io` serialize any layer kind; the on-disk dense
  format is unchanged.

## Notes

- **Reviewing:** the branch is a stack of iso-functional steps; the commit sequence is the
  intended reading order (trait → N-D forward/backward → Flatten → Conv2d → rank-N
  inference → shape contract → training → per-feature scaler → layer I/O).
- **No CLI surface yet.** This is core-library only; wiring the CNN into the `nrn` CLI is
  the next branch. The single `cli/` change is a test message tweak
  (`expects 2` → `expects [2]`) following the `FeatureCountMismatch → InputShapeMismatch`
  rename.
- **Verification:** every layer ships numerical gradient checks (`Conv2d`, `Dense`, the
  full backprop chain); CNN save→load→predict is asserted bit-identical; a `Conv2d →
  Flatten → Dense` network is trained end-to-end and its loss shown to fall. `task checks`
  green (532 tests).
