### PR TITLE
feat(nn): sparse categorical cross-entropy for multi-class

### DIFF
--- a/cli/src/display/hyperparameters.rs
+++ b/cli/src/display/hyperparameters.rs
@@ -67,6 +67,7 @@ fn loss_value(loss: &LossConfig) -> String {
     match loss.kind {
         LossKind::BinaryCrossEntropy => "Binary Cross-Entropy".to_string(),
         LossKind::CategoricalCrossEntropy => "Categorical Cross-Entropy".to_string(),
+        LossKind::SparseCategoricalCrossEntropy => "Sparse Categorical Cross-Entropy".to_string(),
         LossKind::MeanSquaredError => "Mean Squared Error".to_string(),
     }
 }

--- a/core/src/data/dataset.rs
+++ b/core/src/data/dataset.rs
@@ -196,9 +196,9 @@ impl Dataset {
     }
 
     /// Transforms the dataset into a samples-last [`ModelDataset`]: inputs are
-    /// rotated so the sample axis trails; `ClassLabel` targets become one-hot
-    /// rows (multi-class) or a single 0/1 row (binary), while `Value` targets
-    /// are rotated samples-last unchanged.
+    /// rotated so the sample axis trails; `ClassLabel` targets become a single
+    /// class-id row, binary and multi-class alike, while `Value` targets are
+    /// rotated samples-last unchanged.
     pub fn to_model_dataset(&self) -> ModelDataset {
         let inputs = self
             .features
@@ -207,19 +207,9 @@ impl Dataset {
 
         let targets: ArrayD<f32> = match &self.targets {
             Targets::ClassLabel(label) => {
-                let class_count = label.class_count();
-                let ids = label.ids();
-                if class_count > 2 {
-                    let mut one_hot = Array2::zeros((class_count, ids.len()));
-                    for (i, &id) in ids.iter().enumerate() {
-                        one_hot[[id as usize, i]] = 1.0;
-                    }
-                    one_hot.into_dyn()
-                } else {
-                    Array1::from_iter(ids.iter().map(|&id| id as f32))
-                        .insert_axis(Axis(0))
-                        .into_dyn()
-                }
+                Array1::from_iter(label.ids().iter().map(|&id| id as f32))
+                    .insert_axis(Axis(0))
+                    .into_dyn()
             }
             Targets::Value(values) => {
                 let values = values.as_array();
@@ -369,6 +359,11 @@ impl ModelDataset {
         self.inputs.shape()[self.inputs.ndim() - 1]
     }
 
+    /// The per-sample target shape: the targets' axes excluding the trailing sample axis.
+    pub fn target_shape(&self) -> &[usize] {
+        &self.targets.shape()[..self.targets.ndim() - 1]
+    }
+
     /// Gathers the samples at `indices` — along the trailing sample axis of both inputs
     /// and targets — into a fresh owned dataset.
     fn select(&self, indices: &[usize]) -> ModelDataset {
@@ -467,16 +462,21 @@ mod tests {
     }
 
     #[test]
-    fn valid_multiclass_labels_produce_correct_one_hot() {
+    fn multiclass_labels_produce_a_single_class_id_row() {
         let features = Array2::zeros((3, 2));
         let dataset = Dataset::tabular(features, class_ids(vec![0, 1, 2]), None).unwrap();
         let model_dataset = dataset.to_model_dataset();
-        // targets shape: (n_classes=3, n_samples=3)
-        assert_eq!(model_dataset.targets.shape(), &[3, 3]);
-        // Each column is one-hot: column i has 1.0 at row i
-        for i in 0..3 {
-            assert_eq!(model_dataset.targets[[i, i]], 1.0);
-        }
+        // Multi-class labels stay as a single (1, n_samples) class-id row, not one-hot encoded.
+        assert_eq!(model_dataset.targets.shape(), &[1, 3]);
+        assert_eq!(
+            model_dataset
+                .targets
+                .index_axis(Axis(0), 0)
+                .iter()
+                .copied()
+                .collect::<Vec<f32>>(),
+            vec![0.0, 1.0, 2.0]
+        );
     }
 
     #[test]

--- a/core/src/io/model/hyperparams.rs
+++ b/core/src/io/model/hyperparams.rs
@@ -146,6 +146,7 @@ pub struct LossRecord {
 pub enum LossKindRecord {
     BinaryCrossEntropy,
     CategoricalCrossEntropy,
+    SparseCategoricalCrossEntropy,
     MeanSquaredError,
 }
 
@@ -178,6 +179,9 @@ impl From<&LossKind> for LossKindRecord {
         match kind {
             LossKind::BinaryCrossEntropy => LossKindRecord::BinaryCrossEntropy,
             LossKind::CategoricalCrossEntropy => LossKindRecord::CategoricalCrossEntropy,
+            LossKind::SparseCategoricalCrossEntropy => {
+                LossKindRecord::SparseCategoricalCrossEntropy
+            }
             LossKind::MeanSquaredError => LossKindRecord::MeanSquaredError,
         }
     }
@@ -188,6 +192,9 @@ impl From<&LossKindRecord> for LossKind {
         match record {
             LossKindRecord::BinaryCrossEntropy => LossKind::BinaryCrossEntropy,
             LossKindRecord::CategoricalCrossEntropy => LossKind::CategoricalCrossEntropy,
+            LossKindRecord::SparseCategoricalCrossEntropy => {
+                LossKind::SparseCategoricalCrossEntropy
+            }
             LossKindRecord::MeanSquaredError => LossKind::MeanSquaredError,
         }
     }

--- a/core/src/nn/accuracies/mod.rs
+++ b/core/src/nn/accuracies/mod.rs
@@ -1,8 +1,10 @@
 mod binary_accuracy;
 mod categorical_accuracy;
+mod sparse_categorical_accuracy;
 
 pub use binary_accuracy::{BINARY_ACCURACY, BinaryAccuracy};
 pub use categorical_accuracy::{CATEGORICAL_ACCURACY, CategoricalAccuracy};
+pub use sparse_categorical_accuracy::{SPARSE_CATEGORICAL_ACCURACY, SparseCategoricalAccuracy};
 
 use ndarray::ArrayViewD;
 
@@ -14,7 +16,8 @@ pub trait Accuracy: Send + Sync {
     /// # Arguments
     /// - `outputs`: the network's scores with the class axis first (axis 0); every trailing axis —
     ///   the samples, plus any spatial axes — is a position scored independently.
-    /// - `targets`: the ground-truth labels, the same shape as `outputs`.
+    /// - `targets`: the ground-truth labels, laid out per implementation (e.g. the same shape
+    ///   as `outputs`, or a single class-id row).
     ///
     /// # Returns
     /// The accuracy as a percentage (0.0 to 100.0).

--- a/core/src/nn/accuracies/sparse_categorical_accuracy.rs
+++ b/core/src/nn/accuracies/sparse_categorical_accuracy.rs
@@ -1,0 +1,122 @@
+//! Sparse categorical accuracy metric, for a multi-class (softmax) output scored against
+//! direct class ids rather than one-hot targets.
+//!
+//! Predictions carry the per-class scores on their leading axis (axis 0); targets carry a
+//! single class-id row on that same axis. Every trailing axis — the samples, plus any spatial
+//! axes — is a position scored independently: the predicted class is the argmax of the
+//! prediction lane, matched against the target lane's id. The metric is the ratio of correctly
+//! classified positions to the total.
+
+use crate::accuracies::Accuracy;
+use ndarray::{ArrayView1, ArrayViewD, Axis};
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+
+pub struct SparseCategoricalAccuracy;
+
+impl Accuracy for SparseCategoricalAccuracy {
+    /// Computes the sparse categorical accuracy over every position of a batch.
+    ///
+    /// # Arguments
+    /// - `outputs`: the network's scores with the class axis first (axis 0); every trailing axis
+    ///   — the samples, plus any spatial axes — is a position scored independently.
+    /// - `targets`: a single class-id row on axis 0, matching `outputs` on every other axis.
+    ///
+    /// # Returns
+    /// The accuracy as a percentage (0.0 to 100.0): the fraction of positions whose predicted
+    /// class matches the target id.
+    ///
+    /// # Panics
+    /// When `targets`' leading axis does not have length one, when `outputs` and `targets` do
+    /// not agree on every other axis, or when there are fewer than two classes on `outputs`'
+    /// leading axis.
+    fn compute(&self, outputs: ArrayViewD<f32>, targets: ArrayViewD<f32>) -> f32 {
+        assert_eq!(
+            targets.shape()[0],
+            1,
+            "Sparse targets must carry a single class-id row."
+        );
+        assert_eq!(
+            outputs.shape()[1..],
+            targets.shape()[1..],
+            "Outputs and targets must agree on every axis but the class axis."
+        );
+        assert!(
+            outputs.shape()[0] >= 2,
+            "Categorical accuracy expects at least two classes on the leading axis."
+        );
+
+        // Every axis but the class axis is a position: samples, plus any spatial axes.
+        let positions = outputs.len() / outputs.shape()[0];
+
+        // The class axis is a lane per position; the prediction is its argmax, matched against
+        // the target id at that position.
+        let argmax = |lane: ArrayView1<f32>| -> usize {
+            lane.iter()
+                .enumerate()
+                .max_by(|(_, left), (_, right)| left.total_cmp(right))
+                .map(|(idx, _)| idx)
+                .unwrap()
+        };
+        let ids = targets.index_axis(Axis(0), 0);
+        let correct = outputs
+            .lanes(Axis(0))
+            .into_iter()
+            .zip(ids.iter())
+            .filter(|(prediction, id)| argmax(*prediction) == **id as usize)
+            .count();
+
+        correct as f32 * 100.0 / (positions as f32)
+    }
+}
+
+/// Shared static instance of `SparseCategoricalAccuracy` for convenient reuse.
+pub static SPARSE_CATEGORICAL_ACCURACY: Lazy<Arc<SparseCategoricalAccuracy>> =
+    Lazy::new(|| Arc::new(SparseCategoricalAccuracy));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn all_correct_gives_100_percent() {
+        let outputs = array![[0.9_f32, 0.1], [0.1, 0.9]].into_dyn();
+        let targets = array![[0.0_f32, 1.0]].into_dyn();
+        let acc = SPARSE_CATEGORICAL_ACCURACY.compute(outputs.view(), targets.view());
+        assert!((acc - 100.0).abs() < 1e-5, "Expected 100%, got {acc}");
+    }
+
+    #[test]
+    fn does_not_panic_on_nan_predictions() {
+        let outputs = array![[f32::NAN, 1.0], [0.5_f32, 0.8]].into_dyn();
+        let targets = array![[1.0_f32, 0.0]].into_dyn();
+        let _ = SPARSE_CATEGORICAL_ACCURACY.compute(outputs.view(), targets.view());
+    }
+
+    #[test]
+    fn scores_every_spatial_position_by_argmax_over_the_class_axis() {
+        // (n_classes=2, height=2, samples=2): argmax over axis 0 at each of the 4 positions.
+        // Three of the four positions match their target id → 75%.
+        let outputs = array![[[2.0_f32, 1.0], [2.0, 1.0]], [[1.0, 2.0], [1.0, 2.0]]].into_dyn();
+        let targets = array![[[0.0_f32, 1.0], [1.0, 1.0]]].into_dyn();
+        let acc = SPARSE_CATEGORICAL_ACCURACY.compute(outputs.view(), targets.view());
+        assert!((acc - 75.0).abs() < 1e-5, "Expected 75%, got {acc}");
+    }
+
+    #[test]
+    #[should_panic(expected = "at least two classes")]
+    fn panics_on_a_single_class_row() {
+        let outputs = array![[0.5_f32, -0.5]].into_dyn();
+        let targets = array![[0.0_f32, 0.0]].into_dyn();
+        let _ = SPARSE_CATEGORICAL_ACCURACY.compute(outputs.view(), targets.view());
+    }
+
+    #[test]
+    #[should_panic(expected = "single class-id row")]
+    fn panics_on_a_one_hot_target_shape() {
+        let outputs = array![[0.9_f32, 0.1], [0.1, 0.9]].into_dyn();
+        let targets = array![[1.0_f32, 0.0], [0.0, 1.0]].into_dyn();
+        let _ = SPARSE_CATEGORICAL_ACCURACY.compute(outputs.view(), targets.view());
+    }
+}

--- a/core/src/nn/loss_functions/categorical_cross_entropy.rs
+++ b/core/src/nn/loss_functions/categorical_cross_entropy.rs
@@ -35,7 +35,16 @@ impl LossFunction for CategoricalCrossEntropy {
     /// # Arguments
     /// * `inputs` - N-D array view where Axis(0) is `classes`.
     /// * `targets` - N-D array view of matching shape with true labels (one-hot or soft targets).
+    ///
+    /// # Panics
+    /// When `inputs` and `targets` do not have the same shape.
     fn terms(&self, inputs: ArrayViewD<f32>, targets: ArrayViewD<f32>) -> ArrayD<f32> {
+        assert_eq!(
+            inputs.shape(),
+            targets.shape(),
+            "Inputs and targets must have the same shape."
+        );
+
         // Per-position log-sum-exp over the class lane, max-shifted for numerical stability.
         let logsumexp = inputs.map_axis(Axis(0), |lane| {
             let max = lane.iter().copied().fold(f32::NEG_INFINITY, f32::max);
@@ -50,7 +59,16 @@ impl LossFunction for CategoricalCrossEntropy {
     /// Computes ∂L/∂z — the gradient of the loss with respect to the logits: the per-position
     /// residual `softmax(z) − y`, scaled by the [`Reduction`] over the positions (the class lane
     /// is a single term). Works out-of-the-box for N-Dimensional tensors.
+    ///
+    /// # Panics
+    /// When `inputs` and `targets` do not have the same shape.
     fn gradient(&self, inputs: ArrayViewD<f32>, targets: ArrayViewD<f32>) -> ArrayD<f32> {
+        assert_eq!(
+            inputs.shape(),
+            targets.shape(),
+            "Inputs and targets must have the same shape."
+        );
+
         let positions = inputs.len() / inputs.shape()[0];
         let residual = SOFTMAX.apply(inputs) - targets;
         self.reduction.scale_gradient(residual, positions)
@@ -150,5 +168,22 @@ mod tests {
     #[test]
     fn name_is_stable() {
         assert_eq!(cce().name(), "Categorical-Cross-Entropy");
+    }
+
+    #[test]
+    #[should_panic(expected = "must have the same shape")]
+    fn terms_panics_on_a_shape_mismatch() {
+        // A single class-id row instead of a one-hot target: must panic, not silently broadcast.
+        let inputs = array![[0.0_f32, 0.0], [0.0, 0.0], [0.0, 0.0]].into_dyn();
+        let targets = array![[1.0_f32, 2.0]].into_dyn();
+        let _ = cce().terms(inputs.view(), targets.view());
+    }
+
+    #[test]
+    #[should_panic(expected = "must have the same shape")]
+    fn gradient_panics_on_a_shape_mismatch() {
+        let inputs = array![[0.0_f32, 0.0], [0.0, 0.0], [0.0, 0.0]].into_dyn();
+        let targets = array![[1.0_f32, 2.0]].into_dyn();
+        let _ = cce().gradient(inputs.view(), targets.view());
     }
 }

--- a/core/src/nn/loss_functions/mod.rs
+++ b/core/src/nn/loss_functions/mod.rs
@@ -7,10 +7,12 @@
 mod binary_cross_entropy;
 mod categorical_cross_entropy;
 mod mean_squared_error;
+mod sparse_categorical_cross_entropy;
 
 pub use binary_cross_entropy::BinaryCrossEntropy;
 pub use categorical_cross_entropy::CategoricalCrossEntropy;
 pub use mean_squared_error::MeanSquaredError;
+pub use sparse_categorical_cross_entropy::SparseCategoricalCrossEntropy;
 
 use ndarray::{ArrayD, ArrayViewD};
 

--- a/core/src/nn/loss_functions/sparse_categorical_cross_entropy.rs
+++ b/core/src/nn/loss_functions/sparse_categorical_cross_entropy.rs
@@ -1,0 +1,207 @@
+//! Sparse categorical cross-entropy loss for multi-class classification, computed from
+//! **logits** against direct class ids rather than one-hot targets.
+//! Supports N-Dimensional tensors laid out samples-last (the leading axis is always the classes).
+//!
+//! Softmax + categorical cross-entropy, valued via a max-shifted log-sum-exp for numerical
+//! stability; the gradient is `softmax(z) − onehot(y)`, computed without materializing the
+//! one-hot row.
+
+use crate::activations::{Activation, SOFTMAX};
+use crate::loss_functions::{LossFunction, Reduction};
+use ndarray::{ArrayD, ArrayViewD, Axis};
+
+/// Categorical cross-entropy from logits: `k` softmax outputs per position, matched against a
+/// single class-id target lane. The loss is per-position; [`Reduction`] collapses it.
+pub struct SparseCategoricalCrossEntropy {
+    reduction: Reduction,
+}
+
+impl SparseCategoricalCrossEntropy {
+    /// Builds a sparse categorical cross-entropy loss with the given [`Reduction`].
+    pub fn new(reduction: Reduction) -> Self {
+        Self { reduction }
+    }
+}
+
+impl LossFunction for SparseCategoricalCrossEntropy {
+    fn name(&self) -> &'static str {
+        "Sparse-Categorical-Cross-Entropy"
+    }
+
+    fn reduction(&self) -> Reduction {
+        self.reduction
+    }
+
+    /// Computes the per-position loss from N-Dimensional logits.
+    ///
+    /// # Arguments
+    /// * `inputs` - N-D array view where Axis(0) is `classes`.
+    /// * `targets` - N-D array view whose Axis(0) is a single class-id row, matching `inputs`
+    ///   on every other axis.
+    fn terms(&self, inputs: ArrayViewD<f32>, targets: ArrayViewD<f32>) -> ArrayD<f32> {
+        // Per-position log-sum-exp over the class lane, max-shifted for numerical stability.
+        let logsumexp = inputs.map_axis(Axis(0), |lane| {
+            let max = lane.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            max + lane.iter().map(|&z| (z - max).exp()).sum::<f32>().ln()
+        });
+        // Categorical cross-entropy per position: logsumexp − the true class's logit.
+        let ids = targets.index_axis(Axis(0), 0);
+        let true_logit = inputs
+            .lanes(Axis(0))
+            .into_iter()
+            .zip(ids.iter())
+            .map(|(lane, &id)| lane[id as usize]);
+        logsumexp - ArrayD::from_shape_vec(ids.raw_dim(), true_logit.collect()).unwrap()
+    }
+
+    /// Computes ∂L/∂z — the gradient of the loss with respect to the logits: the per-position
+    /// residual `softmax(z) − onehot(y)`, scaled by the [`Reduction`] over the positions (the
+    /// class lane is a single term). Works out-of-the-box for N-Dimensional tensors.
+    fn gradient(&self, inputs: ArrayViewD<f32>, targets: ArrayViewD<f32>) -> ArrayD<f32> {
+        let positions = inputs.len() / inputs.shape()[0];
+        let mut residual = SOFTMAX.apply(inputs);
+        let ids = targets.index_axis(Axis(0), 0);
+        for (mut lane, &id) in residual.lanes_mut(Axis(0)).into_iter().zip(ids.iter()) {
+            lane[id as usize] -= 1.0;
+        }
+        self.reduction.scale_gradient(residual, positions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::loss_functions::CategoricalCrossEntropy;
+    use ndarray::array;
+
+    /// Mean-reduced sparse categorical cross-entropy, the default used throughout training.
+    fn sparse_cce() -> SparseCategoricalCrossEntropy {
+        SparseCategoricalCrossEntropy::new(Reduction::Mean)
+    }
+
+    #[test]
+    fn confident_correct_logits_give_near_zero_loss() {
+        // Two positions, both peaking on the true class → near-zero loss.
+        let inputs = array![[10.0_f32, -10.0], [-10.0, 10.0]].into_dyn();
+        let targets = array![[0.0_f32, 1.0]].into_dyn();
+        let loss = sparse_cce().compute(inputs.view(), targets.view());
+        assert!((0.0..1e-3).contains(&loss), "loss was {loss}");
+    }
+
+    #[test]
+    fn uniform_logits_give_ln_of_n_classes() {
+        // Equal logits → softmax is uniform → per-position loss is ln(k).
+        let inputs = array![[0.0_f32], [0.0], [0.0]].into_dyn();
+        let targets = array![[0.0_f32]].into_dyn();
+        let loss = sparse_cce().compute(inputs.view(), targets.view());
+        assert!((loss - 3.0_f32.ln()).abs() < 1e-6, "loss was {loss}");
+    }
+
+    #[test]
+    fn sum_totals_every_position() {
+        // Two uniform 3-class positions: Sum = 2·ln(3), Mean = ln(3).
+        let inputs = array![[0.0_f32, 0.0], [0.0, 0.0], [0.0, 0.0]].into_dyn();
+        let targets = array![[0.0_f32, 1.0]].into_dyn();
+        let sum = SparseCategoricalCrossEntropy::new(Reduction::Sum)
+            .compute(inputs.view(), targets.view());
+        let mean = sparse_cce().compute(inputs.view(), targets.view());
+        assert!((sum - 2.0 * 3.0_f32.ln()).abs() < 1e-6, "sum was {sum}");
+        assert!((mean - 3.0_f32.ln()).abs() < 1e-6, "mean was {mean}");
+    }
+
+    #[test]
+    fn mean_scores_every_spatial_position() {
+        // (n_classes=2, height=2, samples=1): two uniform positions → Mean = ln(2).
+        let inputs = array![[[0.0_f32], [0.0]], [[0.0], [0.0]]].into_dyn();
+        let targets = array![[[0.0_f32], [1.0]]].into_dyn();
+        let loss = sparse_cce().compute(inputs.view(), targets.view());
+        assert!((loss - 2.0_f32.ln()).abs() < 1e-6, "loss was {loss}");
+    }
+
+    #[test]
+    fn gradient_is_softmax_minus_onehot() {
+        // Uniform logits → softmax 0.5 each; grad = 0.5 - onehot(y).
+        let inputs = array![[0.0_f32], [0.0]].into_dyn();
+        let targets = array![[0.0_f32]].into_dyn();
+        let grad = sparse_cce().gradient(inputs.view(), targets.view());
+        let (g0, g1) = (grad[[0, 0]], grad[[1, 0]]);
+        assert!((g0 - (-0.5)).abs() < 1e-6, "grad was {g0}");
+        assert!((g1 - 0.5).abs() < 1e-6, "grad was {g1}");
+    }
+
+    #[test]
+    fn mean_gradient_divides_the_residual_by_the_position_count() {
+        // Two uniform 2-class positions: residual is softmax(0.5) − onehot(y) at each, and Mean
+        // halves it over the two positions (the class lane counts as a single term).
+        let inputs = array![[0.0_f32, 0.0], [0.0, 0.0]].into_dyn();
+        let targets = array![[0.0_f32, 1.0]].into_dyn();
+        let grad = sparse_cce().gradient(inputs.view(), targets.view());
+        // Position 0: (0.5-1, 0.5-0)/2 = (-0.25, 0.25); position 1: (0.5, 0.5-1)/2 = (0.25, -0.25).
+        assert!(
+            (grad[[0, 0]] - (-0.25)).abs() < 1e-6,
+            "grad was {}",
+            grad[[0, 0]]
+        );
+        assert!(
+            (grad[[1, 0]] - 0.25).abs() < 1e-6,
+            "grad was {}",
+            grad[[1, 0]]
+        );
+        assert!(
+            (grad[[0, 1]] - 0.25).abs() < 1e-6,
+            "grad was {}",
+            grad[[0, 1]]
+        );
+        assert!(
+            (grad[[1, 1]] - (-0.25)).abs() < 1e-6,
+            "grad was {}",
+            grad[[1, 1]]
+        );
+    }
+
+    #[test]
+    fn matches_one_hot_categorical_cross_entropy_bit_for_bit() {
+        let inputs = array![[2.0_f32, -1.0, 0.5], [0.1, 3.0, -2.0], [-1.5, 0.4, 1.2]].into_dyn();
+        let ids = array![[0.0_f32, 1.0, 2.0]].into_dyn();
+        let one_hot = array![[1.0_f32, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]].into_dyn();
+
+        let sparse = sparse_cce();
+        let dense = CategoricalCrossEntropy::new(Reduction::Mean);
+
+        assert_eq!(
+            sparse.compute(inputs.view(), ids.view()),
+            dense.compute(inputs.view(), one_hot.view())
+        );
+        assert_eq!(
+            sparse.gradient(inputs.view(), ids.view()),
+            dense.gradient(inputs.view(), one_hot.view())
+        );
+    }
+
+    #[test]
+    fn stays_finite_where_dense_one_hot_would_nan_on_a_masked_class() {
+        // A -inf logit on a *non-true* class (e.g. a masked-out class) is otherwise harmless:
+        // `exp(-inf - max) = 0.0` inside log-sum-exp. But dense one-hot CCE also computes
+        // `sum_yz = Σ(inputs · targets)`, and `-inf * 0.0 = NaN` in IEEE 754 poisons that sum
+        // even though the target is exactly 0 there. Sparse never multiplies by the target — it
+        // indexes the true class's logit directly — so it stays finite.
+        let inputs = array![[5.0_f32], [f32::NEG_INFINITY]].into_dyn();
+        let ids = array![[0.0_f32]].into_dyn();
+        let one_hot = array![[1.0_f32], [0.0]].into_dyn();
+
+        let sparse_loss = sparse_cce().compute(inputs.view(), ids.view());
+        let dense_loss =
+            CategoricalCrossEntropy::new(Reduction::Mean).compute(inputs.view(), one_hot.view());
+
+        assert!(sparse_loss.is_finite(), "loss was {sparse_loss}");
+        assert!(
+            dense_loss.is_nan(),
+            "expected dense CCE to NaN on -inf * 0.0"
+        );
+    }
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(sparse_cce().name(), "Sparse-Categorical-Cross-Entropy");
+    }
+}

--- a/core/src/nn/loss_functions/sparse_categorical_cross_entropy.rs
+++ b/core/src/nn/loss_functions/sparse_categorical_cross_entropy.rs
@@ -38,7 +38,23 @@ impl LossFunction for SparseCategoricalCrossEntropy {
     /// * `inputs` - N-D array view where Axis(0) is `classes`.
     /// * `targets` - N-D array view whose Axis(0) is a single class-id row, matching `inputs`
     ///   on every other axis.
+    ///
+    /// # Panics
+    /// When `targets`' leading axis does not have length one, when `inputs` and `targets` do
+    /// not agree on every other axis, or when a target id is out of bounds for `inputs`'
+    /// leading axis.
     fn terms(&self, inputs: ArrayViewD<f32>, targets: ArrayViewD<f32>) -> ArrayD<f32> {
+        assert_eq!(
+            targets.shape()[0],
+            1,
+            "Sparse targets must carry a single class-id row."
+        );
+        assert_eq!(
+            inputs.shape()[1..],
+            targets.shape()[1..],
+            "Inputs and targets must agree on every axis but the class axis."
+        );
+
         // Per-position log-sum-exp over the class lane, max-shifted for numerical stability.
         let logsumexp = inputs.map_axis(Axis(0), |lane| {
             let max = lane.iter().copied().fold(f32::NEG_INFINITY, f32::max);
@@ -57,7 +73,23 @@ impl LossFunction for SparseCategoricalCrossEntropy {
     /// Computes ∂L/∂z — the gradient of the loss with respect to the logits: the per-position
     /// residual `softmax(z) − onehot(y)`, scaled by the [`Reduction`] over the positions (the
     /// class lane is a single term). Works out-of-the-box for N-Dimensional tensors.
+    ///
+    /// # Panics
+    /// When `targets`' leading axis does not have length one, when `inputs` and `targets` do
+    /// not agree on every other axis, or when a target id is out of bounds for `inputs`'
+    /// leading axis.
     fn gradient(&self, inputs: ArrayViewD<f32>, targets: ArrayViewD<f32>) -> ArrayD<f32> {
+        assert_eq!(
+            targets.shape()[0],
+            1,
+            "Sparse targets must carry a single class-id row."
+        );
+        assert_eq!(
+            inputs.shape()[1..],
+            targets.shape()[1..],
+            "Inputs and targets must agree on every axis but the class axis."
+        );
+
         let positions = inputs.len() / inputs.shape()[0];
         let mut residual = SOFTMAX.apply(inputs);
         let ids = targets.index_axis(Axis(0), 0);
@@ -203,5 +235,30 @@ mod tests {
     #[test]
     fn name_is_stable() {
         assert_eq!(sparse_cce().name(), "Sparse-Categorical-Cross-Entropy");
+    }
+
+    #[test]
+    #[should_panic(expected = "single class-id row")]
+    fn terms_panics_on_a_one_hot_target() {
+        // A stale one-hot target instead of a class-id row: must panic, not silently misread row 0.
+        let inputs = array![[0.0_f32, 0.0], [0.0, 0.0], [0.0, 0.0]].into_dyn();
+        let targets = array![[1.0_f32, 0.0], [0.0, 1.0], [0.0, 0.0]].into_dyn();
+        let _ = sparse_cce().terms(inputs.view(), targets.view());
+    }
+
+    #[test]
+    #[should_panic(expected = "single class-id row")]
+    fn gradient_panics_on_a_one_hot_target() {
+        let inputs = array![[0.0_f32, 0.0], [0.0, 0.0], [0.0, 0.0]].into_dyn();
+        let targets = array![[1.0_f32, 0.0], [0.0, 1.0], [0.0, 0.0]].into_dyn();
+        let _ = sparse_cce().gradient(inputs.view(), targets.view());
+    }
+
+    #[test]
+    #[should_panic(expected = "agree on every axis")]
+    fn terms_panics_on_a_trailing_axis_mismatch() {
+        let inputs = array![[0.0_f32, 0.0], [0.0, 0.0], [0.0, 0.0]].into_dyn();
+        let targets = array![[0.0_f32]].into_dyn();
+        let _ = sparse_cce().terms(inputs.view(), targets.view());
     }
 }

--- a/core/src/nn/task.rs
+++ b/core/src/nn/task.rs
@@ -83,6 +83,16 @@ impl Task {
     pub fn output_size(&self) -> usize {
         self.output_shape().iter().product()
     }
+
+    /// The per-sample target shape this task implies: identical to
+    /// [`output_shape`](Self::output_shape), except for [`MultiClass`](Task::MultiClass), whose
+    /// targets are a single class id rather than one output per class.
+    pub fn target_shape(&self) -> Vec<usize> {
+        match self {
+            Task::MultiClass { .. } => vec![1],
+            _ => self.output_shape(),
+        }
+    }
 }
 
 /// Checks that `targets` are `ClassLabel` spanning exactly `expected` classes.
@@ -300,6 +310,20 @@ mod tests {
             .output_size(),
             48
         );
+    }
+
+    #[test]
+    fn target_shape_matches_output_shape_except_for_multi_class() {
+        assert_eq!(Task::Binary.target_shape(), Task::Binary.output_shape());
+        assert_eq!(Task::MultiClass { class_count: 4 }.target_shape(), vec![1]);
+        assert_eq!(
+            Task::MultiLabel { label_count: 3 }.target_shape(),
+            Task::MultiLabel { label_count: 3 }.output_shape()
+        );
+        let regression = Task::Regression {
+            target_shape: vec![3, 4, 4],
+        };
+        assert_eq!(regression.target_shape(), regression.output_shape());
     }
 
     #[test]

--- a/core/src/nn/training/hyperparams.rs
+++ b/core/src/nn/training/hyperparams.rs
@@ -2,13 +2,14 @@ use super::callbacks::Callbacks;
 use super::early_stopping::{EarlyStoppingConfig, EarlyStoppingConfigError};
 use super::preprocessing::TrainingData;
 use super::trainer::Trainer;
-use crate::accuracies::{Accuracy, BINARY_ACCURACY, CATEGORICAL_ACCURACY};
-use crate::data::Dataset;
+use crate::accuracies::{Accuracy, BINARY_ACCURACY, SPARSE_CATEGORICAL_ACCURACY};
 use crate::data::scalers::{ScalerFeatureMismatch, ScalerKind, ScalerMethod};
+use crate::data::{Dataset, ModelDataset};
 use crate::gradients::{GradientClipping, GradientClippingError};
 use crate::learning_rate::{LearningRate, LearningRateError};
 use crate::loss_functions::{
     BinaryCrossEntropy, CategoricalCrossEntropy, LossFunction, MeanSquaredError, Reduction,
+    SparseCategoricalCrossEntropy,
 };
 use crate::model::{InputShapeMismatch, NeuralNetwork, OutputShapeMismatch};
 use crate::optimizers::{Adam, Optimizer, StochasticGradientDescent};
@@ -61,8 +62,12 @@ pub struct LossConfig {
 pub enum LossKind {
     /// Binary cross-entropy from logits, for a single-logit task (binary or multi-label).
     BinaryCrossEntropy,
-    /// Categorical cross-entropy from softmax logits, for a multi-class task.
+    /// Categorical cross-entropy from softmax logits against one-hot targets, for a
+    /// multi-class task.
     CategoricalCrossEntropy,
+    /// Categorical cross-entropy from softmax logits against class-id targets, for a
+    /// multi-class task.
+    SparseCategoricalCrossEntropy,
     /// Mean squared error, for a regression task.
     MeanSquaredError,
 }
@@ -108,12 +113,12 @@ impl SchedulerConfig {
 
 impl LossConfig {
     /// The loss that fits `task`, with the default [`Mean`](Reduction::Mean) reduction: binary
-    /// cross-entropy for a single-logit task (binary or multi-label), categorical cross-entropy
-    /// for multi-class, mean squared error for regression.
+    /// cross-entropy for a single-logit task (binary or multi-label), sparse categorical
+    /// cross-entropy for multi-class, mean squared error for regression.
     pub fn for_task(task: &Task) -> Self {
         let kind = match task {
             Task::Binary | Task::MultiLabel { .. } => LossKind::BinaryCrossEntropy,
-            Task::MultiClass { .. } => LossKind::CategoricalCrossEntropy,
+            Task::MultiClass { .. } => LossKind::SparseCategoricalCrossEntropy,
             Task::Regression { .. } => LossKind::MeanSquaredError,
         };
         LossConfig {
@@ -129,19 +134,22 @@ impl LossConfig {
             LossKind::CategoricalCrossEntropy => {
                 Arc::new(CategoricalCrossEntropy::new(self.reduction))
             }
+            LossKind::SparseCategoricalCrossEntropy => {
+                Arc::new(SparseCategoricalCrossEntropy::new(self.reduction))
+            }
             LossKind::MeanSquaredError => Arc::new(MeanSquaredError::new(self.reduction)),
         }
     }
 }
 
 /// Selects the accuracy metric for `task`: binary accuracy for a single-logit task
-/// (binary or multi-label), categorical (argmax) accuracy for multi-class.
+/// (binary or multi-label), sparse categorical (argmax) accuracy for multi-class.
 /// # Panics
 /// When `task` is [`Regression`](Task::Regression), which has no accuracy metric.
 fn accuracy_for(task: &Task) -> Arc<dyn Accuracy> {
     match task {
         Task::Binary | Task::MultiLabel { .. } => BINARY_ACCURACY.clone(),
-        Task::MultiClass { .. } => CATEGORICAL_ACCURACY.clone(),
+        Task::MultiClass { .. } => SPARSE_CATEGORICAL_ACCURACY.clone(),
         Task::Regression { .. } => {
             panic!("Accuracy does not apply to a regression task.")
         }
@@ -494,10 +502,11 @@ impl HyperParameters {
     /// # Errors
     /// [`BuildError::InputShape`] when `model`'s input size does not match the dataset's
     /// feature count; [`BuildError::OutputShape`] when `model`'s output shape does not match
+    /// `task`'s; [`BuildError::TargetShape`] when `data`'s target shape does not match
     /// `task`'s. `model`, `task`, and `data` are supplied separately (e.g. resuming a run with
     /// a fresh dataset), so this is the one place their compatibility is checked; once past
     /// it, every forward pass over the split is guaranteed to fit and to produce a
-    /// `task`-shaped output.
+    /// `task`-shaped output, matched by the split's targets.
     pub fn build(
         self,
         model: NeuralNetwork,
@@ -507,6 +516,7 @@ impl HyperParameters {
     ) -> Result<Trainer, BuildError> {
         model.validate_inputs(data.split.train.inputs().view())?;
         model.validate_task(&task)?;
+        validate_target_shape(&task, &data.split.train)?;
 
         let optimizer = self.optimizer.instantiate(self.lr, self.weight_decay);
         let scheduler = self
@@ -543,6 +553,8 @@ pub enum BuildError {
     InputShape(InputShapeMismatch),
     /// `model`'s output shape does not match the task's.
     OutputShape(OutputShapeMismatch),
+    /// `data`'s target shape does not match the task's.
+    TargetShape(TargetShapeMismatch),
 }
 
 impl fmt::Display for BuildError {
@@ -550,6 +562,7 @@ impl fmt::Display for BuildError {
         match self {
             BuildError::InputShape(e) => write!(f, "{e}"),
             BuildError::OutputShape(e) => write!(f, "{e}"),
+            BuildError::TargetShape(e) => write!(f, "{e}"),
         }
     }
 }
@@ -565,6 +578,51 @@ impl From<InputShapeMismatch> for BuildError {
 impl From<OutputShapeMismatch> for BuildError {
     fn from(error: OutputShapeMismatch) -> Self {
         BuildError::OutputShape(error)
+    }
+}
+
+impl From<TargetShapeMismatch> for BuildError {
+    fn from(error: TargetShapeMismatch) -> Self {
+        BuildError::TargetShape(error)
+    }
+}
+
+/// A dataset's per-sample target shape did not match what a task expects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetShapeMismatch {
+    /// The per-sample target shape the task expects.
+    pub expected: Vec<usize>,
+    /// The per-sample target shape the dataset carries.
+    pub found: Vec<usize>,
+}
+
+impl fmt::Display for TargetShapeMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "dataset targets have shape {:?} but the task expects {:?}",
+            self.found, self.expected
+        )
+    }
+}
+
+impl std::error::Error for TargetShapeMismatch {}
+
+/// Checks that `data`'s per-sample target shape matches `task`'s.
+///
+/// # Errors
+/// [`TargetShapeMismatch`] when `data`'s target shape does not match
+/// [`Task::target_shape`].
+fn validate_target_shape(task: &Task, data: &ModelDataset) -> Result<(), TargetShapeMismatch> {
+    let expected = task.target_shape();
+    let found = data.target_shape();
+    if found == expected.as_slice() {
+        Ok(())
+    } else {
+        Err(TargetShapeMismatch {
+            expected,
+            found: found.to_vec(),
+        })
     }
 }
 
@@ -613,10 +671,13 @@ mod tests {
     }
 
     #[test]
-    fn for_task_picks_categorical_cross_entropy_for_a_multi_class_task() {
+    fn for_task_picks_sparse_categorical_cross_entropy_for_a_multi_class_task() {
         let loss = LossConfig::for_task(&Task::MultiClass { class_count: 3 });
-        assert_eq!(loss.kind, LossKind::CategoricalCrossEntropy);
-        assert_eq!(loss.instantiate().name(), "Categorical-Cross-Entropy");
+        assert_eq!(loss.kind, LossKind::SparseCategoricalCrossEntropy);
+        assert_eq!(
+            loss.instantiate().name(),
+            "Sparse-Categorical-Cross-Entropy"
+        );
     }
 
     #[test]
@@ -629,7 +690,7 @@ mod tests {
     }
 
     #[test]
-    fn accuracy_for_selects_binary_and_categorical_by_task() {
+    fn accuracy_for_selects_binary_and_sparse_categorical_by_task() {
         // The two reachable classification task pick the matching metric; the selection
         // mirrors the loss resolution above.
         use ndarray::array;
@@ -647,7 +708,7 @@ mod tests {
         assert_eq!(
             categorical.compute(
                 array![[2.0_f32], [1.0], [0.0]].into_dyn().view(),
-                array![[1.0_f32], [0.0], [0.0]].into_dyn().view()
+                array![[0.0_f32]].into_dyn().view()
             ),
             100.0
         );
@@ -965,6 +1026,57 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "model outputs shape [3] but shape [1] was expected"
+        );
+    }
+
+    #[test]
+    fn build_rejects_a_dataset_target_shape_that_does_not_match_the_task() {
+        use crate::activations::SIGMOID;
+        use crate::data::ModelSplit;
+        use crate::layers::Dense;
+        use ndarray::{Array1, Array2};
+
+        // A model whose output matches Task::MultiClass{class_count: 3}...
+        let model = NeuralNetwork::single(Dense::new(
+            Array2::from_elem((3, 2), 0.1),
+            Array1::zeros(3),
+            SIGMOID.clone(),
+        ));
+
+        // ...but a one-hot-shaped (3, samples) target, as if a stale caller bypassed
+        // `to_model_dataset`'s pure class-id rotation. MultiClass now expects a single
+        // class-id row.
+        let inputs = Array2::from_shape_fn((2, 4), |(i, _)| i as f32);
+        let one_hot_targets = Array2::<f32>::zeros((3, 4));
+        let train = ModelDataset::new(inputs.clone(), one_hot_targets.clone());
+        let test = ModelDataset::new(inputs, one_hot_targets);
+        let split = ModelSplit {
+            train,
+            validation: None,
+            test,
+        };
+        let data = TrainingData::new(split, None).unwrap();
+
+        let hp = spec_with_scaler(None);
+        let err = hp
+            .build(
+                model,
+                Task::MultiClass { class_count: 3 },
+                data,
+                Callbacks::empty(),
+            )
+            .map(|_| ())
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BuildError::TargetShape(TargetShapeMismatch {
+                expected: vec![1],
+                found: vec![3],
+            })
+        );
+        assert_eq!(
+            err.to_string(),
+            "dataset targets have shape [3] but the task expects [1]"
         );
     }
 

--- a/core/tests/convergence.rs
+++ b/core/tests/convergence.rs
@@ -180,7 +180,7 @@ fn three_class_converges_to_low_loss() {
         SchedulerConfig::Constant,
         GradientClipping::None,
         LossConfig {
-            kind: LossKind::CategoricalCrossEntropy,
+            kind: LossKind::SparseCategoricalCrossEntropy,
             reduction: Reduction::Mean,
         },
         None,


### PR DESCRIPTION
## Summary

- `to_model_dataset` no longer materializes a one-hot array for multi-class targets — `ClassLabel` targets always become a single class-id row, binary and multi-class alike.
- New `SparseCategoricalCrossEntropy`/`SparseCategoricalAccuracy` (class-id targets) become the actual `MultiClass` default, following Keras' own split: `CategoricalCrossEntropy`/`CategoricalAccuracy` (soft/one-hot targets) stay untouched for direct library use (label smoothing, mixup, distillation).
- `Task::target_shape()` and `ModelDataset::target_shape()` let `HyperParameters::build()` validate task↔data target-shape compatibility (new `BuildError::TargetShape`), closing the last gap in the model/task/data validation triangle.
- Both categorical losses now assert `inputs`/`targets` shape compatibility instead of relying on ndarray's silent broadcasting — this was found during self-review: without it, resuming a pre-existing multi-class run recorded with the legacy `LossKind::CategoricalCrossEntropy` would feed it the now-always-sparse targets and silently corrupt loss/gradients with no error at all. It now panics loudly, mirroring the assertions `CategoricalAccuracy`/`SparseCategoricalAccuracy` already had.

## Notes

- `LossKind::CategoricalCrossEntropy`/`LossKindRecord::CategoricalCrossEntropy` are kept (unreachable from `LossConfig::for_task` now, but still needed to deserialize pre-existing `meta.json`/`config.json` files).
- Sparse loss/accuracy math verified against PyTorch/Keras conventions (max-shifted log-sum-exp, `softmax(z) − onehot(y)` gradient) and cross-checked bit-for-bit against the dense implementation on an exact one-hot equivalent (see `matches_one_hot_categorical_cross_entropy_bit_for_bit`).