### PR TITLE
feat(nn): shape-aware regression task, consolidate network validation

### DIFF
--- a/cli/src/commands/plot/run.rs
+++ b/cli/src/commands/plot/run.rs
@@ -119,7 +119,12 @@ impl RunArgs {
                 let mut figures = Vec::with_capacity(indices.len());
                 for &index in indices {
                     figures.push(boundary_at(
-                        archive, index, dataset, task, scaler, resolution,
+                        archive,
+                        index,
+                        dataset,
+                        task.clone(),
+                        scaler,
+                        resolution,
                     )?);
                     progress.advance();
                 }
@@ -141,7 +146,8 @@ impl RunArgs {
 
                 let progress = Frames::new(indices.len(), "Rendering GIF");
                 for &index in indices {
-                    let figure = boundary_at(archive, index, dataset, task, scaler, resolution)?;
+                    let figure =
+                        boundary_at(archive, index, dataset, task.clone(), scaler, resolution)?;
                     writer.write_frame(&figure.to_image(&cfg)?)?;
                     progress.advance();
                 }

--- a/cli/src/commands/train/callbacks.rs
+++ b/cli/src/commands/train/callbacks.rs
@@ -162,7 +162,7 @@ impl TrainerCallback for ModelSaver {
         _epoch: usize,
     ) -> CallbackResult {
         if let Some(model) = model {
-            let predictor = Predictor::new(model.clone(), self.task, self.scaler.clone());
+            let predictor = Predictor::new(model.clone(), self.task.clone(), self.scaler.clone());
             saved(&Artifacts::single("Model", predictor.save(&self.path)?));
         }
         Ok(())

--- a/cli/src/commands/train/resume.rs
+++ b/cli/src/commands/train/resume.rs
@@ -78,7 +78,7 @@ impl ResumeArgs {
             .with(ModelSaver::new(
                 run_dir,
                 &meta.model,
-                task,
+                task.clone(),
                 data.scaler().cloned(),
             ))
             .with_opt(recorder);

--- a/cli/src/commands/train/start.rs
+++ b/cli/src/commands/train/start.rs
@@ -85,7 +85,7 @@ impl StartArgs {
             };
             let config = ModelConfigRecord {
                 network: NetworkConfigRecord::from(&model),
-                task: task.into(),
+                task: task.clone().into(),
             };
             let scaler = data.scaler().cloned().map(ScalerRecord::from);
             let recorder =
@@ -103,7 +103,7 @@ impl StartArgs {
             .with(ModelSaver::new(
                 &run_dir,
                 &model_name,
-                task,
+                task.clone(),
                 data.scaler().cloned(),
             ))
             .with_opt(recorder);

--- a/cli/src/display/task.rs
+++ b/cli/src/display/task.rs
@@ -11,7 +11,7 @@ impl Describe for Task {
             Task::Binary => "classification (binary)".to_string(),
             Task::MultiClass { n_classes } => format!("classification ({n_classes} classes)"),
             Task::MultiLabel { n_labels } => format!("classification ({n_labels} labels)"),
-            Task::Regression { n_outputs } => format!("regression ({n_outputs} outputs)"),
+            Task::Regression { shape } => format!("regression (shape {shape:?})"),
         };
         theme::value(detail)
     }

--- a/core/src/io/model/predictor.rs
+++ b/core/src/io/model/predictor.rs
@@ -21,7 +21,7 @@ impl Predictor {
         self.network.save_weights(dir.join(MODEL_STEM))?;
         ModelConfigRecord {
             network: NetworkConfigRecord::from(&self.network),
-            task: self.task.into(),
+            task: self.task.clone().into(),
         }
         .save(dir.join(CONFIG_STEM))?;
         if let Some(scaler) = &self.scaler {

--- a/core/src/io/model/task.rs
+++ b/core/src/io/model/task.rs
@@ -1,7 +1,8 @@
 use crate::task::Task;
 use serde::{Deserialize, Serialize};
 
-/// Serializable mirror of [`Task`], one JSON object tagged by task with the width it carries.
+/// Serializable mirror of [`Task`], one JSON object tagged by task with the width or shape it
+/// carries.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TaskRecord {
@@ -12,7 +13,7 @@ pub enum TaskRecord {
     /// Mirror of [`Task::MultiLabel`].
     MultiLabel { n_labels: usize },
     /// Mirror of [`Task::Regression`].
-    Regression { n_outputs: usize },
+    Regression { shape: Vec<usize> },
 }
 
 impl From<Task> for TaskRecord {
@@ -21,7 +22,7 @@ impl From<Task> for TaskRecord {
             Task::Binary => TaskRecord::Binary,
             Task::MultiClass { n_classes } => TaskRecord::MultiClass { n_classes },
             Task::MultiLabel { n_labels } => TaskRecord::MultiLabel { n_labels },
-            Task::Regression { n_outputs } => TaskRecord::Regression { n_outputs },
+            Task::Regression { shape } => TaskRecord::Regression { shape },
         }
     }
 }
@@ -32,7 +33,7 @@ impl From<TaskRecord> for Task {
             TaskRecord::Binary => Task::Binary,
             TaskRecord::MultiClass { n_classes } => Task::MultiClass { n_classes },
             TaskRecord::MultiLabel { n_labels } => Task::MultiLabel { n_labels },
-            TaskRecord::Regression { n_outputs } => Task::Regression { n_outputs },
+            TaskRecord::Regression { shape } => Task::Regression { shape },
         }
     }
 }
@@ -47,9 +48,12 @@ mod tests {
             Task::Binary,
             Task::MultiClass { n_classes: 4 },
             Task::MultiLabel { n_labels: 3 },
-            Task::Regression { n_outputs: 2 },
+            Task::Regression { shape: vec![2] },
+            Task::Regression {
+                shape: vec![3, 4, 4],
+            },
         ] {
-            assert_eq!(Task::from(TaskRecord::from(task)), task);
+            assert_eq!(Task::from(TaskRecord::from(task.clone())), task);
         }
     }
 

--- a/core/src/nn/model/network.rs
+++ b/core/src/nn/model/network.rs
@@ -4,6 +4,7 @@
 use crate::activations::Activation;
 use crate::layers::{Layer, format_shape};
 use crate::model::{LayerConfig, LayerConfigError, NetworkConfig};
+use crate::task::Task;
 use crate::tensors::Tensors;
 use ndarray::{ArrayD, ArrayView, ArrayViewD, Dimension};
 use ndarray_rand::rand::SeedableRng;
@@ -227,34 +228,6 @@ impl NeuralNetwork {
         self.layers.iter().all(|layer| layer.is_finite())
     }
 
-    /// Validates that `shape` matches this network's input shape.
-    ///
-    /// # Errors
-    /// [`InputShapeMismatch`] when `shape` differs from the network's input shape.
-    pub fn validate_input_shape(&self, shape: &[usize]) -> Result<(), InputShapeMismatch> {
-        let expected = self.input_shape();
-        (shape == expected)
-            .then_some(())
-            .ok_or_else(|| InputShapeMismatch {
-                expected,
-                found: shape.to_vec(),
-            })
-    }
-
-    /// Validates that this network's output shape matches `expected`.
-    ///
-    /// # Errors
-    /// [`OutputShapeMismatch`] when the network's output shape differs from `expected`.
-    pub fn validate_output_shape(&self, expected: &[usize]) -> Result<(), OutputShapeMismatch> {
-        let found = self.output_shape();
-        (found == expected)
-            .then_some(())
-            .ok_or_else(|| OutputShapeMismatch {
-                expected: expected.to_vec(),
-                found,
-            })
-    }
-
     /// Validates that `inputs` carry the per-sample shape this network expects: the sample axis
     /// is last, so the leading axes are the per-sample features.
     ///
@@ -264,9 +237,27 @@ impl NeuralNetwork {
         &self,
         inputs: ArrayView<f32, D>,
     ) -> Result<(), InputShapeMismatch> {
+        let expected = self.input_shape();
         let shape = inputs.shape();
         let found = &shape[..shape.len().saturating_sub(1)];
-        self.validate_input_shape(found)
+        (found == expected)
+            .then_some(())
+            .ok_or_else(|| InputShapeMismatch {
+                expected,
+                found: found.to_vec(),
+            })
+    }
+
+    /// Validates that this network's output shape matches what `task` expects.
+    ///
+    /// # Errors
+    /// [`OutputShapeMismatch`] when the network's output shape differs from `task`'s.
+    pub fn validate_task(&self, task: &Task) -> Result<(), OutputShapeMismatch> {
+        let expected = task.output_shape();
+        let found = self.output_shape();
+        (found == expected)
+            .then_some(())
+            .ok_or(OutputShapeMismatch { expected, found })
     }
 
     /// Computes the forward pass of the network and returns the output layer's activations.
@@ -376,11 +367,11 @@ mod tests {
     }
 
     #[test]
-    fn validate_output_shape_rejects_a_matching_count_but_wrong_rank() {
+    fn validate_task_rejects_a_matching_count_but_wrong_rank() {
         use crate::layers::Conv2d;
 
         // A Conv2d-only network produces a rank-3 (2, 2, 2) output = 8 features; a flat
-        // 8-wide expectation matches on count but not on shape.
+        // 8-wide regression shape matches on count but not on rank.
         let conv = Conv2d::initialization(
             (1, 4, 4),
             2,
@@ -392,7 +383,9 @@ mod tests {
         );
         let model = NeuralNetwork::single(conv);
 
-        let err = model.validate_output_shape(&[8]).unwrap_err();
+        let err = model
+            .validate_task(&Task::Regression { shape: vec![8] })
+            .unwrap_err();
         assert_eq!(err.expected, vec![8]);
         assert_eq!(err.found, vec![2, 2, 2]);
         assert_eq!(
@@ -402,22 +395,30 @@ mod tests {
     }
 
     #[test]
-    fn validate_output_shape_accepts_a_matching_flat_width() {
+    fn validate_task_accepts_a_matching_shape() {
         let config = NetworkConfig::builder(vec![3])
             .dense(4, &RELU)
             .dense(2, &IDENTITY)
             .build();
         let model = NeuralNetwork::from_config(config, 0).unwrap();
-        assert!(model.validate_output_shape(&[2]).is_ok());
-        assert!(model.validate_output_shape(&[3]).is_err());
+        assert!(
+            model
+                .validate_task(&Task::MultiClass { n_classes: 2 })
+                .is_ok()
+        );
+        assert!(
+            model
+                .validate_task(&Task::MultiClass { n_classes: 3 })
+                .is_err()
+        );
     }
 
     #[test]
-    fn validate_input_shape_rejects_a_matching_count_but_wrong_rank() {
+    fn validate_task_accepts_a_conv2d_terminated_network_for_a_matching_regression_shape() {
         use crate::layers::Conv2d;
 
-        // A Conv2d-first network expects a per-sample shape of (1, 4, 4) = 16 features; a flat
-        // 16-wide shape matches on count but not on shape.
+        // A bare Conv2d head is a legal regression output once the task declares the same
+        // per-sample shape — no trailing Dense/Flatten required.
         let conv = Conv2d::initialization(
             (1, 4, 4),
             2,
@@ -429,20 +430,30 @@ mod tests {
         );
         let model = NeuralNetwork::single(conv);
 
-        let err = model.validate_input_shape(&[16]).unwrap_err();
-        assert_eq!(err.expected, vec![1, 4, 4]);
-        assert_eq!(err.found, vec![16]);
+        assert!(
+            model
+                .validate_task(&Task::Regression {
+                    shape: vec![2, 2, 2]
+                })
+                .is_ok()
+        );
     }
 
     #[test]
-    fn validate_input_shape_accepts_a_matching_shape() {
+    fn validate_inputs_accepts_and_rejects_a_flat_shape() {
         let config = NetworkConfig::builder(vec![3])
             .dense(4, &RELU)
             .dense(2, &IDENTITY)
             .build();
         let model = NeuralNetwork::from_config(config, 0).unwrap();
-        assert!(model.validate_input_shape(&[3]).is_ok());
-        assert!(model.validate_input_shape(&[4]).is_err());
+
+        let matching = Array2::<f32>::zeros((3, 5)); // 3 features, 5 samples.
+        assert!(model.validate_inputs(matching.view()).is_ok());
+
+        let mismatching = Array2::<f32>::zeros((4, 5)); // 4 features, 5 samples.
+        let err = model.validate_inputs(mismatching.view()).unwrap_err();
+        assert_eq!(err.expected, vec![3]);
+        assert_eq!(err.found, vec![4]);
     }
 
     #[test]

--- a/core/src/nn/task.rs
+++ b/core/src/nn/task.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::error::Error;
 
 /// The learning task a training run optimizes for. Each variant names the task and carries the
-/// output width it implies.
+/// output shape it implies.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Task {
     /// Two mutually exclusive classes, one output.

--- a/core/src/nn/task.rs
+++ b/core/src/nn/task.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 
 /// The learning task a training run optimizes for. Each variant names the task and carries the
 /// output width it implies.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Task {
     /// Two mutually exclusive classes, one output.
     Binary,
@@ -15,18 +15,18 @@ pub enum Task {
     MultiClass { n_classes: usize },
     /// `n_labels` independent yes/no labels, `n_labels` outputs.
     MultiLabel { n_labels: usize },
-    /// `n_outputs` real-valued targets, `n_outputs` outputs.
-    Regression { n_outputs: usize },
+    /// Real-valued targets, shaped `shape` per sample.
+    Regression { shape: Vec<usize> },
 }
 
 impl Task {
     /// Infers the task from the shape and dtype of a dataset's targets:
     /// - rank-1 integers over two distinct values → [`Binary`](Task::Binary), over three or
     ///   more → [`MultiClass`](Task::MultiClass);
-    /// - rank-1 real values → [`Regression`](Task::Regression) with one output;
+    /// - rank-1 real values → [`Regression`](Task::Regression) shaped `[1]`;
     /// - rank-2 `(samples, k)` in `{0, 1}` → [`MultiLabel`](Task::MultiLabel);
-    /// - rank-2 `(samples, k)` real values → [`Regression`](Task::Regression) with
-    ///   `k` outputs.
+    /// - real values of any other rank → [`Regression`](Task::Regression), shaped by the
+    ///   dataset's per-sample (trailing) axes.
     pub fn from_dataset(dataset: &Dataset) -> Self {
         let targets = dataset.targets();
         if targets.ndim() == 1 {
@@ -34,14 +34,15 @@ impl Task {
             match dataset.n_classes() {
                 2 if class_ids => Task::Binary,
                 n if class_ids && n > 2 => Task::MultiClass { n_classes: n },
-                _ => Task::Regression { n_outputs: 1 },
+                _ => Task::Regression { shape: vec![1] },
+            }
+        } else if targets.ndim() == 2 && targets.iter().all(|&v| v == 0.0 || v == 1.0) {
+            Task::MultiLabel {
+                n_labels: targets.len_of(Axis(1)),
             }
         } else {
-            let width = targets.len_of(Axis(1));
-            if targets.iter().all(|&v| v == 0.0 || v == 1.0) {
-                Task::MultiLabel { n_labels: width }
-            } else {
-                Task::Regression { n_outputs: width }
+            Task::Regression {
+                shape: targets.shape()[1..].to_vec(),
             }
         }
     }
@@ -57,19 +58,26 @@ impl Task {
             Task::Binary => validate_classification(targets, 2),
             Task::MultiClass { n_classes } => validate_classification(targets, *n_classes),
             Task::MultiLabel { n_labels } => validate_multilabel(targets, *n_labels),
-            Task::Regression { n_outputs } => validate_regression(targets, *n_outputs),
+            Task::Regression { shape } => validate_regression(targets, shape),
         }
     }
 
-    /// The number of output units this task implies: one logit for
-    /// [`Binary`](Task::Binary), and the class/label/output count for the others.
-    pub fn output_size(&self) -> usize {
+    /// The per-sample output shape this task implies: a single-element shape carrying the
+    /// class/label count for every task but [`Regression`](Task::Regression), which carries
+    /// its own declared shape.
+    pub fn output_shape(&self) -> Vec<usize> {
         match self {
-            Task::Binary => 1,
-            Task::MultiClass { n_classes } => *n_classes,
-            Task::MultiLabel { n_labels } => *n_labels,
-            Task::Regression { n_outputs } => *n_outputs,
+            Task::Binary => vec![1],
+            Task::MultiClass { n_classes } => vec![*n_classes],
+            Task::MultiLabel { n_labels } => vec![*n_labels],
+            Task::Regression { shape } => shape.clone(),
         }
+    }
+
+    /// The flattened output width this task implies: the element count of
+    /// [`output_shape`](Self::output_shape).
+    pub fn output_size(&self) -> usize {
+        self.output_shape().iter().product()
     }
 }
 
@@ -112,30 +120,28 @@ fn validate_multilabel(targets: &ArrayD<f32>, n_labels: usize) -> Result<(), Tas
     if !targets.iter().all(|&v| v == 0.0 || v == 1.0) {
         return Err(TaskDataError::LabelsNotBinary);
     }
-    let width = targets.len_of(Axis(1));
-    if width != n_labels {
-        return Err(TaskDataError::WidthMismatch {
-            expected: n_labels,
-            found: width,
-        });
+    let found = vec![targets.len_of(Axis(1))];
+    let expected = vec![n_labels];
+    if found != expected {
+        return Err(TaskDataError::ShapeMismatch { expected, found });
     }
     Ok(())
 }
 
-/// Checks that `targets` are finite and `n_outputs` wide.
-fn validate_regression(targets: &ArrayD<f32>, n_outputs: usize) -> Result<(), TaskDataError> {
+/// Checks that `targets` are finite and shaped `expected` per sample.
+fn validate_regression(targets: &ArrayD<f32>, expected: &[usize]) -> Result<(), TaskDataError> {
     if !targets.iter().all(|&v| v.is_finite()) {
         return Err(TaskDataError::NonFiniteTargets);
     }
-    let width = if targets.ndim() == 1 {
-        1
+    let found = if targets.ndim() == 1 {
+        vec![1]
     } else {
-        targets.len_of(Axis(1))
+        targets.shape()[1..].to_vec()
     };
-    if width != n_outputs {
-        return Err(TaskDataError::WidthMismatch {
-            expected: n_outputs,
-            found: width,
+    if found != expected {
+        return Err(TaskDataError::ShapeMismatch {
+            expected: expected.to_vec(),
+            found,
         });
     }
     Ok(())
@@ -156,8 +162,11 @@ pub enum TaskDataError {
     LabelsNotBinary,
     /// The regression targets contain a non-finite value.
     NonFiniteTargets,
-    /// The target width differs from the task's declared width.
-    WidthMismatch { expected: usize, found: usize },
+    /// The targets' per-sample shape differs from the task's declared shape.
+    ShapeMismatch {
+        expected: Vec<usize>,
+        found: Vec<usize>,
+    },
 }
 
 impl std::fmt::Display for TaskDataError {
@@ -182,9 +191,9 @@ impl std::fmt::Display for TaskDataError {
             TaskDataError::NonFiniteTargets => {
                 write!(f, "regression targets must all be finite")
             }
-            TaskDataError::WidthMismatch { expected, found } => write!(
+            TaskDataError::ShapeMismatch { expected, found } => write!(
                 f,
-                "task declares {expected} outputs, but the targets carry {found}"
+                "task declares shape {expected:?}, but the targets carry shape {found:?}"
             ),
         }
     }
@@ -209,6 +218,13 @@ mod tests {
         Dataset::new(inputs, targets.into_dyn(), None).unwrap()
     }
 
+    /// A two-feature dataset carrying a rank-3 `(samples, height, width)` targets block.
+    fn rank3_target_dataset(targets: ndarray::Array3<f32>) -> Dataset {
+        let inputs =
+            Array2::from_shape_fn((targets.len_of(Axis(0)), 2), |(i, _)| i as f32).into_dyn();
+        Dataset::new(inputs, targets.into_dyn(), None).unwrap()
+    }
+
     /// A dataset with `n_classes` contiguous labels spread across ten samples.
     fn dataset_with_classes(n_classes: usize) -> Dataset {
         tabular_dataset(Array1::from_shape_fn(10, |i| (i % n_classes) as f32))
@@ -228,7 +244,7 @@ mod tests {
         let dataset = tabular_dataset(array![0.5f32, 1.5, 2.25, 0.1]);
         assert_eq!(
             Task::from_dataset(&dataset),
-            Task::Regression { n_outputs: 1 }
+            Task::Regression { shape: vec![1] }
         );
     }
 
@@ -238,7 +254,7 @@ mod tests {
         let dataset = tabular_dataset(array![1.0f32, 1.0, 1.0]);
         assert_eq!(
             Task::from_dataset(&dataset),
-            Task::Regression { n_outputs: 1 }
+            Task::Regression { shape: vec![1] }
         );
     }
 
@@ -256,16 +272,47 @@ mod tests {
         let targets = array![[0.5f32, 1.0], [2.0, 3.5]];
         assert_eq!(
             Task::from_dataset(&rank2_target_dataset(targets)),
-            Task::Regression { n_outputs: 2 }
+            Task::Regression { shape: vec![2] }
         );
     }
 
     #[test]
-    fn output_size_reflects_the_task_width() {
+    fn from_dataset_infers_regression_shape_from_real_rank3_targets() {
+        // A (samples, height, width) target block: the per-sample shape is the trailing axes.
+        let targets = ndarray::Array3::from_shape_fn((2, 3, 4), |(s, h, w)| (s + h + w) as f32);
+        assert_eq!(
+            Task::from_dataset(&rank3_target_dataset(targets)),
+            Task::Regression { shape: vec![3, 4] }
+        );
+    }
+
+    #[test]
+    fn output_shape_reflects_the_task_shape() {
+        assert_eq!(Task::Binary.output_shape(), vec![1]);
+        assert_eq!(Task::MultiClass { n_classes: 4 }.output_shape(), vec![4]);
+        assert_eq!(Task::MultiLabel { n_labels: 3 }.output_shape(), vec![3]);
+        assert_eq!(
+            Task::Regression {
+                shape: vec![3, 4, 4]
+            }
+            .output_shape(),
+            vec![3, 4, 4]
+        );
+    }
+
+    #[test]
+    fn output_size_flattens_the_task_shape() {
         assert_eq!(Task::Binary.output_size(), 1);
         assert_eq!(Task::MultiClass { n_classes: 4 }.output_size(), 4);
         assert_eq!(Task::MultiLabel { n_labels: 3 }.output_size(), 3);
-        assert_eq!(Task::Regression { n_outputs: 2 }.output_size(), 2);
+        assert_eq!(Task::Regression { shape: vec![2] }.output_size(), 2);
+        assert_eq!(
+            Task::Regression {
+                shape: vec![3, 4, 4]
+            }
+            .output_size(),
+            48
+        );
     }
 
     #[test]
@@ -288,7 +335,7 @@ mod tests {
         );
         let regression = rank2_target_dataset(array![[0.5f32, 1.0], [2.0, 3.5]]);
         assert!(
-            Task::Regression { n_outputs: 2 }
+            Task::Regression { shape: vec![2] }
                 .validate_dataset(&regression)
                 .is_ok()
         );
@@ -379,13 +426,13 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_a_multi_label_width_mismatch() {
+    fn validate_rejects_a_multi_label_shape_mismatch() {
         let dataset = rank2_target_dataset(array![[1.0f32, 0.0], [0.0, 1.0]]);
         assert_eq!(
             Task::MultiLabel { n_labels: 3 }.validate_dataset(&dataset),
-            Err(TaskDataError::WidthMismatch {
-                expected: 3,
-                found: 2
+            Err(TaskDataError::ShapeMismatch {
+                expected: vec![3],
+                found: vec![2]
             })
         );
     }
@@ -394,19 +441,34 @@ mod tests {
     fn validate_rejects_non_finite_regression_targets() {
         let dataset = rank2_target_dataset(array![[0.5f32, f32::NAN], [1.0, 2.0]]);
         assert_eq!(
-            Task::Regression { n_outputs: 2 }.validate_dataset(&dataset),
+            Task::Regression { shape: vec![2] }.validate_dataset(&dataset),
             Err(TaskDataError::NonFiniteTargets)
         );
     }
 
     #[test]
-    fn validate_rejects_a_regression_width_mismatch() {
+    fn validate_rejects_a_regression_shape_mismatch() {
         let dataset = rank2_target_dataset(array![[0.5f32, 1.0], [2.0, 3.5]]);
         assert_eq!(
-            Task::Regression { n_outputs: 1 }.validate_dataset(&dataset),
-            Err(TaskDataError::WidthMismatch {
-                expected: 1,
-                found: 2
+            Task::Regression { shape: vec![1] }.validate_dataset(&dataset),
+            Err(TaskDataError::ShapeMismatch {
+                expected: vec![1],
+                found: vec![2]
+            })
+        );
+    }
+
+    #[test]
+    fn validate_rejects_a_regression_rank_mismatch_with_a_matching_element_count() {
+        // A (3, 4) target block flattens to 12 elements, same as a declared [12] shape, but
+        // the rank differs — a flattened count match is not enough.
+        let targets = ndarray::Array3::from_shape_fn((2, 3, 4), |(s, h, w)| (s + h + w) as f32);
+        let dataset = rank3_target_dataset(targets);
+        assert_eq!(
+            Task::Regression { shape: vec![12] }.validate_dataset(&dataset),
+            Err(TaskDataError::ShapeMismatch {
+                expected: vec![12],
+                found: vec![3, 4]
             })
         );
     }
@@ -430,12 +492,12 @@ mod tests {
             "task declares 2 classes, but the targets carry 3"
         );
         assert_eq!(
-            TaskDataError::WidthMismatch {
-                expected: 1,
-                found: 2
+            TaskDataError::ShapeMismatch {
+                expected: vec![1],
+                found: vec![3, 4]
             }
             .to_string(),
-            "task declares 1 outputs, but the targets carry 2"
+            "task declares shape [1], but the targets carry shape [3, 4]"
         );
     }
 }

--- a/core/src/nn/training/hyperparams.rs
+++ b/core/src/nn/training/hyperparams.rs
@@ -506,7 +506,7 @@ impl HyperParameters {
         callbacks: Callbacks,
     ) -> Result<Trainer, BuildError> {
         model.validate_inputs(data.split.train.inputs().view())?;
-        model.validate_output_shape(&[task.output_size()])?;
+        model.validate_task(&task)?;
 
         let optimizer = self.optimizer.instantiate(self.lr, self.weight_decay);
         let scheduler = self
@@ -621,7 +621,7 @@ mod tests {
 
     #[test]
     fn for_task_picks_mean_squared_error_for_a_regression_task() {
-        let loss = LossConfig::for_task(&Task::Regression { n_outputs: 1 });
+        let loss = LossConfig::for_task(&Task::Regression { shape: vec![1] });
         assert_eq!(loss.kind, LossKind::MeanSquaredError);
         assert_eq!(loss.instantiate().name(), "Mean-Squared-Error");
     }


### PR DESCRIPTION
## Summary

- `Task::Regression` now carries an output *shape* (`Vec<usize>`) instead of a flat `n_outputs`, so a regression head no longer has to end in a flat `Dense` layer — a bare `Conv2d`-terminated network can now validate against a matching regression shape.
- `Task::output_shape()`/`output_size()` mirror `NeuralNetwork`'s existing pair (`output_size()` is the product of `output_shape()`).
- `Task::from_dataset` infers the full trailing per-sample shape for any target rank instead of truncating to `Axis(1)` width.
- `NeuralNetwork`'s three validation methods (`validate_input_shape`, `validate_output_shape`, `validate_inputs`) are consolidated into two: `validate_inputs` (array-based) and `validate_task` (shape equality against `task.output_shape()`).
- `TaskDataError::WidthMismatch` merges into the more general `ShapeMismatch`, since both carried the same expected/found shape-mismatch concept.

## Notes

- `Task` no longer derives `Copy` (a `Vec<usize>` field can't be), so several CLI call sites that reused a `Task` value now clone it explicitly — mechanical, no behavior change.
- `MultiLabel` inference narrowed from "any rank ≥ 2 with 0/1 values" to "rank exactly 2 with 0/1 values"; higher-rank 0/1 targets now fall through to `Regression` with their real shape instead of being silently truncated to `Axis(1)` width.
- `train start`'s default (non `--model`) builder still always appends a flat `Dense` output layer, so it now fails fast with a clear `OutputShapeMismatch` for rank-≥3 regression targets instead of silently building a semantically wrong model as before. This is a known, accepted gap tracked separately under the CNN CLI wiring effort (the `--layers` DSL doesn't build conv layers yet) — not addressed in this PR.