### PR TITLE
feat(plot): label panel axes

### DIFF
--- a/core/src/plot/build.rs
+++ b/core/src/plot/build.rs
@@ -104,6 +104,8 @@ impl EvaluationHistory {
             title: "Training Loss Over Epochs".to_string(),
             x_range,
             y_range: (mins[0], maxs[0]),
+            x_label: Some("Epoch".to_string()),
+            y_label: Some("Loss".to_string()),
             show_legend: true,
             series: line_series(
                 &epochs,
@@ -119,6 +121,8 @@ impl EvaluationHistory {
             title: "Training and Test Accuracy Over Epochs".to_string(),
             x_range,
             y_range: (mins[1], maxs[1]),
+            x_label: Some("Epoch".to_string()),
+            y_label: Some("Accuracy".to_string()),
             show_legend: true,
             series: line_series(
                 &epochs,
@@ -184,6 +188,8 @@ fn scatter_panel(
         title: "Scatter Plot of Dataset Features".to_string(),
         x_range: (mins[0], maxs[0]),
         y_range: (mins[1], maxs[1]),
+        x_label: Some("Feature 0".to_string()),
+        y_label: Some("Feature 1".to_string()),
         show_legend,
         series,
     })
@@ -285,6 +291,23 @@ mod tests {
                 .iter()
                 .all(|series| matches!(series, Series::Points { label: Some(_), .. }))
         );
+    }
+
+    #[test]
+    fn scatter_panel_labels_axes_by_feature_index() {
+        let panel = &two_feature_dataset().figure().unwrap().panels[0];
+        assert_eq!(panel.x_label.as_deref(), Some("Feature 0"));
+        assert_eq!(panel.y_label.as_deref(), Some("Feature 1"));
+    }
+
+    #[test]
+    fn history_panels_label_epoch_against_their_own_metric() {
+        let history = EvaluationHistory::new(vec![checkpoint(0), checkpoint(1)]);
+        let figure = history.figure().unwrap();
+        assert_eq!(figure.panels[0].x_label.as_deref(), Some("Epoch"));
+        assert_eq!(figure.panels[0].y_label.as_deref(), Some("Loss"));
+        assert_eq!(figure.panels[1].x_label.as_deref(), Some("Epoch"));
+        assert_eq!(figure.panels[1].y_label.as_deref(), Some("Accuracy"));
     }
 
     #[test]

--- a/core/src/plot/console/figure.rs
+++ b/core/src/plot/console/figure.rs
@@ -33,13 +33,18 @@ impl Figure {
     }
 }
 
-/// Renders one panel as a titled block: its title, the plotted canvas, and —
-/// when the panel carries a legend — a colored key beneath it.
+/// Renders one panel as a titled block: its title, the plotted canvas, the
+/// axis labels (when either axis carries one), and — when the panel carries a
+/// legend — a colored key beneath it.
 fn render_block(panel: &Panel, cfg: &ConsoleConfig) -> String {
     let mut block = String::new();
     block.push_str(&panel.title);
     block.push('\n');
     block.push_str(&render_panel(panel, cfg));
+    if let Some(axis_labels) = axis_label_line(panel) {
+        block.push_str(&axis_labels);
+        block.push('\n');
+    }
     if panel.show_legend
         && let Some(legend) = legend_line(panel)
     {
@@ -47,6 +52,20 @@ fn render_block(panel: &Panel, cfg: &ConsoleConfig) -> String {
         block.push('\n');
     }
     block
+}
+
+/// A one-line `x: <label>   y: <label>` caption, omitting either axis missing
+/// a label, or `None` when neither axis carries one.
+fn axis_label_line(panel: &Panel) -> Option<String> {
+    let entries: Vec<String> = [
+        panel.x_label.as_deref().map(|label| format!("x: {label}")),
+        panel.y_label.as_deref().map(|label| format!("y: {label}")),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    (!entries.is_empty()).then(|| entries.join("   "))
 }
 
 /// Joins panel blocks side by side, padding each to its own visible width and
@@ -165,6 +184,8 @@ mod tests {
             title: "Loss".to_string(),
             x_range: (0.0, 10.0),
             y_range: (0.0, 1.0),
+            x_label: Some("Epoch".to_string()),
+            y_label: Some("Loss".to_string()),
             show_legend: true,
             series: vec![
                 Series::Line {
@@ -200,6 +221,25 @@ mod tests {
         let text = figure.to_console(&ConsoleConfig::new(64, 32).unwrap());
         // The labeled line shows up in the key, in its own truecolor swatch.
         assert!(text.contains("\u{1b}[38;2;214;39;40m\u{25cf}\u{1b}[0m Train"));
+    }
+
+    #[test]
+    fn to_console_appends_an_axis_label_line_beneath_the_canvas() {
+        let figure = Figure::chart(vec![line_panel()]);
+        let text = figure.to_console(&ConsoleConfig::new(64, 32).unwrap());
+        assert!(text.contains("x: Epoch   y: Loss\n"));
+    }
+
+    #[test]
+    fn axis_label_line_omits_a_missing_axis_and_is_none_without_either() {
+        let mut x_only = line_panel();
+        x_only.y_label = None;
+        assert_eq!(axis_label_line(&x_only), Some("x: Epoch".to_string()));
+
+        let mut neither = line_panel();
+        neither.x_label = None;
+        neither.y_label = None;
+        assert_eq!(axis_label_line(&neither), None);
     }
 
     #[test]

--- a/core/src/plot/console/figure.rs
+++ b/core/src/plot/console/figure.rs
@@ -57,14 +57,19 @@ fn render_block(panel: &Panel, cfg: &ConsoleConfig) -> String {
 /// A one-line `x: <label>   y: <label>` caption, omitting either axis missing
 /// a label, or `None` when neither axis carries one.
 fn axis_label_line(panel: &Panel) -> Option<String> {
-    let entries: Vec<String> = [
-        panel.x_label.as_deref().map(|label| format!("x: {label}")),
-        panel.y_label.as_deref().map(|label| format!("y: {label}")),
-    ]
-    .into_iter()
-    .flatten()
-    .collect();
+    joined_line(
+        [
+            panel.x_label.as_deref().map(|label| format!("x: {label}")),
+            panel.y_label.as_deref().map(|label| format!("y: {label}")),
+        ]
+        .into_iter()
+        .flatten()
+        .collect(),
+    )
+}
 
+/// `entries` joined with a triple-space gutter, or `None` when empty.
+fn joined_line(entries: Vec<String>) -> Option<String> {
     (!entries.is_empty()).then(|| entries.join("   "))
 }
 
@@ -129,20 +134,20 @@ fn display_width(line: &str) -> usize {
 /// A one-line color key for a panel's labeled series — a swatch in each series'
 /// own color followed by its label — or `None` when no series carries a label.
 fn legend_line(panel: &Panel) -> Option<String> {
-    let entries: Vec<String> = panel
-        .series
-        .iter()
-        .filter_map(|series| {
-            let (color, label) = match series {
-                Series::Line { color, label, .. } | Series::Points { color, label, .. } => {
-                    (color, label.as_deref()?)
-                }
-            };
-            Some(format!("{} {label}", swatch(*color)))
-        })
-        .collect();
-
-    (!entries.is_empty()).then(|| entries.join("   "))
+    joined_line(
+        panel
+            .series
+            .iter()
+            .filter_map(|series| {
+                let (color, label) = match series {
+                    Series::Line { color, label, .. } | Series::Points { color, label, .. } => {
+                        (color, label.as_deref()?)
+                    }
+                };
+                Some(format!("{} {label}", swatch(*color)))
+            })
+            .collect(),
+    )
 }
 
 /// The `textplots` color for a scene color.

--- a/core/src/plot/image/figure.rs
+++ b/core/src/plot/image/figure.rs
@@ -49,7 +49,14 @@ fn draw_panel(
         .y_label_area_size(cfg.area_size)
         .build_cartesian_2d(x_min..x_max, y_min..y_max)?;
 
-    chart.configure_mesh().draw()?;
+    let mut mesh = chart.configure_mesh();
+    if let Some(x_label) = &panel.x_label {
+        mesh.x_desc(x_label.as_str());
+    }
+    if let Some(y_label) = &panel.y_label {
+        mesh.y_desc(y_label.as_str());
+    }
+    mesh.draw()?;
 
     for series in &panel.series {
         draw_series(&mut chart, series)?;
@@ -126,6 +133,8 @@ mod tests {
             title: "Lines".to_string(),
             x_range: (0.0, 10.0),
             y_range: (0.0, 1.0),
+            x_label: Some("X".to_string()),
+            y_label: Some("Y".to_string()),
             show_legend: true,
             series: vec![
                 Series::Line {
@@ -154,6 +163,8 @@ mod tests {
             title: "Scatter".to_string(),
             x_range: (0.0, 1.0),
             y_range: (0.0, 1.0),
+            x_label: None,
+            y_label: None,
             show_legend: false,
             series: vec![
                 Series::Line {
@@ -187,6 +198,8 @@ mod tests {
             title: "Panel".to_string(),
             x_range: (0.0, 1.0),
             y_range: (0.0, 1.0),
+            x_label: None,
+            y_label: None,
             show_legend: false,
             series: Vec::new(),
         };

--- a/core/src/plot/scene.rs
+++ b/core/src/plot/scene.rs
@@ -90,6 +90,8 @@ pub struct Panel {
     pub title: String,
     pub x_range: (f32, f32),
     pub y_range: (f32, f32),
+    pub x_label: Option<String>,
+    pub y_label: Option<String>,
     pub show_legend: bool,
     pub series: Vec<Series>,
 }
@@ -210,6 +212,8 @@ mod tests {
             title: String::new(),
             x_range,
             y_range,
+            x_label: None,
+            y_label: None,
             show_legend: false,
             series: Vec::new(),
         }


### PR DESCRIPTION
## Summary

- `Panel` gains `x_label`/`y_label`, filled by `scatter_panel` (`"Feature 0"`/`"Feature 1"`, matching the wording `predict`'s interactive prompt uses per feature index) and by `EvaluationHistory::figure` (`"Epoch"`/`"Loss"`/`"Accuracy"`).
- Both renderers pick them up: `x_desc`/`y_desc` in the `plotters` image renderer, a new `x: <label>   y: <label>` caption line beneath the console canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)